### PR TITLE
Deploy using Nginx instead of ember serve

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/Scalingo/nodejs-buildpack.git
+https://github.com/Scalingo/nginx-buildpack

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,9 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
-    // Add options here
+    fingerprint: {
+      exclude: ['images/logo-pix_250x250.png'],
+    }
   });
 
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,14 @@
+# exactly match the / URI
+location = / {
+  root /app/dist/;
+}
+
+# all the other URIs
+location / {
+  root /app/dist/;
+
+  # try_files try to load the file of the URI, and if it fails, it serve the / URI
+  # => in our case, if the uri is not found, it means that's an Ember URL and just return the index
+  # => BECAUSE / is not a file, this would make a infinite redirection loop. So we need the first block without try_files
+  try_files $uri /;
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git@github.com:1024pix/pix-site.git"
   },
   "scripts": {
-    "build": "npx ember build",
+    "build": "npx ember build --environment production",
     "lint:js": "eslint ./*.js app blueprints config lib server tests",
     "start": "npx ember serve --environment production --liveReload false --port $PORT",
     "dev": "npx ember serve",


### PR DESCRIPTION
Use Nginx to serve the static site.
Exclude the Pix logo from fingerprinting so that it can be used from outside.