### PR TITLE
[BUGFIX] Afficher la page d'actualités sous IE.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,7 +1,11 @@
+import RSVP from 'rsvp'
 import Application from '@ember/application';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
+
+// Prismic requires a Promise implementation, undefined under IE
+window.Promise = RSVP.Promise;
 
 const App = Application.extend({
   modulePrefix: config.modulePrefix,


### PR DESCRIPTION
Il manquait une librairie de promesse pour que Prismic puisse s'exécuter.