### PR TITLE
[BUGFIX] Réajustement du contenu de la page enseignement supérieur. 

### DIFF
--- a/app/styles/pages/_organization.scss
+++ b/app/styles/pages/_organization.scss
@@ -206,6 +206,7 @@
 
       @media (min-width: 600px) {
         margin-bottom: 32px;
+        width: 100%;
       }
     }
 

--- a/app/templates/higher-education.hbs
+++ b/app/templates/higher-education.hbs
@@ -61,6 +61,7 @@
           <p class="text text-s text-left regular text-white mb-5">A l’issue d’un test, des indices et des tutos répondent à la curiosité suscitée par les épreuves. Ils engagent les étudiants dans une dynamique de progression en appui à la formation que vous dispensez.</p>
           <h4 class="text text-r text-left semi-bold text-white mb-0">Des ressources pédagogiques partagées</h4>
           <p class="text text-s text-left regular text-white mb-5">Les tutos sont des liens vers des vidéos et des textes, de sources diverses. Ils constituent un ensemble de ressources que vous pouvez contribuer à enrichir.</p>
+          {{link-to 'Obtenir plus d’informations sur les conditions d’accès' 'formable-pages.higher-education-establishement-registration' class="formable-link text text-s text-left semi-bold text-white"}}
         </div>
       </div>
       <div class="box">
@@ -86,7 +87,7 @@
         <p class="text text-s text-left light text-black">Incontournable sur le CV, la certification Pix favorise l’insertion professionnelle des étudiants. Déclinée du référentiel européen DIGCOMP, elle facilite leur mobilité en Europe.</p>
       </div>
       <div class="column">
-        <a class="text text-s text-left semi-bold text-blue mb-0 mt-0 formable-link" href="{{rootURL}}/documents/Cahier_des_charges_des_centres_de_certification_Pix_(tous_publics_hors_scolaires)_-_Decembre_2018.pdf">Télécharger le cahier des charges des centres de certification Pix</a>
+        <a class="text text-s text-left semi-bold text-blue mb-0 mt-2 formable-link" href="{{rootURL}}/documents/Cahier_des_charges_des_centres_de_certification_Pix_(tous_publics_hors_scolaires)_-_Decembre_2018.pdf">Télécharger le cahier des charges des centres de certification Pix</a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## :unicorn: Problèmes
- Un lien en trop avait été supprimé 
- Le logo du ministère n'était pas centré avec le texte
- Un lien trop proche du texte

## :robot: Solutions
- Remettre le bouton 
- Modifier le css