### PR TITLE
[BSR] Renommage du helper as-url en handle-url

### DIFF
--- a/app/helpers/handle-url.js
+++ b/app/helpers/handle-url.js
@@ -1,6 +1,6 @@
 import { helper } from '@ember/component/helper';
 
-export function asUrl(url) {
+export function handleUrl(url) {
   var doc = document.createElement('a');
   doc.href = url;
   if(doc.hostname === 'pix.fr') {
@@ -9,4 +9,4 @@ export function asUrl(url) {
   return url;
 }
 
-export default helper(asUrl);
+export default helper(handleUrl);

--- a/app/templates/components/about-nav.hbs
+++ b/app/templates/components/about-nav.hbs
@@ -1,6 +1,6 @@
 <h4 class="text text-sm text-up text-left text-black mb-2 semi-bold">A propos</h4>
 <ul class="unstyled">
   {{#each items as |item|}}
-    <li><a class="text text-xs text-left regular text-black-l" target="{{if item.primary.link.target "_blank"}}" href="{{as-url item.primary.link.url}}">{{as-text item.primary.title}}</a></li>
+    <li><a class="text text-xs text-left regular text-black-l" target="{{if item.primary.link.target "_blank"}}" href="{{handle-url item.primary.link.url}}">{{as-text item.primary.title}}</a></li>
   {{/each}}
 </ul>

--- a/app/templates/components/main-nav.hbs
+++ b/app/templates/components/main-nav.hbs
@@ -1,5 +1,5 @@
 {{#each items as |item|}}
-  <div><a class="text text-s text-left regular text-black" target="{{if item.primary.link.target "_blank"}}" href="{{as-url item.primary.link.url}}">{{as-text item.primary.title}}</a></div>
+  <div><a class="text text-s text-left regular text-black" target="{{if item.primary.link.target "_blank"}}" href="{{handle-url item.primary.link.url}}">{{as-text item.primary.title}}</a></div>
 {{/each}}
 <div><a class="text text-s text-left regular text-black" href="https://app.pix.fr/">Se connecter</a></div>
 <div><a class="btn-nav" href="https://app.pix.fr/inscription">S'inscrire</a></div>

--- a/app/templates/components/organizations-nav.hbs
+++ b/app/templates/components/organizations-nav.hbs
@@ -1,7 +1,7 @@
 <div class="nav-switch">
   <div class="container padding-container">
     {{#each items as |item|}}
-      <a class="text text-xs text-left text-up regular text-black" target="{{if item.primary.link.target "_blank"}}" href="{{as-url item.primary.link.url}}">{{as-text item.primary.title}}</a>
+      <a class="text text-xs text-left text-up regular text-black" target="{{if item.primary.link.target "_blank"}}" href="{{handle-url item.primary.link.url}}">{{as-text item.primary.title}}</a>
     {{/each}}
   </div>
 </div>

--- a/app/templates/components/ressources-nav.hbs
+++ b/app/templates/components/ressources-nav.hbs
@@ -1,6 +1,6 @@
 <h4 class="text text-sm text-up text-left text-black mb-2 semi-bold">Ressources</h4>
 <ul class="unstyled">
   {{#each items as |item|}}
-    <li><a class="text text-xs text-left regular text-black-l" target="{{if item.primary.link.target "_blank"}}" href="{{as-url item.primary.link.url}}">{{as-text item.primary.title}}</a></li>
+    <li><a class="text text-xs text-left regular text-black-l" target="{{if item.primary.link.target "_blank"}}" href="{{handle-url item.primary.link.url}}">{{as-text item.primary.title}}</a></li>
   {{/each}}
 </ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4385,7 +4385,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {

--- a/tests/integration/helpers/handle-url-test.js
+++ b/tests/integration/helpers/handle-url-test.js
@@ -3,24 +3,24 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Helper | as-url', function(hooks) {
+module('Integration | Helper | handle-url', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it should return path for pix url', async function(assert) {
     // given
     this.set('inputValue', 'https://pix.fr/enseignement-scolaire');
     // when
-    await render(hbs`{{as-url inputValue}}`);
+    await render(hbs`{{handle-url inputValue}}`);
     // then
     assert.equal(this.element.textContent.trim(), '/enseignement-scolaire');
   });
 
-  test('it should return entire url', async function(assert) {
+  test('it should return entire url for other url', async function(assert) {
     // given
     this.set('inputValue', 'https://youtube.fr/tgsbfjd');
     // when
-    await render(hbs`{{as-url inputValue}}`);
+    await render(hbs`{{handle-url inputValue}}`);
     // then
-    assert.equal(this.element.textContent.trim(), 'https://youtube.fr/tgsbfjd');
+    assert.equal(this.element.textContent.trim(), this.inputValue);
   });
 });


### PR DESCRIPTION
## :unicorn: Problèmes
- `as-url` n'indiquait pas assez la fonction du helper.
- Les tests ne permettaient pas de comprendre non plus la fonction de celui-ci.

## :robot: Solutions
- Renommer le helper `as-url` en `handle-url`
- Renommer les tests