### PR TITLE
[FEATURE] Rendre le menu mobile contribuable.

### DIFF
--- a/app/components/burger-menu-nav.js
+++ b/app/components/burger-menu-nav.js
@@ -10,9 +10,9 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    const nav = this.navigations.nav;
-    const itemsTop = nav.data.body.filter(body => body.primary.type === 'burger-menu-top');
-    const itemsBottom = nav.data.body.filter(body => body.primary.type === 'burger-menu-bottom');
+    const navBody = this.navigations.nav.data.body;
+    const itemsTop = navBody.filter(body => body.primary.type === 'burger-menu-top');
+    const itemsBottom = navBody.filter(body => body.primary.type === 'burger-menu-bottom');
     this.set('itemsTop', itemsTop);
     this.set('itemsBottom', itemsBottom);
   },

--- a/app/components/burger-menu-nav.js
+++ b/app/components/burger-menu-nav.js
@@ -1,0 +1,19 @@
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+
+export default Component.extend({
+
+  //props
+  navigations: service(),
+  itemsTop: null,
+  itemsBottom: null,
+
+  init() {
+    this._super(...arguments);
+    const nav = this.navigations.nav;
+    const itemsTop = nav.data.body.filter(body => body.primary.type === 'burger-menu-top');
+    const itemsBottom = nav.data.body.filter(body => body.primary.type === 'burger-menu-bottom');
+    this.set('itemsTop', itemsTop);
+    this.set('itemsBottom', itemsBottom);
+  },
+});

--- a/app/styles/_burger-menu.scss
+++ b/app/styles/_burger-menu.scss
@@ -31,41 +31,6 @@
       display: block;
     }
 
-    .nav-top a {
-      text-decoration: none;
-      display: block;
-      transition: 0.3s;
-      font-size: 1rem;
-      line-height: 1.5rem;
-    }
-    .nav-bottom {
-      position: absolute;
-      bottom: 40px;
-
-      hr {
-        width: 180px;
-        height: 1px;
-        opacity: .5;
-        border: 1px solid #DDDDDD;
-        -webkit-border-radius: 0px;
-        -moz-border-radius: 0px;
-        border-radius: 0px;
-        display: inline-block;
-      }
-
-      a {
-        text-decoration: none;
-        display: block;
-        transition: 0.3s;
-        font-size: 12px;
-        line-height: 17px;
-      }
-    }
-
-    .nav-top a:hover,
-    .nav-bottom a:hover {
-      text-decoration: underline;
-    }
   }
 
   .hamburger {

--- a/app/styles/components/_burger-menu-nav.scss
+++ b/app/styles/components/_burger-menu-nav.scss
@@ -1,21 +1,52 @@
 
 .bm-menu {
 
-  .nav-top a {
+  .nav-top {
+
+    &__link {
+      font-weight: 600;
+      color: $white;
+      text-align: left;
+      margin-bottom: 12px;
+    }
+
+    ul {
+      padding-left: 0;
+    }
+
+    a {
     text-decoration: none;
     display: block;
     transition: 0.3s;
     font-size: 1rem;
     line-height: 1.5rem;
+    }
   }
+
 
   .nav-bottom {
     position: absolute;
     bottom: 40px;
 
+    &__link {
+      font-weight: 400;
+      color: $white;
+      text-align: left;
+      text-transform: uppercase;
+      margin-bottom: 20px;
+    }
+
     .show-page-icon {
       font-size:10px;
       margin-left:5px;
+    }
+
+    &__bar {
+      margin-bottom: 12px;
+    }
+
+    ul {
+      padding-left: 0;
     }
 
     hr {

--- a/app/styles/components/_burger-menu-nav.scss
+++ b/app/styles/components/_burger-menu-nav.scss
@@ -1,4 +1,46 @@
-.arrow {
-  font-size:10px;
-  margin-left:5px;
+
+.bm-menu {
+
+  .nav-top a {
+    text-decoration: none;
+    display: block;
+    transition: 0.3s;
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
+
+  .nav-bottom {
+    position: absolute;
+    bottom: 40px;
+
+    .arrow {
+      font-size:10px;
+      margin-left:5px;
+    }
+
+    hr {
+      width: 180px;
+      height: 1px;
+      opacity: .5;
+      border: 1px solid #DDDDDD;
+      -webkit-border-radius: 0px;
+      -moz-border-radius: 0px;
+      border-radius: 0px;
+      display: inline-block;
+    }
+
+    a {
+      text-decoration: none;
+      display: block;
+      transition: 0.3s;
+      font-size: 12px;
+      line-height: 17px;
+    }
+  }
+
+  .nav-top a:hover,
+  .nav-bottom a:hover {
+    text-decoration: underline;
+  }
+
 }

--- a/app/styles/components/_burger-menu-nav.scss
+++ b/app/styles/components/_burger-menu-nav.scss
@@ -1,0 +1,4 @@
+.arrow {
+  font-size:10px;
+  margin-left:5px;
+}

--- a/app/styles/components/_burger-menu-nav.scss
+++ b/app/styles/components/_burger-menu-nav.scss
@@ -13,7 +13,7 @@
     position: absolute;
     bottom: 40px;
 
-    .arrow {
+    .show-page-icon {
       font-size:10px;
       margin-left:5px;
     }

--- a/app/styles/components/_index.scss
+++ b/app/styles/components/_index.scss
@@ -1,6 +1,7 @@
 @import "./app-header";
 @import "./app-footer";
 @import "./app-navbar";
+@import "./burger-menu-nav";
 @import "./faq-category";
 @import "./faq-item";
 @import "./faq-menu";

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -4,29 +4,8 @@
   translucentOverlay=true
 as |burger|}}
 
-  {{#burger.menu dismissOnItemClick=true itemTagName="li" as |menu|}}
-
-    <nav class="nav-top">
-      <ul class="unstyled">
-        {{#menu.item}}{{link-to 'Accueil' 'index' class="text mb-0-1 text-left semi-bold text-white"}}{{/menu.item}}
-        {{#menu.item}}{{link-to 'Qui sommes-nous ?' 'about' class="text mb-0-1 text-left semi-bold text-white"}}{{/menu.item}}
-        {{#menu.item}}{{link-to 'Compétences' 'competences' class="text mb-0-1 text-left semi-bold text-white"}}{{/menu.item}}
-        {{#menu.item}}{{link-to 'FAQ' 'faq' class="text mb-0-1 text-left semi-bold text-white"}}{{/menu.item}}
-        {{#menu.item}}<a href="https://app.pix.fr/" class="text mb-0-1 text-left semi-bold text-white">Se connecter</a>{{/menu.item}}
-        {{#menu.item}}<a href="https://app.pix.fr/inscription" class="btn-nav-mobile">S'inscrire</a>{{/menu.item}}
-      </ul>
-    </nav>
-
-    <div class="nav-bottom">
-      <hr class="mb-0-1">
-      <ul class="unstyled">
-        {{#menu.item}}{{#link-to 'digital-mediation' class="text mb-1 text-left text-up regular text-white"}}Médiation numérique<span style="font-size:10px;margin-left:5px;">&gt;</span>{{/link-to}}{{/menu.item}}
-        {{#menu.item}}{{#link-to 'school-education' class="text mb-1 text-left text-up regular text-white"}}Enseignement scolaire<span style="font-size:10px;margin-left:5px;">&gt;</span>{{/link-to}}{{/menu.item}}
-        {{#menu.item}}{{#link-to 'higher-education' class="text mb-1 text-left text-up regular text-white"}}Enseignement supérieur<span style="font-size:10px;margin-left:5px;">&gt;</span>{{/link-to}}{{/menu.item}}
-        {{#menu.item}}{{#link-to 'employers' class="text mb-1 text-left text-up regular text-white"}}Employeurs<span style="font-size:10px;margin-left:5px;">&gt;</span>{{/link-to}}{{/menu.item}}
-      </ul>
-    </div>
-
+  {{#burger.menu dismissOnItemClick=true }}
+    <BurgerMenuNav />
   {{/burger.menu}}
 
   {{#burger.outlet}}

--- a/app/templates/components/burger-menu-nav.hbs
+++ b/app/templates/components/burger-menu-nav.hbs
@@ -1,18 +1,18 @@
 <nav class="nav-top">
-  <ul class="unstyled">
+  <ul>
     {{#each itemsTop as |item|}}
-    <li><a class="text mb-0-1 text-left semi-bold text-white" target="{{if item.primary.link.target "_blank"}}" href="{{handle-url item.primary.link.url}}">{{as-text item.primary.title}}</a></li>
+    <li><a class="nav-top__link" target="{{if item.primary.link.target "_blank"}}" href="{{handle-url item.primary.link.url}}">{{as-text item.primary.title}}</a></li>
     {{/each}}
-    <li><a href="https://app.pix.fr/" class="text mb-0-1 text-left semi-bold text-white">Se connecter</a></li>
+    <li><a href="https://app.pix.fr/" class="nav-top__link">Se connecter</a></li>
     <li><a href="https://app.pix.fr/inscription" class="btn-nav-mobile">S'inscrire</a></li>
   </ul>
 </nav>
 
 <div class="nav-bottom">
-  <hr class="mb-0-1">
-  <ul class="unstyled">
+  <hr class="nav-bottom__bar">
+  <ul>
     {{#each itemsBottom as |item|}}
-    <li><a class="text mb-1 text-left text-up regular text-white" target="{{if item.primary.link.target "_blank"}}" href="{{handle-url item.primary.link.url}}">{{as-text item.primary.title}}<span class="show-page-icon">&gt;</span></a></li>
+    <li><a class="nav-bottom__link" target="{{if item.primary.link.target "_blank"}}" href="{{handle-url item.primary.link.url}}">{{as-text item.primary.title}}<span class="show-page-icon">&gt;</span></a></li>
     {{/each}}
   </ul>
 </div>

--- a/app/templates/components/burger-menu-nav.hbs
+++ b/app/templates/components/burger-menu-nav.hbs
@@ -12,7 +12,7 @@
   <hr class="mb-0-1">
   <ul class="unstyled">
     {{#each itemsBottom as |item|}}
-    <li><a class="text mb-1 text-left text-up regular text-white" target="{{if item.primary.link.target "_blank"}}" href="{{handle-url item.primary.link.url}}">{{as-text item.primary.title}}<span class="arrow">&gt;</span></a></li>
+    <li><a class="text mb-1 text-left text-up regular text-white" target="{{if item.primary.link.target "_blank"}}" href="{{handle-url item.primary.link.url}}">{{as-text item.primary.title}}<span class="show-page-icon">&gt;</span></a></li>
     {{/each}}
   </ul>
 </div>

--- a/app/templates/components/burger-menu-nav.hbs
+++ b/app/templates/components/burger-menu-nav.hbs
@@ -1,0 +1,18 @@
+<nav class="nav-top">
+  <ul class="unstyled">
+    {{#each itemsTop as |item|}}
+    <li><a class="text mb-0-1 text-left semi-bold text-white" target="{{if item.primary.link.target "_blank"}}" href="{{handle-url item.primary.link.url}}">{{as-text item.primary.title}}</a></li>
+    {{/each}}
+    <li><a href="https://app.pix.fr/" class="text mb-0-1 text-left semi-bold text-white">Se connecter</a></li>
+    <li><a href="https://app.pix.fr/inscription" class="btn-nav-mobile">S'inscrire</a></li>
+  </ul>
+</nav>
+
+<div class="nav-bottom">
+  <hr class="mb-0-1">
+  <ul class="unstyled">
+    {{#each itemsBottom as |item|}}
+    <li><a class="text mb-1 text-left text-up regular text-white" target="{{if item.primary.link.target "_blank"}}" href="{{handle-url item.primary.link.url}}">{{as-text item.primary.title}}<span class="arrow">&gt;</span></a></li>
+    {{/each}}
+  </ul>
+</div>

--- a/tests/integration/components/burger-menu-nav-test.js
+++ b/tests/integration/components/burger-menu-nav-test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | burger-menu-nav', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Given
+    const navigations = this.owner.lookup('service:navigations');
+    await navigations.load();
+
+    // When
+    await render(hbs`<BurgerMenuNav />`);
+
+    // Then
+    assert.dom('.nav-top').exists();
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Le header/footer sont devenus contribuables seulement le menu mobile non. Il pouvait donc y avoir une incohérence entre la version normale et mobile. 

## :robot: Solution
Rendre le menu mobile contribuable grâce à Prismic. 
- Ajout de tags dans le document `navigation` sur Prismic : `burger-menu-top` et `burger-menu-bottom`
- Ajout d'un component `burger-menu-nav`