### PR TITLE
[FEATURE] Ajout d'une bannière pour indiquer le status des applications (site-9). 

### DIFF
--- a/app/components/hot-news-banner.js
+++ b/app/components/hot-news-banner.js
@@ -1,0 +1,13 @@
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+
+export default Component.extend({
+  hotNews: service(),
+  isClose: false,
+
+  actions: {
+    closeBanner() {
+      this.set('isClose', true);
+    }
+  },
+});

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,12 +1,18 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { all } from 'rsvp';
 
 export default Route.extend({
 
   navigations: service(),
+  hotNews: service(),
 
   beforeModel() {
-    return this._loadNavigation();
+    return all([this._loadHotNews(),this._loadNavigation()]);
+  },
+
+  _loadHotNews() {
+    return this.hotNews.load();
   },
 
   _loadNavigation() {

--- a/app/services/hot-news.js
+++ b/app/services/hot-news.js
@@ -1,0 +1,13 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+
+export default Service.extend({
+
+  prismic: service(),
+  news: null,
+
+  async load() {
+    const news = await this.prismic.getHotNews();
+    this.set('news', news);
+  },
+});

--- a/app/services/prismic.js
+++ b/app/services/prismic.js
@@ -63,6 +63,11 @@ export default Service.extend({
     const api = await this.getApi();
     return await api.getByUID('navigation','navigation');
   },
+
+  async getHotNews() {
+    const api = await this.getApi();
+    return await api.getSingle('hot_news');
+  }
 });
 
 function resolveDocumentLink(doc) {

--- a/app/styles/components/_hot-news-banner.scss
+++ b/app/styles/components/_hot-news-banner.scss
@@ -1,0 +1,46 @@
+.hot-news {
+  top: 0;
+  left: 0;
+  height: 70px;
+  width: 100%;
+
+  color: $white;
+  background-color: $blue-1;
+  padding: 2px;
+
+  display: flex;
+  flex-direction: row;
+
+  @media (min-width: 769px) {
+    padding: 5px;
+    height: 60px;
+  }
+
+  p {
+    text-align: center;
+    line-height: 1rem;
+    font-size: 0.875rem;
+    margin: 0 auto;
+    align-self: center;
+
+    @media (min-width: 769px) {
+      width: 700px;
+      line-height: 1.375rem;
+    }
+  }
+
+  .close {
+    margin-right: 20px;
+    opacity: .5;
+    transition: .5s;
+    cursor: pointer;
+
+    @media (min-width: 769px) {
+      margin-right: 32px;
+    }
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+}

--- a/app/styles/components/_index.scss
+++ b/app/styles/components/_index.scss
@@ -5,6 +5,7 @@
 @import "./faq-category";
 @import "./faq-item";
 @import "./faq-menu";
+@import "./hot-news-banner";
 @import "./key-numbers";
 @import "./main-nav";
 @import "./multiple-column";

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -9,6 +9,7 @@ as |burger|}}
   {{/burger.menu}}
 
   {{#burger.outlet}}
+    <HotNewsBanner />
     {{app-navbar burger=burger}}
 
     {{outlet}}

--- a/app/templates/components/hot-news-banner.hbs
+++ b/app/templates/components/hot-news-banner.hbs
@@ -1,0 +1,8 @@
+{{#if hotNews.news}}
+  {{#unless isClose}}
+    <div class="hot-news">
+      {{as-html hotNews.news.data.description}}
+      <img class="close" src="{{rootUrl}}/images/close-icon.svg" {{action "closeBanner"}}/>
+    </div>
+  {{/unless}}
+{{/if}}

--- a/tests/integration/components/hot-news-banner-test.js
+++ b/tests/integration/components/hot-news-banner-test.js
@@ -1,0 +1,33 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
+
+module('Integration | Component | hot-news-banner', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Given
+    const news = {
+      type: "hot_news",
+      data: {
+        description: [
+          {
+            type: "paragraph",
+            text: "On a rencontré un problème, mais pas de panique, nous sommes en train de le résoudre rapidement,enfin on fait tout ce qu’est possible pour que vous puissiez revenir faire vos tests.",
+            spans: []
+          }
+        ]
+      }
+    }
+    this.owner.register('service:hotNews', Service.extend({ news: news}));
+
+    // When
+    await render(hbs`<HotNewsBanner />`);
+
+    // then
+    assert.dom('.hot-news').exists();
+    assert.dom('.hot-news').hasText('On a rencontré un problème, mais pas de panique, nous sommes en train de le résoudre rapidement,enfin on fait tout ce qu’est possible pour que vous puissiez revenir faire vos tests.');
+  });
+});

--- a/tests/unit/services/hot-news-test.js
+++ b/tests/unit/services/hot-news-test.js
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | hot-news', function(hooks) {
+  setupTest(hooks);
+
+  test('it should load hot news', async function(assert) {
+    // Given
+    const hotNews = this.owner.lookup('service:hotNews');
+
+    // When
+    await hotNews.load();
+
+    // Then
+    const expectObjectKeys = {
+      id: '',
+      uid: null,
+      type: '',
+      href: '',
+      tags: [],
+      first_publication_date: '',
+      last_publication_date: '',
+      slugs: [],
+      linked_documents: [],
+      lang: '',
+      alternate_languages: [],
+      data: {}
+    }
+    assert.deepEqual(Object.keys(hotNews.news), Object.keys(expectObjectKeys));
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'il y a un soucis avec des services de Pix, les utilisateurs n'ont pas de visuel sur le problème sauf grâce à la page : https://status.pix.fr. On souhaite donc ajouter de la visibilité sur les problèmes sur https://pix.fr 

## :robot: Solution
Ajout d'une bannière sur le site https://pix.fr, pour prévenir l'utilisateur des problèmes qu'il peut y avoir.

## :sparkles: Review APP
http://pix-site-integration-pr44.scalingo.io