### PR TITLE
[FEATURE] Ajout d'un slice permettant d'ajouter du texte (site-17).

### DIFF
--- a/app/components/slices/rich-text.js
+++ b/app/components/slices/rich-text.js
@@ -1,0 +1,6 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+    // Element
+    classNames: ['rich-text'],
+});

--- a/app/templates/components/slices/rich-text.hbs
+++ b/app/templates/components/slices/rich-text.hbs
@@ -1,0 +1,1 @@
+{{as-text slice.primary.text}}

--- a/tests/integration/components/slices/rich-text-test.js
+++ b/tests/integration/components/slices/rich-text-test.js
@@ -1,0 +1,30 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | slices/rich-text', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+  //given
+  this.set('slice', {
+    slice_type: "rich_text",
+    primary: {
+      text: [
+        {
+          type: "paragraph",
+          text: "test text",
+          spans: []
+        }
+      ]
+    },
+  });
+
+  //when
+  await render(hbs `{{slices/rich-text slice=slice}}`);
+
+  //then
+  assert.dom('.rich-text').hasText('test text');
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Sur Prismic nous pouvons pas ajouter du texte après des slices (ex: après deux colonnes). 

## :robot: Solution
Rajouter un slice `Rich Text` permettant de rajouter du texte quand on le veut.

