### PR TITLE
[BUGFIX] Problème de taille du logo dans le footer (site-19).

### DIFF
--- a/app/styles/components/_app-footer.scss
+++ b/app/styles/components/_app-footer.scss
@@ -45,6 +45,10 @@ footer {
     img {
       display: block;
     }
+
+    .logo {
+      width: 50%;
+    }
   }
 
   .sitenav {

--- a/app/templates/components/app-footer.hbs
+++ b/app/templates/components/app-footer.hbs
@@ -1,6 +1,6 @@
 <div class="container padding-container">
   <div class="sitelogo">
-    <a href=""><img class="mb-2" alt="pix" src="{{rootURL}}/images/pix-logo.svg"></a>
+    <a href=""><img class="mb-2 logo" alt="pix" src="{{rootURL}}/images/pix-logo.svg"></a>
     <div>
       <img style="margin-left: -4px;" class="ministere" alt="ministere de l education" src="{{rootURL}}/images/ministere-logo-2.svg">
     </div>


### PR DESCRIPTION
## :unicorn: Problème
Le logo de Pix était trop gros dans le footer ce qui ne correspondait pas au mockup et dérangeait la navigation mobile. 

## :robot: Solution
Réduire la taille du logo. 
