### PR TITLE
[FEATURE] Ajout de la possibilité de centrer le texte verticalement par rapport à une colonne sur Prismic (site-20).

### DIFF
--- a/app/components/slices/multiple-column.js
+++ b/app/components/slices/multiple-column.js
@@ -1,7 +1,15 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 export default Component.extend({
 
-      // Element
-      classNames: ['multiple-column']
+  // Elements
+  classNames: ['multiple-column'],
+  slice: null,
+  verticalAlignCenter: computed('slice', function() {
+    if(this.slice && this.slice.primary.vertical_align_center === "true") {
+      return true;
+    }
+  }),
+
 });

--- a/app/styles/components/_multiple-column.scss
+++ b/app/styles/components/_multiple-column.scss
@@ -9,4 +9,8 @@
     flex-basis: 50%;
     padding: 0 10px;
   }
+
+  .vertical_align_center {
+    align-self: center;
+  }
 }

--- a/app/templates/components/slices/multiple-column.hbs
+++ b/app/templates/components/slices/multiple-column.hbs
@@ -1,5 +1,5 @@
 {{#each slice.items as |column|}}
-  <div class="column">
+  <div class="column {{if verticalAlignCenter "vertical_align_center"}}">
     {{as-html column.column_content}}
   </div>
 {{/each}}

--- a/tests/integration/components/slices/multiple-column-test.js
+++ b/tests/integration/components/slices/multiple-column-test.js
@@ -14,35 +14,35 @@ module('Integration | Component | slices/multiple-column', function (hooks) {
   test('it should have columns', async function (assert) {
     //given
     this.set('slice', {
-      "slice_type": "multiple_column",
-      "slice_label": null,
-      "items": [
+      slice_type: "multiple_column",
+      slice_label: null,
+      items: [
         {
-          "column_content": [
+          column_content: [
             {
-              "type": "paragraph",
-              "text": "Column 1",
-              "spans": []
+              type: "paragraph",
+              text: "Column 1",
+              spans: []
             }
           ]
         },
         {
-          "column_content": [
+          column_content: [
             {
-              "type": "paragraph",
-              "text": "Column 2",
-              "spans": []
+              type: "paragraph",
+              text: "Column 2",
+              spans: []
             }
           ]
         },
         {
-          "column_content": [
+          column_content: [
             {
-              "type": "image",
-              "url": "https://pix-site.cdn.prismic.io/pix-site/3a29bf3168b1357d462651dde9526d427e98eced_recruitment.jpg",
-              "alt": null,
-              "copyright": null,
-              "dimensions": {
+              type: "image",
+              url: "https://pix-site.cdn.prismic.io/pix-site/3a29bf3168b1357d462651dde9526d427e98eced_recruitment.jpg",
+              alt: null,
+              copyright: null,
+              dimensions: {
                 "width": 350,
                 "height": 200
               }
@@ -50,7 +50,9 @@ module('Integration | Component | slices/multiple-column', function (hooks) {
           ]
         }
       ],
-      "primary": {}
+      primary: {
+        vertical_align_center: true,
+      }
     });
 
     //when
@@ -61,5 +63,41 @@ module('Integration | Component | slices/multiple-column', function (hooks) {
     assert.dom('.multiple-column>.column:nth-child(2)').hasText('Column 2');
     assert.dom('.column').exists({ count: 3 });
     assert.dom('.block-img').exists();
+  });
+
+  test('it should have vertical_align_center class', async function (assert) {
+    //given
+    this.set('slice', {
+      slice_type: "multiple_column",
+      slice_label: null,
+      primary: {
+        vertical_align_center: "true",
+      },
+      items: [
+        {
+          column_content: [
+            {
+              type: "paragraph",
+              text: "Column 1",
+              spans: []
+            }
+          ]
+        },
+        {
+          column_content: [
+            {
+              type: "paragraph",
+              text: "Column 2",
+              spans: []
+            }
+          ]
+        },
+      ],
+    });
+
+    //when
+    await render(hbs `{{slices/multiple-column slice=slice}}`);
+    //then
+    assert.dom('.column.vertical_align_center').exists();
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Sur Prismic, il est possible de créer des colonnes avec du textes et une image, seulement quand l'image est plus longue que le texte cela ne rends pas très bien.

## :robot: Solution
Ajout de la possibilité de pouvoir centrer le texte verticalement par rapport à une autre colonne. 
