### PR TITLE
[FEATURE] Ajout du jaune Pix et utilisable depuis Prismic (site-22).

### DIFF
--- a/app/styles/_colors.scss
+++ b/app/styles/_colors.scss
@@ -13,5 +13,7 @@ $blue-4: #388AFF;
 
 $purple-1: #985FFF;
 
+$pix-yellow: #ffcb00;
+
 $black: #000000;
 $white: #FFFFFF;

--- a/app/styles/components/_news-item-post.scss
+++ b/app/styles/components/_news-item-post.scss
@@ -162,6 +162,10 @@
     color: $blue-1;
   }
 
+  .yellow {
+    color: $pix-yellow;
+  }
+
   .large {
     font-size: 1.875rem;
     line-height: 2.375rem;


### PR DESCRIPTION
## :unicorn: Problème
Il est impossible d'écrire du texte depuis Prismic avec le jaune Pix.

## :robot: Solution
Ajouter le jaune Pix et la class css permettant de l'utiliser depuis Prismic.

