### PR TITLE
[FEATURE] Ajout de la redirection lorsque le slug d'une actualité n'est pas bon (site-23).

### DIFF
--- a/app/routes/news/show.js
+++ b/app/routes/news/show.js
@@ -6,7 +6,13 @@ export default Route.extend({
   prismic: service(),
 
   model({ uid }) {
-    return this.prismic.getNewsItemByUid(uid);  
+    return this.prismic.getNewsItemByUid(uid);
   },
+
+  afterModel(model) {
+    if(!model) {
+      this.transitionTo('index');
+    }
+  }
 
 });

--- a/tests/acceptance/news-test.js
+++ b/tests/acceptance/news-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+
+module('Acceptance | news', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('it should visit actualites when the url is valid', async function(assert) {
+    //when
+    await visit('/actualites');
+    //then
+    assert.equal(currentURL(), '/actualites');
+  });
+
+  test('it should redirect to index when the url is invalid', async function(assert) {
+    //when
+    await visit('/actualites/no-exist-slug-test');
+    //then
+    assert.equal(currentURL(), '/');
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateurs saisie une url de type : `/actualites/slug-non-existant` celui-ci voit la page d'une actualité mais vide.

## :robot: Solution
Rediriger l'utilisateur vers la page `/index` lorsqu'il va sur une actualité non existante.

## :sparkles: Review App
[https://pix-site-integration-pr54.scalingo.io](url)