### PR TITLE
[FEATURE] Rendre responsive la page actualités (site-29).

### DIFF
--- a/app/styles/components/_news-item-card.scss
+++ b/app/styles/components/_news-item-card.scss
@@ -4,7 +4,10 @@
 */
 
 .news-item-card {
-  position: relative;
+  margin: 20px;
+  max-width: 340px;
+  margin-left: auto;
+  margin-right: auto;
   overflow: hidden;
   border-radius: 10px;
   background: #fff;
@@ -12,9 +15,15 @@
   transition: all 250ms cubic-bezier(0.02, 0.01, 0.47, 1);
   color: $grey-1;
 
+  @media (min-width: 700px) {
+    margin: 20px;
+  }
+
   &:hover {
-    box-shadow: 0 30px 30px rgba(0, 0, 0, 0.1);
-    transform: translate3D(0, -20px, 0);
+    @media (min-width: 900px) {
+      box-shadow: 0 30px 30px rgba(0, 0, 0, 0.1);
+      transform: translate3D(0, -20px, 0);
+    }
   }
 
   /* === LAYOUT === */

--- a/app/styles/pages/news/_index.scss
+++ b/app/styles/pages/news/_index.scss
@@ -1,9 +1,15 @@
 .page.news {
 
   .news__list {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    grid-column-gap: 30px;
-    grid-row-gap: 45px;
+    max-width: 1140px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+
+    @media (min-width: 700px) {
+      flex-wrap: wrap;
+      flex-direction: row;
+      justify-content: space-evenly;
+    }
   }
 }

--- a/app/templates/news/index.hbs
+++ b/app/templates/news/index.hbs
@@ -10,7 +10,7 @@
 
   <main class="page-body">
 
-    <div class="news__list container padding-container">
+    <div class="news__list">
       {{#each model as |newsItem|}}
         {{news-item-card newsItem=newsItem}}
       {{else}}


### PR DESCRIPTION
## :unicorn: Problème
La page `/actualites` n'est pas responsive, il est alors difficile de lire les descriptions d'actualités sur mobile. 

## :robot: Solution
Rendre la page responsive.

## :sparkles: Review App
https://pix-site-integration-pr57.scalingo.io
