### PR TITLE
[FEATURE] Affichage de la date de publication pour les actualités (site-25).

### DIFF
--- a/app/templates/components/news-item-card.hbs
+++ b/app/templates/components/news-item-card.hbs
@@ -10,7 +10,7 @@
     <p class="news-item-card__meta">
       <span class="news-item-card__category {{categoryClassName}}">{{categoryLabel}}</span>
       •
-      <span class="news-item-card__date">le {{moment-format newsItem.last_publication_date 'LL'}}</span>
+      <span class="news-item-card__date">le {{moment-format newsItem.first_publication_date 'LL'}}</span>
     </p>
 
     <h1 class="news-item-card__title">{{as-text newsItem.data.title}}</h1>

--- a/app/templates/components/news-item-post.hbs
+++ b/app/templates/components/news-item-post.hbs
@@ -3,9 +3,9 @@
   <p class="news-item-post__meta">
     <span class="news-item-post__category {{categoryClassName}}">{{categoryLabel}}</span>
     •
-    {{#if newsItem.last_publication_date}}
-    <span class="news-item-post__date">le {{moment-format newsItem.last_publication_date 'LL'}}</span>
-    {{else}} 
+    {{#if newsItem.first_publication_date}}
+    <span class="news-item-post__date">le {{moment-format newsItem.first_publication_date 'LL'}}</span>
+    {{else}}
     <span class="news-item-post__date">Preview</span>
     {{/if}}
   </p>

--- a/tests/index.html
+++ b/tests/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Pix FAQ Tests</title>
+    <title>Pix</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/tests/integration/components/news-item-card-test.js
+++ b/tests/integration/components/news-item-card-test.js
@@ -12,6 +12,7 @@ module('Integration | Component | news-item-card', function(hooks) {
   hooks.beforeEach(function() {
     newsItem = {
       last_publication_date: '2019-04-09T13:19:32+0000',
+      first_publication_date: '2019-03-09T13:19:32+0000',
       data: {
         category: 'Announcement',
         title: [{ spans:[], text: 'The title of the news post', type: 'heading1' }],
@@ -60,13 +61,13 @@ module('Integration | Component | news-item-card', function(hooks) {
     assert.dom('.news-item-card__excerpt').hasText('The excerpt of the news post');
   });
 
-  test('it renders the last publication date', async function(assert) {
+  test('it renders the first publication date', async function(assert) {
 
     // when
     await render(hbs`{{news-item-card newsItem=newsItem}}`);
 
     // then
     assert.dom('.news-item-card__date').exists();
-    assert.dom('.news-item-card__date').hasText('le 9 avril 2019');
+    assert.dom('.news-item-card__date').hasText('le 9 mars 2019');
   });
 });

--- a/tests/integration/components/news-item-post-test.js
+++ b/tests/integration/components/news-item-post-test.js
@@ -12,6 +12,7 @@ module('Integration | Component | news-item-post', function(hooks) {
   hooks.beforeEach(function() {
     newsItem = {
       last_publication_date: '2019-04-09T13:19:32+0000',
+      first_publication_date: '2019-03-09T13:19:32+0000',
       data: {
         category: 'Announcement',
         title: [{ spans:[], text: 'The title of the news post', type: 'heading1' }],
@@ -41,14 +42,14 @@ module('Integration | Component | news-item-post', function(hooks) {
     assert.dom('.news-item-post__title').hasText('The title of the news post');
   });
 
-  test('it renders the last publication date', async function(assert) {
+  test('it renders the first publication date', async function(assert) {
 
     // when
     await render(hbs`{{news-item-post newsItem=newsItem}}`);
 
     // then
     assert.dom('.news-item-post__date').exists();
-    assert.dom('.news-item-post__date').hasText('le 9 avril 2019');
+    assert.dom('.news-item-post__date').hasText('le 9 mars 2019');
   });
 
   test('it renders the body', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Quand une actualité est modifié, celle-ci reprend la date de modification et par conséquent n'affiche plus la date de création.

## :robot: Solution
Afficher la date de première publication.

## :sparkles: Review App
https://pix-site-integration-pr58.scalingo.io
