### PR TITLE
[FEATURE] Ajout d'une page d'erreur (site-14).

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -11,6 +11,5 @@ export default Route.extend({
 
   _loadNavigation() {
     return this.navigations.load();
-  }
-
+  },
 });

--- a/app/styles/_pages.scss
+++ b/app/styles/_pages.scss
@@ -1,4 +1,5 @@
 @import "./pages/about";
+@import "./pages/application-error";
 @import "./pages/competences";
 @import "./pages/digital-mediation";
 @import "./pages/faq";

--- a/app/styles/pages/_application-error.scss
+++ b/app/styles/pages/_application-error.scss
@@ -1,0 +1,15 @@
+.error {
+  width: 300px;
+  margin-left: auto;
+  margin-right: auto;
+
+  @media (min-width: 769px) {
+    width: 500px;
+  }
+
+  .logo {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}

--- a/app/templates/application-error.hbs
+++ b/app/templates/application-error.hbs
@@ -1,0 +1,6 @@
+<div class="error">
+  <img class="logo" src="{{rootUrl}}/images/pix-logo.svg" />
+  <h1>Oups ! Un problème est survenu, mais pas de panix, nous revenons très vite !</h1>
+  <p>Pour en savoir plus, vous pouvez consulter <a href="http://status.pix.fr/">cette page</a> ou aller sur nos réseaux sociaux : <a href="https://twitter.com/Pix_officiel">Twitter</a>, <a href="https://www.facebook.com/Pix1024/" >Facebook</a>, <a href="https://www.linkedin.com/company/gip-pix/">LinkedIn</a>.</p>
+  <p>Si vous avez besoin d’aide, vous pouvez également contacter le support <a href="mailto:contact@pix.fr">icix</a>.</p>
+</div>


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, si Prismic tombe nous affichons un site dégradé, on a plus de header ni footer et il manquerait certains contenus. 

## :robot: Solution
Ajouter une page d'erreur.

## :sparkles: Review App
Pour afficher l'erreur dans la review App j'ai modifié les variables d'environnement sur Scalingo.
https://pix-site-integration-pr59.scalingo.io
