### PR TITLE
[BUGFIX] Problème de marge dans le slice multiple-column (site-35).

### DIFF
--- a/app/styles/components/_multiple-column.scss
+++ b/app/styles/components/_multiple-column.scss
@@ -1,5 +1,7 @@
 .multiple-column {
 
+  margin:0 -10px;
+
   @media (min-width: 600px) {
     display: flex;
     justify-content: space-between;
@@ -7,7 +9,7 @@
 
   .column {
     flex-basis: 50%;
-    padding: 0 10px;
+    margin: 0 10px;
   }
 
   .vertical_align_center {


### PR DESCRIPTION
## :unicorn: Problème
Lors d'une utilisation du slice multiple-column sur prismic, le texte de la première colonne est décalé de 10px par rapport à un texte normal. Exemple  : https://pix.fr/actualites/votre-profil-evolue

## :robot: Solution
Enlever ce décalage. 

## :sparkles: Review App
https://pix-site-integration-pr60.scalingo.io

Lien de la review app pointant sur l'exemple : https://pix-site-integration-pr60.scalingo.io/actualites/votre-profil-evolue