### PR TITLE
[TECH] Correction du crash de Chrome 76 sur Mac pendant les tests front.

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -13,7 +13,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',


### PR DESCRIPTION
## :unicorn: Problème
Depuis Chrome 76, il est impossible de lancer `npm test` sur mac.

## :robot: Solution
En s'appuyant sur : https://github.com/ember-cli/ember-cli/pull/8774, on enlève `--disable-gpu` dans les différents `testem`.

## :rainbow: Remarque
`--disable-gpu ` était recommandé pour l'exécution de Chrome en headless sur Linux, mais d'après ember-cli/ember-cli#8774 il n'est plus nécessaire depuis environ 2017.