### PR TITLE
[BUGFIX] Problème d'affichage du logo Pix dans le footer (site-38).

### DIFF
--- a/app/styles/components/_app-footer.scss
+++ b/app/styles/components/_app-footer.scss
@@ -26,6 +26,7 @@ footer {
 
   .sitelogo {
     margin-bottom: 40px;
+    width: 50%;
 
     @media (min-width: 769px) {
       margin-bottom: 0;


### PR DESCRIPTION
## :unicorn: Problème
Le logo Pix est trop grand dans le footer sur un format tablette.

## :robot: Solution
Changer sa taille pour les tablettes et téléphones.

## :sparkles: Review App
https://pix-site-integration-pr63.scalingo.io
