### PR TITLE
[FEATURE] Possibilité de choisir la date affichée d'une actualité sur Prismic  (site-37).

### DIFF
--- a/app/services/prismic.js
+++ b/app/services/prismic.js
@@ -43,7 +43,7 @@ export default Service.extend({
     const documents = await api.query(PrismicJS.Predicates.at('document.type', 'news_item'), {
       page,
       pageSize,
-      orderings: '[document.first_publication_date desc]'
+      orderings: '[my.news_item.date desc]'
     });
     return documents.results;
   },

--- a/app/templates/components/news-item-card.hbs
+++ b/app/templates/components/news-item-card.hbs
@@ -10,7 +10,7 @@
     <p class="news-item-card__meta">
       <span class="news-item-card__category {{categoryClassName}}">{{categoryLabel}}</span>
       •
-      <span class="news-item-card__date">le {{moment-format newsItem.first_publication_date 'LL'}}</span>
+      <span class="news-item-card__date">le {{moment-format newsItem.data.date 'LL'}}</span>
     </p>
 
     <h1 class="news-item-card__title">{{as-text newsItem.data.title}}</h1>

--- a/app/templates/components/news-item-post.hbs
+++ b/app/templates/components/news-item-post.hbs
@@ -1,5 +1,4 @@
 <header class="news-item-post__header">
-  {{log newsItem}}
   <h1 class="news-item-post__title">{{as-text newsItem.data.title}}</h1>
   <p class="news-item-post__meta">
     <span class="news-item-post__category {{categoryClassName}}">{{categoryLabel}}</span>

--- a/app/templates/components/news-item-post.hbs
+++ b/app/templates/components/news-item-post.hbs
@@ -1,10 +1,11 @@
 <header class="news-item-post__header">
+  {{log newsItem}}
   <h1 class="news-item-post__title">{{as-text newsItem.data.title}}</h1>
   <p class="news-item-post__meta">
     <span class="news-item-post__category {{categoryClassName}}">{{categoryLabel}}</span>
     •
     {{#if newsItem.first_publication_date}}
-    <span class="news-item-post__date">le {{moment-format newsItem.first_publication_date 'LL'}}</span>
+    <span class="news-item-post__date">le {{moment-format newsItem.data.date 'LL'}}</span>
     {{else}}
     <span class="news-item-post__date">Preview</span>
     {{/if}}

--- a/tests/integration/components/news-item-card-test.js
+++ b/tests/integration/components/news-item-card-test.js
@@ -14,6 +14,7 @@ module('Integration | Component | news-item-card', function(hooks) {
       last_publication_date: '2019-04-09T13:19:32+0000',
       first_publication_date: '2019-03-09T13:19:32+0000',
       data: {
+        date: '2019-03-10',
         category: 'Announcement',
         title: [{ spans:[], text: 'The title of the news post', type: 'heading1' }],
         excerpt: [{ spans:[], text: 'The excerpt of the news post', type: 'paragraph' }],
@@ -61,13 +62,13 @@ module('Integration | Component | news-item-card', function(hooks) {
     assert.dom('.news-item-card__excerpt').hasText('The excerpt of the news post');
   });
 
-  test('it renders the first publication date', async function(assert) {
+  test('it renders the chosen date', async function(assert) {
 
     // when
     await render(hbs`{{news-item-card newsItem=newsItem}}`);
 
     // then
     assert.dom('.news-item-card__date').exists();
-    assert.dom('.news-item-card__date').hasText('le 9 mars 2019');
+    assert.dom('.news-item-card__date').hasText('le 10 mars 2019');
   });
 });

--- a/tests/integration/components/news-item-post-test.js
+++ b/tests/integration/components/news-item-post-test.js
@@ -14,6 +14,7 @@ module('Integration | Component | news-item-post', function(hooks) {
       last_publication_date: '2019-04-09T13:19:32+0000',
       first_publication_date: '2019-03-09T13:19:32+0000',
       data: {
+        date: '2019-03-10',
         category: 'Announcement',
         title: [{ spans:[], text: 'The title of the news post', type: 'heading1' }],
         body: [{ spans:[], text: 'The body of the news post', type: 'paragraph' }],
@@ -42,14 +43,14 @@ module('Integration | Component | news-item-post', function(hooks) {
     assert.dom('.news-item-post__title').hasText('The title of the news post');
   });
 
-  test('it renders the first publication date', async function(assert) {
+  test('it renders the chosen date on prismic', async function(assert) {
 
     // when
     await render(hbs`{{news-item-post newsItem=newsItem}}`);
 
     // then
     assert.dom('.news-item-post__date').exists();
-    assert.dom('.news-item-post__date').hasText('le 9 mars 2019');
+    assert.dom('.news-item-post__date').hasText('le 10 mars 2019');
   });
 
   test('it renders the body', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, la date affichée représente la date de première publication, seulement il est nécessaire de pouvoir choisir la date qui sera affiché, pour par exemple faire remonter une actualité etc.

## :robot: Solution
Ajout d'un attribut date sur Prismic, et gérer ce nouvel attribut.

## :sparkles: Review App
https://pix-site-integration-pr65.scalingo.io
