### PR TITLE
[BUGFIX] Rendre le texte "code parcours" de la pop-in rejoindre une campagne visible sous IE (site-39).

### DIFF
--- a/app/styles/components/_pop-in-campaigns.scss
+++ b/app/styles/components/_pop-in-campaigns.scss
@@ -155,4 +155,11 @@
   line-height: 1.375rem;
   white-space: nowrap;
   transform: rotate(-90deg);
+
+  /*  Support IE */
+  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    position: relative;
+    top: 42px;
+    left: 40px;
+  }
 }


### PR DESCRIPTION
## :unicorn: Problème
Le texte "code parcours" n'était pas visible sous IE.

## :robot: Solution
Le rendre visible sous IE.

## :sparkles: Review App
https://pix-site-integration-pr66.scalingo.io
