### PR TITLE
[TECH] Problème de build pour développer avec IE (site-40).

### DIFF
--- a/config/targets.js
+++ b/config/targets.js
@@ -3,7 +3,8 @@
 const browsers = [
   'last 1 Chrome versions',
   'last 1 Firefox versions',
-  'last 1 Safari versions'
+  'last 1 Safari versions',
+  'ie 11'
 ];
 
 const isCI = !!process.env.CI;


### PR DESCRIPTION
## :unicorn: Problème
Il est impossible de voir notre avancement en local car le build development n'inclut pas IE.

## :robot: Solution
Ajouter IE aux browsers dans `target.js`

## :sparkles: Review App
https://pix-site-integration-pr67.scalingo.io
