### PR TITLE
[FEATURE] Rendre contribuables la page statistiques (site-28).

### DIFF
--- a/app/routes/stats.js
+++ b/app/routes/stats.js
@@ -1,69 +1,92 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
 
-  model() {
-    return {
-      accounts: {
-        data: {
-          labels: ['07/18', '08/18', '09/18', '10/18', '11/18', '12/18', '01/19', '02/19', '03/19', '04/19','05/19','06/19'],
-          datasets: [{
-            label: 'Comptes Pix créés',
-            data: [62109, 63349, 100892, 127596, 146492, 160055, 192281, 211985, 234103, 250656, 271282, 294515],
-            type: 'line',
-            backgroundColor: 'rgba(54, 162, 235, 0.2)',
-            borderColor: 'rgb(54, 162, 235)',
-          }],
-        },
-      },
-      campaigns: {
-        data: {
-          labels: ['07/18', '08/18', '09/18', '10/18', '11/18', '12/18', '01/19', '02/19', '03/19', '04/19', '05/19', '06/19'],
-          datasets: [{
-            label: 'Campagnes d’évaluation',
-            data: [ 0, 10, 31, 64, 261, 687, 1272, 1896, 2487, 3034, 4005, 4886],
-            type: 'line',
-            backgroundColor: 'rgba(255, 205, 86, 0.2)',
-            borderColor: 'rgb(255, 205, 86)',
-          }],
-        },
-      },
-      certifications: {
-        data: {
-          labels: ['07/18', '08/18', '09/18', '10/18', '11/18', '12/18', '01/19', '02/19', '03/19', '04/19', '05/19', '06/19'],
-          datasets: [{
-            label: 'Certifications Pix délivrées',
-            data: [8554, 8677, 9083, 9366, 10697, 18333, 23859, 24171, 27567, 34496, 39447, 49201],
-            type: 'line',
-            backgroundColor: 'rgba(75, 192, 192, 0.2)',
-            borderColor: 'rgb(75, 192, 192)',
-          }],
-        },
-      },
-      feedbacks: {
-        data: {
-          labels: ['07/18', '08/18', '09/18', '10/18', '11/18', '12/18', '01/19', '02/19', '03/19', '04/19','05/19', '06/19'],
-          datasets: [{
-            label: 'Signalements d’épreuves',
-            data: [9354, 9500, 10728, 13397, 15292, 16641, 18600, 20862, 25086, 28108, 30748, 31947],
-            type: 'line',
-            backgroundColor: 'rgba(153, 102, 255, 0.2)',
-            borderColor: 'rgb(153, 102, 255)',
-          }],
-        },
-      },
-      organizations: {
-        data: {
-          labels: ['07/18', '08/18', '09/18', '10/18', '11/18', '12/18', '01/19', '02/19', '03/19', '04/19', '05/19', '06/19'],
-          datasets: [{
-            label: 'Organisations partenaires',
-            data: [340, 357, 362, 365, 575, 874, 1076, 1236, 1381, 1517, 1717, 1795],
-            type: 'line',
-            backgroundColor: 'rgba(153, 102, 255, 0.2)',
-            borderColor: 'rgb(153, 102, 255)',
-          }],
-        },
+  prismic: service(),
+
+  async model() {
+    const accounts = {
+      data: {
+        labels: null,
+        datasets: [{
+          label: 'Comptes Pix créés',
+          data: [],
+          type: 'line',
+          backgroundColor: 'rgba(54, 162, 235, 0.2)',
+          borderColor: 'rgb(54, 162, 235)',
+        }]
       }
-    }
+    };
+    const campaigns = {
+      data: {
+        labels: null,
+        datasets: [{
+          label: 'Campagnes d’évaluation',
+          data: [],
+          type: 'line',
+          backgroundColor: 'rgba(255, 205, 86, 0.2)',
+          borderColor: 'rgb(255, 205, 86)',
+        }]
+      }
+    };
+    const certifications = {
+      data: {
+        labels: null,
+        datasets: [{
+          label: 'Certifications Pix délivrées',
+          data: [],
+          type: 'line',
+          backgroundColor: 'rgba(75, 192, 192, 0.2)',
+          borderColor: 'rgb(75, 192, 192)',
+        }]
+      }
+    };
+    const organizations = {
+      data: {
+        labels: null,
+        datasets: [{
+          label: 'Organisations partenaires',
+          data: [],
+          type: 'line',
+          backgroundColor: 'rgba(153, 102, 255, 0.2)',
+          borderColor: 'rgb(153, 102, 255)',
+        }]
+      }
+    };
+
+    const dates = [];
+    const accountsData = [];
+    const campaignsData = [];
+    const certificationsData = [];
+    const organizationsData = [];
+
+    const doc = await this.prismic.getPage('statistiques');
+
+    doc.data.stats.forEach(stats => {
+      const date = new Date(stats.primary.date);
+      const month = date.getMonth() + 1;
+      const year = date.getFullYear().toString().substr(2);
+
+      dates.push(`${month}/${year}`);
+      accountsData.push(stats.primary.accounts);
+      campaignsData.push(stats.primary.campaigns);
+      certificationsData.push(stats.primary.certifications);
+      organizationsData.push(stats.primary.organizations);
+    });
+
+    accounts.data.labels = dates;
+    accounts.data.datasets[0].data = accountsData;
+
+    campaigns.data.labels = dates;
+    campaigns.data.datasets[0].data = campaignsData;
+
+    certifications.data.labels = dates;
+    certifications.data.datasets[0].data = certificationsData;
+
+    organizations.data.labels = dates;
+    organizations.data.datasets[0].data = organizationsData;
+
+    return {doc, accounts, campaigns, certifications, organizations};
   }
 });

--- a/app/styles/pages/_stats-page.scss
+++ b/app/styles/pages/_stats-page.scss
@@ -9,7 +9,7 @@
     margin-bottom: 15px;
   }
 
-  b {
+  .blue {
     font-weight: bold;
     color: $blue-1;
   }

--- a/app/templates/stats.hbs
+++ b/app/templates/stats.hbs
@@ -1,39 +1,32 @@
 <main class="page stats-page">
-
   <header class="page-header">
     <div class="container md padding-container">
       <h1 class="page-header__title">
-        Chiffres clés
+        {{as-html model.doc.data.title}}
       </h1>
     </div>
   </header>
-
   <main class="page-body">
 
     <div class="container md padding-container">
 
       <section>
-        <h2>Comptes utilisateurs</h2>
-        <p>Depuis le lancement de la plateforme en septembre 2017, près de <b>300 000 utilisateurs</b> - élèves, étudiants, professionnels, demandeurs d’emploi, retraités - se sont inscrits sur Pix afin d'évaluer, développer et valoriser leurs compétences numériques.</p>
+        {{as-html model.doc.data.accounts}}
         {{ember-chart type='line' data=model.accounts.data width=300 height=110}}
       </section>
 
       <section>
-        <h2>Évaluation des compétences numériques</h2>
-        <p>À ce jour, les utilisateurs de Pix ont répondu à plus de <b>28 millions d'épreuves</b> adaptatives portant sur les 5 grands domaines sur 16 compétences numériques en correspondance avec le Cadre de Référence des Compétences Numériques français et le cadre européen DigComp.</p>
-        <p>Depuis octobre 2018, plus de <b>4 500 campagnes d'évaluation</b> ciblées et trans-compétences ont été élaborées par les organisations partenaires mettant en oeuvre Pix dans leur établissement et proposées aux personnes qu'ils accompagnent (collaborateurs, élèves, étudiants, demandeurs d’emploi et personnes éloignées du numérique).</p>
+        {{as-html model.doc.data.campaigns}}
         {{ember-chart type='line' data=model.campaigns.data width=300 height=110}}
       </section>
 
       <section>
-        <h2>Certifications Pix</h2>
-        <p>Depuis décembre 2017, plus de 3 000 sessions de certifications ont eu lieu dans les différents centres agréés répartis dans toute la France. Près de <b>50 000 certifications Pix</b> , reconnues par l’Etat et le monde professionnel, ont été délivrées permettant de valoriser les compétences de leurs titulaires.</p>
+        {{as-html model.doc.data.certifications}}
         {{ember-chart type='line' data=model.certifications.data width=300 height=110}}
       </section>
 
       <section>
-        <h2>Déploiement</h2>
-        <p>Pix est déployé et utilisé pour le diagnostic et l'accompagnement du développement des compétences numériques au sein de plus de <b>1 700 organisations</b> telles que des établissements scolaires ou d'enseignement supérieur, des organismes publics et des services administratifs, ainsi que des structures ou entreprises du secteur privé.</p>
+        {{as-html model.doc.data.organizations}}
         {{ember-chart type='line' data=model.organizations.data width=300 height=110}}
       </section>
     </div>


### PR DESCRIPTION
## :unicorn: Problème
La page statistiques est mise à jour tous les mois. On a donc du wording à faire, une PR et mise en production pour que cette mise à jour se fasse tous les mois, c'est lourd d'un point de vue organisationnelle. 

## :robot: Solution
Rendre les statistiques contribuables via Prismic.

## :sparkles: Review App
https://pix-site-integration-pr68.scalingo.io
