### PR TITLE
[BUGFIX] Problème de largeur de la page actualités (site-42).

### DIFF
--- a/app/styles/_burger-menu.scss
+++ b/app/styles/_burger-menu.scss
@@ -2,6 +2,7 @@
 
   @supports not (-webkit-overflow-scrolling: touch) {
     position: absolute;
+    width: 100%;
   }
 
   @media (min-width: 600px) {


### PR DESCRIPTION
## :unicorn: Problème
La page actualité ne prends plus toute la largeur sous mobile.

## :robot: Solution
Ajout d'un `width: 100%`

## :sparkles: Review App
https://pix-site-integration-pr70.scalingo.io
