### PR TITLE
[FEATURE] Commencer l'origine des axes Y par 0 (site-45).

### DIFF
--- a/app/components/ember-chart.js
+++ b/app/components/ember-chart.js
@@ -23,6 +23,13 @@ export default Component.extend({
         options: {
           legend: {
             poisition: this.legendPosition,
+          },
+          scales: {
+            yAxes: [{
+                ticks: {
+                    beginAtZero: true
+                }
+            }]
           }
         }
       });


### PR DESCRIPTION
## :unicorn: Problème
On affiche des graphiques dont l'origine est choisie automatiquement par chart.js. Cependant, cela tronque la pertinence des données.

## :robot: Solution
Commencer l'origine de l'axe Y par 0. 

## :sparkles: Review App
https://pix-site-integration-pr71.scalingo.io
