### PR TITLE
[TECH] Ajout d'un stub pour le test du service hot-news.

### DIFF
--- a/tests/unit/services/hot-news-test.js
+++ b/tests/unit/services/hot-news-test.js
@@ -1,31 +1,38 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'ember-qunit'
+import { resolve } from 'rsvp';
+import Service from '@ember/service';
 
 module('Unit | Service | hot-news', function(hooks) {
   setupTest(hooks);
 
   test('it should load hot news', async function(assert) {
     // Given
+    const expectedNews = {
+      id: 'XTglrBIAACQASurY',
+      uid: null,
+      type: 'hot_news',
+      href: '',
+      tags: [],
+      first_publication_date: '2019-07-24T09:32:32+0000',
+      last_publication_date: '2019-08-27T08:39:57+0000',
+      slugs: [],
+      linked_documents: [],
+      lang: 'fr-fr',
+      alternate_languages: [],
+      data: {}
+    };
+
+    const prismicStub = Service.create({
+      getHotNews: () => resolve(expectedNews)
+    });
     const hotNews = this.owner.lookup('service:hotNews');
+    hotNews.set('prismic', prismicStub);
 
     // When
     await hotNews.load();
 
     // Then
-    const expectObjectKeys = {
-      id: '',
-      uid: null,
-      type: '',
-      href: '',
-      tags: [],
-      first_publication_date: '',
-      last_publication_date: '',
-      slugs: [],
-      linked_documents: [],
-      lang: '',
-      alternate_languages: [],
-      data: {}
-    }
-    assert.deepEqual(Object.keys(hotNews.news), Object.keys(expectObjectKeys));
+    assert.deepEqual(Object.keys(hotNews.news), Object.keys(expectedNews));
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lorsque la page hot-news n'est pas publié sur Prismic, le test du service ne fonctionnait plus.

## :robot: Solution
Stuber le service de Prismic dans le test du service hot-news
