### PR TITLE
[BUGFIX] Problème pour les liens pix pointant sur un document (site-54).

### DIFF
--- a/app/components/handle-link.js
+++ b/app/components/handle-link.js
@@ -10,6 +10,9 @@ export default Component.extend({
       return doc.pathname;
     }
   }),
+  useLinkTo: computed('path', function() {
+    return this.path && !this.path.includes('documents/');
+  }),
   linkClass: null,
   text: null,
   target: null,

--- a/app/templates/components/handle-link.hbs
+++ b/app/templates/components/handle-link.hbs
@@ -1,5 +1,5 @@
-{{#if path}}
+{{#if useLinkTo}}
   <LinkTo @route="{{as-route path}}" class="{{linkClass}}">{{{text}}}</LinkTo>
 {{else}}
-  <a href="{{url}}" class="{{linkClass}}" target="{{target}}">{{{text}}}</a>
+  <a href="{{if path path url}}" class="{{linkClass}}" target="{{target}}">{{{text}}}</a>
 {{/if }}

--- a/tests/integration/components/handle-link-test.js
+++ b/tests/integration/components/handle-link-test.js
@@ -35,6 +35,18 @@ module('Integration | Component | handle-link', function(hooks) {
     assert.equal(this.element.querySelector('a').getAttribute('href'), '/mediation-numerique');
   });
 
+  test('it should return path of url if it\'s a Pix url for documents', async function(assert) {
+    // given
+    const url = "https://pix.fr/documents/document_1233.pdf";
+    this.set('url', url);
+
+    // when
+    await render(hbs`<HandleLink @url={{this.url}} />`);
+
+    // then
+    assert.equal(this.element.querySelector('a').getAttribute('href'), '/documents/document_1233.pdf');
+  });
+
   test('it should add class for external link', async function(assert) {
     // given
     const url = "https://youtube.fr";


### PR DESCRIPTION
## :unicorn: Problème
Les liens pointant vers un document dans le header et footer ne fonctionnent plus et nous retournent sur la page index. 

## :robot: Solution
Gérer les documents dans le composant `handle-link` pour gérer le cas du pathname `/documents/uid`

