### PR TITLE
[BUGFIX] Problème de page blanche sous IE (site-55).

### DIFF
--- a/app/components/handle-link.js
+++ b/app/components/handle-link.js
@@ -10,8 +10,8 @@ export default Component.extend({
       return doc.pathname;
     }
   }),
-  useLinkTo: computed('path', function() {
-    return this.path && !this.path.includes('documents/');
+  needInternalLink: computed('path', function() {
+    return this.path && this.path.indexOf('documents/') === -1;
   }),
   linkClass: null,
   text: null,

--- a/app/components/handle-link.js
+++ b/app/components/handle-link.js
@@ -3,15 +3,15 @@ import { computed } from '@ember/object';
 
 export default Component.extend({
   url: null,
-  path: computed('url', function() {
+  internalLink: computed('url', function() {
     const doc = document.createElement('a');
     doc.href = this.url;
     if(doc.hostname === 'pix.fr') {
       return doc.pathname;
     }
   }),
-  needInternalLink: computed('path', function() {
-    return this.path && this.path.indexOf('documents/') === -1;
+  inDocuments: computed('path', function() {
+    return this.internalLink && this.internalLink.indexOf('documents/') !== -1;
   }),
   linkClass: null,
   text: null,

--- a/app/templates/components/handle-link.hbs
+++ b/app/templates/components/handle-link.hbs
@@ -1,5 +1,9 @@
-{{#if useLinkTo}}
-  <LinkTo @route="{{as-route path}}" class="{{linkClass}}">{{{text}}}</LinkTo>
+{{#if internalLink}}
+  {{#if inDocuments}}
+    <a href="{{internalLink}}" class="{{linkClass}}" target="{{target}}">{{{text}}}</a>
+  {{else}}
+    <LinkTo @route="{{as-route internalLink}}" class="{{linkClass}}">{{{text}}}</LinkTo>
+  {{/if}}
 {{else}}
-  <a href="{{if path path url}}" class="{{linkClass}}" target="{{target}}">{{{text}}}</a>
+  <a href="{{url}}" class="{{linkClass}}" target="{{target}}">{{{text}}}</a>
 {{/if }}


### PR DESCRIPTION
## :unicorn: Problème
On observe une page blanche sous IE. 

## :robot: Solution
Lors de la précédente PR https://github.com/1024pix/pix-site/pull/76, il a été utlisé `includes`, qui fait parti de ES6, hors IE est incompatible avec celui-ci, on utilise donc à la place `indexOf`.
 
## :rainbow: Remarque 
Un BSR a été fait pour faire apparaître le besoin métier dans le code.
