### PR TITLE
[TECH] Remise en place de fr-fr comme language par défault

### DIFF
--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -1,7 +1,6 @@
 export default {
   'en-gb': 'English',
   'fr-fr': 'Français',
-  'fr-be': 'Français',
   'contact-digital-mediation': {
     'page-title': 'Information request',
     'form-id': '28758'

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -1,5 +1,4 @@
 export default {
-  'fr-be': 'Français',
   'fr-fr': 'Français',
   'en-gb': 'English',
   'contact-digital-mediation': {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -87,10 +87,10 @@ export default {
    */
   axios: {},
   i18n: {
-    defaultLocale: 'fr-be',
+    defaultLocale: 'fr-fr',
     locales: [
       {
-        code: 'fr-be',
+        code: 'fr-fr',
         file: 'fr-fr.js'
       },
       {
@@ -101,7 +101,7 @@ export default {
     lazy: true,
     langDir: 'lang/',
     vueI18n: {
-      fallbackLocale: 'fr-be'
+      fallbackLocale: 'fr-fr'
     }
   },
   router: {

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -57,7 +57,6 @@ export default {
   nuxtI18n: {
     paths: {
       'fr-fr': '/qui-sommes-nous',
-      'fr-be': '/qui-sommes-nous',
       'en-gb': '/about'
     }
   },

--- a/pages/digital-mediation.vue
+++ b/pages/digital-mediation.vue
@@ -79,7 +79,6 @@ export default {
   nuxtI18n: {
     paths: {
       'fr-fr': '/mediation-numerique',
-      'fr-be': '/mediation-numerique',
       'en-gb': '/digital-mediation'
     }
   },

--- a/pages/employers.vue
+++ b/pages/employers.vue
@@ -87,7 +87,6 @@ export default {
   nuxtI18n: {
     paths: {
       'fr-fr': '/employeurs',
-      'fr-be': '/employeurs',
       'en-gb': '/employers'
     }
   },

--- a/pages/formable-pages/contact-digital-mediation.vue
+++ b/pages/formable-pages/contact-digital-mediation.vue
@@ -16,7 +16,6 @@ export default {
   nuxtI18n: {
     paths: {
       'fr-fr': '/formulaire/contact-mediation-numerique',
-      'fr-be': '/formulaire/contact-mediation-numerique',
       'en-gb': '/form/contact-digital-mediation'
     }
   }

--- a/pages/formable-pages/higher-education-establishment-registration.vue
+++ b/pages/formable-pages/higher-education-establishment-registration.vue
@@ -16,7 +16,6 @@ export default {
   nuxtI18n: {
     paths: {
       'fr-fr': '/formulaire/inscription-etablissement-superieur',
-      'fr-be': '/formulaire/inscription-etablissement-superieur',
       'en-gb': '/form/higher-education-establishment-registration'
     }
   }

--- a/pages/formable-pages/pix-certification-application.vue
+++ b/pages/formable-pages/pix-certification-application.vue
@@ -16,7 +16,6 @@ export default {
   nuxtI18n: {
     paths: {
       'fr-fr': '/formulaire/demande-agrement-centre-certification',
-      'fr-be': '/formulaire/demande-agrement-centre-certification',
       'en-gb': '/form/pix-certification-application'
     }
   }

--- a/pages/formable-pages/pix-orga-higher-school-registration.vue
+++ b/pages/formable-pages/pix-orga-higher-school-registration.vue
@@ -16,7 +16,6 @@ export default {
   nuxtI18n: {
     paths: {
       'fr-fr': '/formulaire/finalisation-pix-orga-sup',
-      'fr-be': '/formulaire/finalisation-pix-orga-sup',
       'en-gb': '/form/pix-orga-higher-school-registration'
     }
   }

--- a/pages/formable-pages/pix-orga-registration.vue
+++ b/pages/formable-pages/pix-orga-registration.vue
@@ -16,7 +16,6 @@ export default {
   nuxtI18n: {
     paths: {
       'fr-fr': '/formulaire/contact-pix-pro',
-      'fr-be': '/formulaire/contact-pix-pro',
       'en-gb': '/form/pix-orga-registration'
     }
   }

--- a/pages/higher-education.vue
+++ b/pages/higher-education.vue
@@ -95,7 +95,6 @@ export default {
   nuxtI18n: {
     paths: {
       'fr-fr': '/enseignement-superieur',
-      'fr-be': '/enseignement-superieur',
       'en-gb': '/higher-education'
     }
   },

--- a/pages/legal-notices.vue
+++ b/pages/legal-notices.vue
@@ -36,7 +36,6 @@ export default {
   nuxtI18n: {
     paths: {
       'fr-fr': '/mentions-legales',
-      'fr-be': '/mentions-legales',
       'en-gb': '/en-gb/legal-notices'
     }
   },

--- a/pages/news/_slug.vue
+++ b/pages/news/_slug.vue
@@ -18,7 +18,6 @@ export default {
   nuxtI18n: {
     paths: {
       'fr-fr': '/actualites/:slug',
-      'fr-be': '/actualites/:slug',
       'en-gb': '/news/:slug'
     }
   },

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -34,7 +34,6 @@ export default {
   nuxtI18n: {
     paths: {
       'fr-fr': '/actualites',
-      'fr-be': '/actualites',
       'en-gb': '/news'
     }
   },

--- a/pages/school-education.vue
+++ b/pages/school-education.vue
@@ -124,7 +124,6 @@ export default {
   nuxtI18n: {
     paths: {
       'fr-fr': '/enseignement-scolaire',
-      'fr-be': '/enseignement-scolaire',
       'en-gb': '/school-education'
     }
   },

--- a/pages/skills.vue
+++ b/pages/skills.vue
@@ -32,7 +32,6 @@ export default {
   nuxtI18n: {
     paths: {
       'fr-fr': '/competences',
-      'fr-be': '/competences',
       'en-gb': '/skills'
     }
   },

--- a/pages/stats.vue
+++ b/pages/stats.vue
@@ -28,7 +28,6 @@ export default {
   nuxtI18n: {
     paths: {
       'fr-fr': '/stats',
-      'fr-be': '/stats',
       'en-gb': '/stats'
     }
   },

--- a/pages/terms-of-service.vue
+++ b/pages/terms-of-service.vue
@@ -29,7 +29,6 @@ export default {
   nuxtI18n: {
     paths: {
       'fr-fr': '/conditions-generales-d-utilisation',
-      'fr-be': '/conditions-generales-d-utilisation',
       'en-gb': '/terms-of-service'
     }
   },

--- a/plugins/link-resolver.js
+++ b/plugins/link-resolver.js
@@ -1,4 +1,4 @@
-const defaultLocale = 'fr-be'
+const defaultLocale = 'fr-fr'
 
 export default function(doc) {
   const staticRoute = [


### PR DESCRIPTION
## :unicorn: Problème
Pour faciliter la migration vers Nuxt, on a mis en place `fr-be` comme language par défault, maintenant que la migration est finie, il faut remettre `fr-fr` comme language par default.

## :robot: Solution
Supprimer `fr-be` comme language par défaut et comme langue.