### PR TITLE
[BUGFIX] Correction du lien vers les tests de démo (#84).

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -32,7 +32,7 @@
               class="course__description"
             />
             <div class="course__start-button">
-              <a :href="item.card_button_link.url.link" target="pix_app">
+              <a :href="item.card_button_link.url" target="pix_app">
                 {{ $prismic.richTextAsPlain(item.card_button_title) }}
               </a>
             </div>


### PR DESCRIPTION
## :unicorn: Problème
Le lien "Commencer" des tests de démo était généré avec le HTML suivant :

    <a href="function link() { [native code] }" target="pix_app">
      Commencer
    </a>

ce qui ne fonctionnait pas bien sûr.

## :robot: Solution
On utilise `item.card_button_link.url` et non `item.card_button_link.url.link` qui faisait référence à une fonction `link()` non pertinente ici.
