### PR TITLE
[BUGFIX] Problèmes d'affichage du burger menu. 

### DIFF
--- a/components/burger-menu-nav.vue
+++ b/components/burger-menu-nav.vue
@@ -129,6 +129,15 @@ export default {
   .nav-bottom a:hover {
     text-decoration: underline;
   }
+
+  .bm-item-list {
+    margin-left: 0;
+    padding: 0 25px;
+
+    & > * {
+      padding: 0;
+    }
+  }
 }
 
 .bm-burger-bars {
@@ -144,14 +153,5 @@ export default {
 .bm-cross {
   background: $grey-1;
   height: 24px !important;
-}
-
-.bm-item-list {
-  margin-left: 0;
-  padding: 0 25px;
-
-  & > * {
-    padding: 0;
-  }
 }
 </style>

--- a/components/burger-menu-nav.vue
+++ b/components/burger-menu-nav.vue
@@ -92,6 +92,7 @@ export default {
       color: $white;
       text-align: left;
       text-transform: uppercase;
+      margin-top: 10px;
     }
 
     .show-page-icon {


### PR DESCRIPTION
## :unicorn: Problème
Le burger menu est trop décalé vers la droite et les éléments du menu du bas sont trop collés

## :robot: Solution
Résoudre les problèmes sass et d'héritage des composants de vue 
Et ajout d'un `margin-top: 10px` pour les élements du menu du bas dans le burger menu. 