### PR TITLE
[TECH] Création d'un fichier scalingo.json pour dimensionner les review apps

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,18 @@
+{
+  "name": "Pix Site Review App",
+  "env": {
+    "REVIEW_APP": {
+      "description": "Indicates that the application is a review app",
+      "value": "true"
+    }
+  },
+  "addons": [
+  ],
+  "formation": {
+    "web": {
+      "amount": 1,
+      "size": "S"
+    }
+  }
+}
+


### PR DESCRIPTION
## :unicorn: Problème
Par défaut Scalingo crée les _review apps_ avec une taille de conteneur `M` alors qu'une taille `S` est suffisante.

## :robot: Solution
Avec le fichier `scalingo.json` on peut spécifier la taille par défaut des conteneurs.
