### PR TITLE
[BUGFIX] Problème d'images dans certaines sections. 

### DIFF
--- a/components/slices/section-column.vue
+++ b/components/slices/section-column.vue
@@ -16,8 +16,8 @@
         </ul>
       </div>
       <div class="container-column">
-        <div :class="rightClass">
-          <prismic-image v-if="image !== null" :field="image"></prismic-image>
+        <div v-if="hasImage" :class="rightClass">
+          <prismic-image :field="image"></prismic-image>
         </div>
       </div>
     </div>
@@ -61,6 +61,9 @@ export default {
     },
     image() {
       return this.content.primary.image
+    },
+    hasImage() {
+      return this.image && this.image.url
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
On peut avoir une 404, qui affiche un logo d'image sur la page, lorsqu'on ne met pas d'image sur Prismic mais que le slice `section-column` en cherche quand même une.  

## :robot: Solution
Ajout d'une condition pour afficher l'image seulement quand il y en a une. 
