### PR TITLE
[BUGFIX] Certaines images sur mobile sont collées à gauche.

### DIFF
--- a/pages/school-education.vue
+++ b/pages/school-education.vue
@@ -231,6 +231,7 @@ export default {
           &.block-img {
             width: 100%;
             min-height: 100px;
+            text-align: center;
 
             img {
               max-width: 100%;


### PR DESCRIPTION
## :unicorn: Problème
Certaines images provenant de prismic sur mobile sont collées à gauche

## :robot: Solution
Ajouter un text-align: center pour centrer les images.
