### PR TITLE
[FEATURE] Ajout d'une page /aide pour rediriger vers le support de Pix.

### DIFF
--- a/middleware/redirect-to-external-link.js
+++ b/middleware/redirect-to-external-link.js
@@ -1,0 +1,7 @@
+export default function(context) {
+  const { redirect, route } = context
+  const currentPageName = route.name.split('___')[0]
+  if (currentPageName === 'help') {
+    redirect('https://support.pix.fr')
+  }
+}

--- a/pages/help.vue
+++ b/pages/help.vue
@@ -1,0 +1,12 @@
+<script>
+export default {
+  middleware: 'redirect-to-external-link',
+  name: 'Help',
+  nuxtI18n: {
+    paths: {
+      'fr-fr': '/aide',
+      'en-gb': '/help'
+    }
+  }
+}
+</script>


### PR DESCRIPTION
## :unicorn: Problème
Certains liens externe à `https//pix.fr` pointe vers `https://pix.fr/aide` qui a été remplacé par le support de Pix : `https://support.pix.fr`, les utilisateurs se retrouvent alors sur une page oups et sont donc perdus sur le site. 

## :robot: Solution
Ajouter une page help `/aide` en `fr-fr` 
Ajout d'un middleware `redirect-to-external-link` qui dans le cas de la page `help` redirige vers `https://support.pix.fr`

## :sparkles: Review App