### PR TITLE
[BUGFIX] Lien vers un doc certif KO (PS-2)

### DIFF
--- a/assets/scss/pages/_pages.scss
+++ b/assets/scss/pages/_pages.scss
@@ -38,5 +38,15 @@
 
   .page-section {
     padding: 20px;
+
+    &__description {
+      h2 {
+        font-weight: 400;
+      }
+
+      ul {
+        list-style: none;
+      }
+    }
   }
 }

--- a/pages/_simple-page.vue
+++ b/pages/_simple-page.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="page">
+    <header class="page-header">
+      <div class="container md padding-container">
+        <h1 class="page-header__title">
+          <prismic-rich-text :field="newsItem.data.title" />
+        </h1>
+      </div>
+    </header>
+
+    <div class="page-body">
+      <section class="page-section">
+        <div class="container md padding-container">
+          <div class="page-section__description">
+            <prismic-rich-text :field="newsItem.data.body" />
+          </div>
+        </div>
+      </section>
+    </div>
+    <prismic-edit-button :document-id="documentId" />
+  </div>
+</template>
+
+<script>
+import { documentFetcher } from '~/services/document-fetcher'
+export default {
+  name: 'SimplePage',
+  nuxtI18n: {
+    paths: {
+      'fr-fr': '/:uid',
+      'en-gb': '/:uid'
+    }
+  },
+  async asyncData({ params, app, req, error, route }) {
+    const host = req ? req.headers.host : window.location.host
+    const currentPagePath = `${host}${route.path}`
+    try {
+      const newsItem = await documentFetcher(app.i18n, req).getSimplePageByUid(
+        params.uid
+      )
+      return { currentPagePath, newsItem, documentId: newsItem.id }
+    } catch (e) {
+      error({ statusCode: 404, message: 'Page not found' })
+    }
+  },
+  head() {
+    const meta = this.$getMeta(
+      this.newsItem.data.meta,
+      this.currentPagePath,
+      this.$prismic
+    )
+    return {
+      meta
+    }
+  }
+}
+</script>
+
+<style lang="scss"></style>

--- a/pages/terms-of-service.vue
+++ b/pages/terms-of-service.vue
@@ -57,14 +57,4 @@ export default {
 }
 </script>
 
-<style lang="scss">
-.page-section__description {
-  h2 {
-    font-weight: 400;
-  }
-
-  ul {
-    list-style: none;
-  }
-}
-</style>
+<style lang="scss"></style>

--- a/services/document-fetcher.js
+++ b/services/document-fetcher.js
@@ -51,13 +51,10 @@ export function documentFetcher(i18n = { defaultLocale: 'fr-fr' }, req) {
     },
     getSimplePageByUid: async (uid) => {
       const api = await getApi()
-      console.log(language)
       const document = await api.query(
-        PrismicConfig.Predicates.at('my.simple_page.uid', uid),
+        Prismic.Predicates.at('my.simple_page.uid', uid),
         { lang: language }
       )
-      console.log('simplePage', uid)
-      console.log(document)
       return document.results[0]
     }
   }

--- a/services/document-fetcher.js
+++ b/services/document-fetcher.js
@@ -48,6 +48,17 @@ export function documentFetcher(i18n = { defaultLocale: 'fr-fr' }, req) {
     getPreviewUrl: async (previewToken) => {
       const api = await getApi()
       return api.previewSession(previewToken, LinkResolver, '/')
+    },
+    getSimplePageByUid: async (uid) => {
+      const api = await getApi()
+      console.log(language)
+      const document = await api.query(
+        PrismicConfig.Predicates.at('my.simple_page.uid', uid),
+        { lang: language }
+      )
+      console.log('simplePage', uid)
+      console.log(document)
+      return document.results[0]
     }
   }
 


### PR DESCRIPTION
## :unicorn: Problème
Lien vers https://pix.fr/dp-formulaire-demande-agrement KO
Ce lien est accessible depuis le formulaire de demande d'agrément : https://pix.fr/formulaire/demande-agrement-centre-certification (tout en bas de page en cliquant sur "lien")
<img width="669" alt="image" src="https://user-images.githubusercontent.com/38167520/71076232-a58bf000-2185-11ea-9d06-100c12554f35.png">

## :robot: Solution
Ajout de la gestion des documents `simple page` provenant de Prismic. 
Pour cela on gère les URI de type `pix.fr/:uid` dans la nouvelle page : `simple-page`.

## :rainbow: Remarques
Les documents affichés dans le site vitrine pix sont accessibles via une URI, fournie par le CMS prismic. 
Par exemple, pour la page qui ne fonctionnait plus, son URI est : `dp-formulaire-demande-agrement` (le rendu du doc peut être vu sur prismic https://pix-site.prismic.io/documents~k=simple_page&b=working&c=published&l=fr-fr/XQJW-xIAACAAYmsk*XWvliRAAACIAVfj8/)

Rendu : 
<img width="1323" alt="image" src="https://user-images.githubusercontent.com/38167520/71078345-7d9e8b80-2189-11ea-85d9-261e455c3ddf.png">



## :sparkles: Review App
https://pix-site-integration-pr.scalingo.io
