### PR TITLE
[FEATURE] Rajoute une entrée accueil dans la navigation (PS-11).

### DIFF
--- a/assets/scss/components/_app-navbar.scss
+++ b/assets/scss/components/_app-navbar.scss
@@ -51,11 +51,7 @@
   .logo {
     width: 82px;
     height: 62px;
-    margin-right: 18px;
-
-    @include device-is('tablet') {
-      margin-right: 35px;
-    }
+    margin-right: 24px;
   }
 
   .nav-principal {
@@ -74,11 +70,7 @@
     .logo {
       width: 82px;
       height: 62px;
-      margin-right: 18px;
-
-      @include device-is('tablet') {
-        margin-right: 35px;
-      }
+      margin-right: 24px;
     }
 
     .navigation {
@@ -89,7 +81,7 @@
       align-items: center;
 
       .text-black {
-        margin-right: 38px;
+        margin-right: 24px;
 
         &:last-child {
           margin-right: 0;

--- a/components/main-nav.vue
+++ b/components/main-nav.vue
@@ -1,12 +1,19 @@
 <template>
   <div class="navigation">
     <pix-link
-      v-for="item in mainNavItems"
+      v-for="(item, index) in mainNavItems"
       :key="item.id"
       :field="item.primary.link"
-      class="text text-xs text-left regular text-black"
+      :class="[
+        'text',
+        'text-xs',
+        'text-left',
+        'regular',
+        { 'text-black': index < mainNavItems.length - 1 },
+        { 'btn-nav': index === mainNavItems.length - 1 }
+      ]"
     >
-      <prismic-rich-text :field="item.primary.title" />
+      {{ $prismic.richTextAsPlain(item.primary.title) }}
     </pix-link>
   </div>
 </template>

--- a/components/main-nav.vue
+++ b/components/main-nav.vue
@@ -4,7 +4,7 @@
       v-for="item in mainNavItems"
       :key="item.id"
       :field="item.primary.link"
-      class="text text-s text-left regular text-black"
+      class="text text-xs text-left regular text-black"
     >
       <prismic-rich-text :field="item.primary.title" />
     </pix-link>


### PR DESCRIPTION
## :unicorn: Problème
Les utilisateurs n'ont pas tous le réflexe de cliquer sur le logo pour revenir à l'accueil.

## :robot: Solution
Ajouter une entrée accueil dans la navigation principale.

## :rainbow: Remarques
Vous pouvez tester le menu avec l'entrée "Accueil" en ajoutant /en-gb dans l'url.

J'ai aussi amélioré le markup de la navigation pour passer de : 

```html
  <a>
    <div>
      <p>
        Accueil
      </p>
    </div>
  </a>
```

à : 

```html
  <a>
  </a>
```
