### PR TITLE
[BUGFIX] Corrige le bug de superposition dans le burger menu (PS-19).

### DIFF
--- a/components/burger-menu-nav.vue
+++ b/components/burger-menu-nav.vue
@@ -84,9 +84,6 @@ export default {
   }
 
   .nav-bottom {
-    position: absolute;
-    bottom: 40px;
-
     &__link {
       font-weight: 400;
       color: $white;
@@ -132,11 +129,15 @@ export default {
   }
 
   .bm-item-list {
+    height: 100%;
     margin-left: 0;
     padding: 0 25px;
 
     & > * {
       padding: 0;
+      flex-direction: column;
+      justify-content: space-between;
+      height: 100%;
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Les entrées du burger menu se superpose sur Iphone 5.

## :robot: Solution
J'ai fixé la hauteur du menu pour que les deux parties ne se superposent plus.