### PR TITLE
[FEATURE] Ajout du style pour le lien vers pro.pix.fr (PS-14).

### DIFF
--- a/assets/scss/components/_main-nav.scss
+++ b/assets/scss/components/_main-nav.scss
@@ -1,3 +1,8 @@
 .btn-nav {
   transition: all ease-in .2s;
 }
+
+.link-separator-left {
+  border-left: 1px solid $grey-8;
+  padding-left: 24px;
+}

--- a/assets/scss/globals/_colors.scss
+++ b/assets/scss/globals/_colors.scss
@@ -5,6 +5,7 @@ $grey-4: #CCCCCC;
 $grey-5: #666666;
 $grey-6: #444444;
 $grey-7: #DDDDDD;
+$grey-8: #96a0af;
 
 $blue-1: #3D68FF;
 $blue-2: #12A3FF;

--- a/components/main-nav.vue
+++ b/components/main-nav.vue
@@ -10,6 +10,7 @@
         'text-left',
         'regular',
         { 'text-black': index < mainNavItems.length - 1 },
+        { 'link-separator-left': index === mainNavItems.length - 3 },
         { 'btn-nav': index === mainNavItems.length - 1 }
       ]"
     >


### PR DESCRIPTION
## :unicorn: Problème
Le lien vers Pix Pro doit disposer d'un séparateur à gauche.

## :robot: Solution
Ajout d'une bordure à gauche du lien vers Pix Pro

## :rainbow: Remarques
Pour tester il faut cloner le repo et lancer la commande `npm run dev`. Ouvrez ensuite le site en ajoutant `/en-gb` à l'url.
