### PR TITLE
[FEATURE] Changement de texte pour la page d'erreur (PS-34).

### DIFF
--- a/components/slices/video.vue
+++ b/components/slices/video.vue
@@ -1,9 +1,5 @@
 <template>
-  <video
-    controls
-    autoplay
-    class="video-slice"
-  >
+  <video controls autoplay class="video-slice">
     <source :src="videoUrl" type="video/mp4" />
   </video>
 </template>

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -36,20 +36,10 @@ export default {
   'stats-legend-label-certifications': 'Certifications Pix délivrées',
   'stats-legend-label-organizations': 'Organisations partenaires',
   'error-content':
-    '<p>Oups ! Un problème est survenu, mais pas de panix, nous revenons très vite !</p>' +
-    '<p>Pour en savoir plus, vous pouvez consulter ' +
-    '<a href="http://status.pix.fr/">la page du status de Pix</a> ou aller sur nos réseaux' +
-    '      sociaux : <a href="https://twitter.com/Pix_officiel">Twitter</a>,' +
-    '      <a href="https://www.facebook.com/Pix1024/">Facebook</a>,' +
-    '      <a href="https://www.linkedin.com/company/gip-pix/">LinkedIn</a>.' +
-    '    </p>' +
-    '    <p>' +
-    '      Si vous avez besoin d’aide, vous pouvez également' +
-    '      <a href="https://support.pix.fr/support/tickets/new">contacter le support</a>.' +
-    '    </p>',
-  'error-page-not-found':
-    "<p>Oups ! La page n'existe pas !</p>" +
-    '<p>Revenez sur ' +
-    '<a href="http://pix.fr/">l\'accueil</a>.' +
+    '<p>Oups ! Un problème est survenu, mais pas de panix !</p>' +
+    '<p>Vous pouvez revenir sur la ' +
+    "<a href='http://pix.fr/'>page d'accueil</a>." +
+    '<br/>Si vous avez besoin d’aide, vous pouvez consulter le ' +
+    '<a href="https://support.pix.fr/">support</a>.' +
     '</p>'
 }

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -36,18 +36,20 @@ export default {
   'stats-legend-label-certifications': 'Certifications Pix délivrées',
   'stats-legend-label-organizations': 'Organisations partenaires',
   'error-content':
-    '<p>\n' +
-    '      Oups ! Un problème est survenu, mais pas de panix, nous revenons très vite !\n' +
-    '    </p>\n' +
-    '    <p>\n' +
-    '      Pour en savoir plus, vous pouvez consulter\n' +
-    '      <a href="http://status.pix.fr/">cette page</a> ou aller sur nos réseaux\n' +
-    '      sociaux : <a href="https://twitter.com/Pix_officiel">Twitter</a>,\n' +
-    '      <a href="https://www.facebook.com/Pix1024/">Facebook</a>,\n' +
-    '      <a href="https://www.linkedin.com/company/gip-pix/">LinkedIn</a>.\n' +
-    '    </p>\n' +
-    '    <p>\n' +
-    '      Si vous avez besoin d’aide, vous pouvez également contacter le support\n' +
-    '      <a href="mailto:contact@pix.fr">icix</a>.\n' +
-    '    </p>'
+    '<p>Oups ! Un problème est survenu, mais pas de panix, nous revenons très vite !</p>' +
+    '<p>Pour en savoir plus, vous pouvez consulter ' +
+    '<a href="http://status.pix.fr/">la page du status de Pix</a> ou aller sur nos réseaux' +
+    '      sociaux : <a href="https://twitter.com/Pix_officiel">Twitter</a>,' +
+    '      <a href="https://www.facebook.com/Pix1024/">Facebook</a>,' +
+    '      <a href="https://www.linkedin.com/company/gip-pix/">LinkedIn</a>.' +
+    '    </p>' +
+    '    <p>' +
+    '      Si vous avez besoin d’aide, vous pouvez également' +
+    '      <a href="https://support.pix.fr/support/tickets/new">contacter le support</a>.' +
+    '    </p>',
+  'error-page-not-found':
+    "<p>Oups ! La page n'existe pas !</p>" +
+    '<p>Revenez sur ' +
+    '<a href="http://pix.fr/">l\'accueil</a>.' +
+    '</p>'
 }

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -36,20 +36,10 @@ export default {
   'stats-legend-label-certifications': 'Certifications Pix délivrées',
   'stats-legend-label-organizations': 'Organisations partenaires',
   'error-content':
-    '<p>Oups ! Un problème est survenu, mais pas de panix, nous revenons très vite !</p>' +
-    '<p>Pour en savoir plus, vous pouvez consulter ' +
-    '<a href="http://status.pix.fr/">la page du status de Pix</a> ou aller sur nos réseaux' +
-    '      sociaux : <a href="https://twitter.com/Pix_officiel">Twitter</a>,' +
-    '      <a href="https://www.facebook.com/Pix1024/">Facebook</a>,' +
-    '      <a href="https://www.linkedin.com/company/gip-pix/">LinkedIn</a>.' +
-    '    </p>' +
-    '    <p>' +
-    '      Si vous avez besoin d’aide, vous pouvez également' +
-    '      <a href="https://support.pix.fr/support/tickets/new">contacter le support</a>.' +
-    '    </p>',
-  'error-page-not-found':
-    "<p>Oups ! La page n'existe pas !</p>" +
-    '<p>Revenez sur ' +
-    '<a href="http://pix.fr/">l\'accueil</a>.' +
+    '<p>Oups ! Un problème est survenu, mais pas de panix !</p>' +
+    '<p>Vous pouvez revenir sur la ' +
+    "<a href='http://pix.fr/'>page d'accueil</a>." +
+    '<br/>Si vous avez besoin d’aide, vous pouvez consulter le ' +
+    '<a href="https://support.pix.fr/">support</a>.' +
     '</p>'
 }

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -38,13 +38,18 @@ export default {
   'error-content':
     '<p>Oups ! Un problème est survenu, mais pas de panix, nous revenons très vite !</p>' +
     '<p>Pour en savoir plus, vous pouvez consulter ' +
-    '<a href="http://status.pix.fr/">cette page</a> ou aller sur nos réseaux' +
+    '<a href="http://status.pix.fr/">la page du status de Pix</a> ou aller sur nos réseaux' +
     '      sociaux : <a href="https://twitter.com/Pix_officiel">Twitter</a>,' +
     '      <a href="https://www.facebook.com/Pix1024/">Facebook</a>,' +
     '      <a href="https://www.linkedin.com/company/gip-pix/">LinkedIn</a>.' +
     '    </p>' +
     '    <p>' +
-    '      Si vous avez besoin d’aide, vous pouvez également contacter le support' +
-    '      <a href="mailto:contact@pix.fr">icix</a>.' +
-    '    </p>'
+    '      Si vous avez besoin d’aide, vous pouvez également' +
+    '      <a href="https://support.pix.fr/support/tickets/new">contacter le support</a>.' +
+    '    </p>',
+  'error-page-not-found':
+    "<p>Oups ! La page n'existe pas !</p>" +
+    '<p>Revenez sur ' +
+    '<a href="http://pix.fr/">l\'accueil</a>.' +
+    '</p>'
 }

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,10 +1,15 @@
 <template>
   <div class="error">
     <nuxt-link to="/">
-      <img class="logo" src="/images/pix-logo.svg" alt="logo pix" />
+      <img class="logo" src="/images/pix-logo.svg" alt="Lien pour revenir à l'accueil" />
     </nuxt-link>
     <!-- eslint-disable-next-line vue/no-v-html -->
-    <div v-html="$t('error-content')"></div>
+    <div v-if="error.statusCode === 404">
+      <div v-html="$t('error-page-not-found')"></div>
+    </div>
+    <div v-else>
+      <div v-html="$t('error-content')"></div>
+    </div>
   </div>
 </template>
 <script>
@@ -14,6 +19,11 @@ export default {
     error: {
       type: Object,
       default: null
+    }
+  },
+  head() {
+    return {
+      title: 'Error | Pix'
     }
   }
 }

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,15 +1,14 @@
 <template>
   <div class="error">
     <nuxt-link to="/">
-      <img class="logo" src="/images/pix-logo.svg" alt="Lien pour revenir à l'accueil" />
+      <img
+        class="logo"
+        src="/images/pix-logo.svg"
+        alt="Lien pour revenir à l'accueil"
+      />
     </nuxt-link>
     <!-- eslint-disable-next-line vue/no-v-html -->
-    <div v-if="error.statusCode === 404">
-      <div v-html="$t('error-page-not-found')"></div>
-    </div>
-    <div v-else>
-      <div v-html="$t('error-content')"></div>
-    </div>
+    <div v-html="$t('error-content')"></div>
   </div>
 </template>
 <script>


### PR DESCRIPTION
## :unicorn: Problème
L'utilisateur qui tombait sur une page qui n'existait pas n'avait pas de moyen facile de revenir à l'accueil.

## :robot: Solution
- Changer le texte quand l'erreur est une 404.

## :rainbow: Remarques
- La première solution fut de faire une redirection automatique. Malheureusement, la page Error.vue est un layout avec peu de fonctionnalité : pas de `fetch` ou de `asyncData`, impossibilité de savoir qu'on vient de la page `error.vue`quand on est dans un middleware. Donc pour l'instant on met de coté cette solution.
- Ajout de quelques améliorations d'A11Y de cette page.

## 🖍 Pour tester 
Aller sur : https://pix-site-review-pr111.osc-fr1.scalingo.io/aide/certifications

## :sparkles: Review App
https://pix-site-review-pr111.osc-fr1.scalingo.io/