### PR TITLE
[FEATURE] Gestion de pix.org et pix.fr (PIX-xxx).

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,36 @@
 
 > Site vitrine de Pix.
 
+## Variables d'environnement
+
+`PRISMIC_API_ENDPOINT`  
+URL of the Prismic API used for content management.
+
+- presence: required
+- type: Url
+- default: none
+
+`PRISMIC_API_TOKEN`
+API token of the Prismic API used for content management.
+
+- presence: required
+- type: String
+- default: none
+
+`DOMAIN_FR`
+Domain name for `.fr` extension.
+
+- presence: required
+- type: String
+- default: none
+
+`DOMAIN_ORG`
+Domain name for `.org` extension.
+
+- presence: required
+- type: String
+- default: none
+
 ## Build Setup
 
 ```bash

--- a/config/locale-domains.js
+++ b/config/locale-domains.js
@@ -1,0 +1,4 @@
+module.exports = {
+  'fr-fr': process.env.DOMAIN_FR,
+  fr: process.env.DOMAIN_ORG
+}

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -1,0 +1,45 @@
+export default {
+  'fr-fr': 'Français',
+  'en-gb': 'English',
+  'contact-digital-mediation': {
+    'page-title': "Demande d'information",
+    'form-id': '24665'
+  },
+  'higher-education-establishment-registration': {
+    'page-title': 'Demande d’espace Pix Orga',
+    'form-id': '22367'
+  },
+  'pix-certification-application': {
+    'page-title': "Demande d'agrément comme centre de certification Pix",
+    'form-id': '23331'
+  },
+  'pix-orga-registration': {
+    'page-title': "Demande d'information",
+    'form-id': '22370'
+  },
+  'pix-orga-higher-school-registration': {
+    'page-title': "Finalisez votre demande d'espace Pix Orga",
+    'form-id': '22797'
+  },
+  'news-page-title': 'Actualités',
+  'news-page-no-news': "Il n’y a pas encore d'actualités",
+  announcement: 'Annonce',
+  engineering: 'Ingénierie',
+  event: 'Événement',
+  feature: 'Nouveauté',
+  society: 'Société',
+  'about-title': 'A propos',
+  'resources-title': 'Ressources',
+  'social-networks-title': 'Nous suivre',
+  'stats-legend-label-accounts': 'Comptes Pix créés',
+  'stats-legend-label-campaigns': 'Campagnes d’évaluation',
+  'stats-legend-label-certifications': 'Certifications Pix délivrées',
+  'stats-legend-label-organizations': 'Organisations partenaires',
+  'error-content':
+    '<p>Oups ! Un problème est survenu, mais pas de panix !</p>' +
+    '<p>Vous pouvez revenir sur la ' +
+    "<a href='http://pix.fr/'>page d'accueil</a>." +
+    '<br/>Si vous avez besoin d’aide, vous pouvez consulter le ' +
+    '<a href="https://support.pix.fr/">support</a>.' +
+    '</p>'
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line nuxt/no-cjs-in-config
 const PrismicConfig = require('./prismic.config')
+const localeDomains = require('./config/locale-domains')
 
 export default {
   mode: 'universal',
@@ -80,7 +81,12 @@ export default {
     '@nuxtjs/axios',
     '@nuxtjs/dotenv',
     '@nuxtjs/style-resources',
-    'nuxt-i18n',
+    [
+      'nuxt-i18n',
+      {
+        differentDomains: true
+      }
+    ],
     '@nuxtjs/moment',
     ['nuxt-matomo', { matomoUrl: 'https://stats.pix.fr/', siteId: 1 }],
     [
@@ -112,17 +118,24 @@ export default {
     locales: [
       {
         code: 'fr-fr',
-        file: 'fr-fr.js'
+        file: 'fr-fr.js',
+        domain: localeDomains['fr-fr']
       },
       {
         code: 'en-gb',
-        file: 'en-gb.js'
+        file: 'en-gb.js',
+        domain: localeDomains.fr
+      },
+      {
+        code: 'fr',
+        file: 'fr.js',
+        domain: localeDomains.fr
       }
     ],
     lazy: true,
     langDir: 'lang/',
     vueI18n: {
-      fallbackLocale: 'fr-fr'
+      fallbackLocale: 'fr'
     }
   },
   router: {

--- a/store/index.js
+++ b/store/index.js
@@ -1,4 +1,5 @@
 import { documents, documentFetcher } from '~/services/document-fetcher'
+import localeDomains from '~/config/locale-domains'
 
 export const state = () => ({
   organizationNavItems: [],
@@ -8,7 +9,8 @@ export const state = () => ({
   bottomItems: [],
   resourcesNavItems: [],
   aboutNavItems: [],
-  hotNews: null
+  hotNews: null,
+  localeDomains
 })
 export const actions = {
   async nuxtServerInit({ commit }, { app }) {


### PR DESCRIPTION
## :unicorn: Problème
Le site actuel est le même quelque soit le domaine ou la langue.

## :robot: Solution
Le plugin `nuxt-i18n` permet de configurer un domaine différent par locale.
Il est choisi d'utiliser pix.org pour la locale `fr` (French dans prismic) et pix.fr pour la locale `fr-fr` (Français - France dans prismic).

## :rainbow: Remarques
En attente de plus d'informations sur le contenu éditorial du site pix.org.

## :sparkles: Review App
https://pix-site-integration-pr.scalingo.io
