### PR TITLE
[FEATURE] Gestion de pix.org et pix.fr (PIX-629).

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,44 @@
 
 > Site vitrine de Pix.
 
+## Variables d'environnement
+
+`PRISMIC_API_ENDPOINT`  
+URL of the Prismic API used for content management.
+
+- presence: required
+- type: Url
+- default: none
+
+`PRISMIC_API_TOKEN`
+API token of the Prismic API used for content management.
+
+- presence: required
+- type: String
+- default: none
+
+`DOMAIN_FR`
+Domain name for `.fr` extension.
+
+- presence: required
+- type: String
+- default: none
+
+`DOMAIN_ORG`
+Domain name for `.org` extension.
+
+- presence: required
+- type: String
+- default: none
+
+`FORWARDED_HOST`
+Indicates whether host is forwarded.
+Shall be set to `true` on Review Apps.
+
+- presence: optional
+- type: Boolean
+- default: false
+
 ## Build Setup
 
 ```bash

--- a/components/pix-link.vue
+++ b/components/pix-link.vue
@@ -22,14 +22,16 @@ export default {
       }
       let template = ''
       const url = prismicDOM.Link.url(this.field, this.$prismic.linkResolver)
+      const relativeLinkPrefix = getRelativeLinkPrefix(url)
+
       if (this.field.link_type === 'Document') {
         template = `
           <router-link to="${url}">
             <slot/>
           </router-link>
         `
-      } else if (url.startsWith('https://pix.fr')) {
-        const relativeUrl = url.replace('https://pix.fr', '')
+      } else if (relativeLinkPrefix) {
+        const relativeUrl = url.replace(relativeLinkPrefix, '')
         template = `
           <router-link to="${relativeUrl}">
             <slot/>
@@ -48,5 +50,19 @@ export default {
       return { template }
     }
   }
+}
+function getRelativeLinkPrefix(url) {
+  if (!url) {
+    return ''
+  }
+  const defaultPrefixes = 'https://pix.org,https://pix.fr'
+  const relativeLinkPrefixes = (
+    process.env.RELATIVE_LINK_PREFIXES || defaultPrefixes
+  ).split(',')
+  return relativeLinkPrefixes
+    .map((relativeLinkPrefix) =>
+      url.startsWith(relativeLinkPrefix) ? relativeLinkPrefix : ''
+    )
+    .filter((relativeLinkPrefix) => relativeLinkPrefix !== '')[0]
 }
 </script>

--- a/config/locale-domains.js
+++ b/config/locale-domains.js
@@ -1,0 +1,4 @@
+export default {
+  'fr-fr': process.env.DOMAIN_FR,
+  fr: process.env.DOMAIN_ORG
+}

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -1,0 +1,45 @@
+export default {
+  'fr-fr': 'Français',
+  'en-gb': 'English',
+  'contact-digital-mediation': {
+    'page-title': "Demande d'information",
+    'form-id': '24665'
+  },
+  'higher-education-establishment-registration': {
+    'page-title': 'Demande d’espace Pix Orga',
+    'form-id': '22367'
+  },
+  'pix-certification-application': {
+    'page-title': "Demande d'agrément comme centre de certification Pix",
+    'form-id': '23331'
+  },
+  'pix-orga-registration': {
+    'page-title': "Demande d'information",
+    'form-id': '22370'
+  },
+  'pix-orga-higher-school-registration': {
+    'page-title': "Finalisez votre demande d'espace Pix Orga",
+    'form-id': '22797'
+  },
+  'news-page-title': 'Actualités',
+  'news-page-no-news': "Il n’y a pas encore d'actualités",
+  announcement: 'Annonce',
+  engineering: 'Ingénierie',
+  event: 'Événement',
+  feature: 'Nouveauté',
+  society: 'Société',
+  'about-title': 'A propos',
+  'resources-title': 'Ressources',
+  'social-networks-title': 'Nous suivre',
+  'stats-legend-label-accounts': 'Comptes Pix créés',
+  'stats-legend-label-campaigns': 'Campagnes d’évaluation',
+  'stats-legend-label-certifications': 'Certifications Pix délivrées',
+  'stats-legend-label-organizations': 'Organisations partenaires',
+  'error-content':
+    '<p>Oups ! Un problème est survenu, mais pas de panix !</p>' +
+    '<p>Vous pouvez revenir sur la ' +
+    "<a href='http://pix.fr/'>page d'accueil</a>." +
+    '<br/>Si vous avez besoin d’aide, vous pouvez consulter le ' +
+    '<a href="https://support.pix.fr/">support</a>.' +
+    '</p>'
+}

--- a/middleware/current-page-path.js
+++ b/middleware/current-page-path.js
@@ -1,5 +1,18 @@
 export default function(context) {
   const { req, route } = context
-  const host = req ? req.headers.host : window.location.host
+  const host = _getHostFromRequest(req)
+    ? _getHostFromRequest(req)
+    : window.location.host
+
   context.currentPagePath = `${host}${route.path}`
+}
+
+function _getHostFromRequest(req) {
+  if (!req) {
+    return
+  }
+  const headers = req.headers
+  return headers['x-forwarded-host']
+    ? headers['x-forwarded-host']
+    : headers.host
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,5 @@
 import { transports } from 'winston'
+import localeDomains from './config/locale-domains'
 import PrismicConfig from './prismic.config'
 
 export default {
@@ -80,7 +81,13 @@ export default {
     '@nuxtjs/axios',
     '@nuxtjs/dotenv',
     '@nuxtjs/style-resources',
-    'nuxt-i18n',
+    [
+      'nuxt-i18n',
+      {
+        differentDomains: true,
+        forwardedHost: process.env.FORWARDED_HOST || false
+      }
+    ],
     '@nuxtjs/moment',
     ['nuxt-matomo', { matomoUrl: 'https://stats.pix.fr/', siteId: 1 }],
     [
@@ -121,11 +128,13 @@ export default {
     locales: [
       {
         code: 'fr-fr',
-        file: 'fr-fr.js'
+        file: 'fr-fr.js',
+        domain: localeDomains['fr-fr']
       },
       {
-        code: 'en-gb',
-        file: 'en-gb.js'
+        code: 'fr',
+        file: 'fr.js',
+        domain: localeDomains.fr
       }
     ],
     lazy: true,

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,5 +1,5 @@
-// eslint-disable-next-line nuxt/no-cjs-in-config
-const PrismicConfig = require('./prismic.config')
+import { transports } from 'winston'
+import PrismicConfig from './prismic.config'
 
 export default {
   mode: 'universal',
@@ -93,6 +93,15 @@ export default {
             icons: ['faCog', 'faCalendar', 'faHome', 'faCircle', 'faCheck']
           }
         ]
+      }
+    ],
+    [
+      'nuxt-winston-log',
+      {
+        loggerOptions: {
+          level: 'debug',
+          transports: [new transports.Console()]
+        }
       }
     ]
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -2216,7 +2216,6 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.14"
       }
@@ -3441,6 +3440,36 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "colornames": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      },
+      "dependencies": {
+        "color": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+          "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+          "requires": {
+            "color-convert": "^1.9.1",
+            "color-string": "^1.5.2"
+          }
+        }
+      }
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -4190,6 +4219,16 @@
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
     },
+    "diagnostics": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+      "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "1.0.x",
+        "kuler": "1.0.x"
+      }
+    },
     "diff-sequences": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
@@ -4428,6 +4467,14 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
+    "enabled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "requires": {
+        "env-variable": "0.0.x"
+      }
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -4488,6 +4535,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
       "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+    },
+    "env-variable": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.6.tgz",
+      "integrity": "sha512-bHz59NlBbtS0NhftmR8+ExBEekE7br0e01jw+kk0NDro7TtZzBYZ5ScGPs3OmwnpyfHTHOtr1Y6uedCdrIldtg=="
     },
     "errno": {
       "version": "0.1.7",
@@ -5439,6 +5491,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
     "fb-watchman": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
@@ -5447,6 +5504,11 @@
       "requires": {
         "bser": "^2.0.0"
       }
+    },
+    "fecha": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
     "figgy-pudding": {
       "version": "3.5.1",
@@ -8285,6 +8347,14 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "kuler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
+      "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
+      "requires": {
+        "colornames": "^1.1.1"
+      }
+    },
     "last-call-webpack-plugin": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
@@ -8562,6 +8632,18 @@
       "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
       "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=",
       "dev": true
+    },
+    "logform": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.1.2.tgz",
+      "integrity": "sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==",
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^2.3.3",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
+      }
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -9516,6 +9598,22 @@
       "resolved": "https://registry.npmjs.org/nuxt-matomo/-/nuxt-matomo-1.2.3.tgz",
       "integrity": "sha512-jaA8u5XjBi1KJ/MAymzMexNvJO6meoMLMRH4M7AsVpnw4F5Dm+ahsvp2xKaFqtcKtknVi6x/n2IBd8FqVWSXBw=="
     },
+    "nuxt-winston-log": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/nuxt-winston-log/-/nuxt-winston-log-1.1.0.tgz",
+      "integrity": "sha512-oLnHQhVVSelfmLUsrrK86cnqL9m1+6rL1HzG5s8zAj2O5ZvsqMnqnTHwJ7qNHZrz91fGqt3QyvV606MJwpgwMg==",
+      "requires": {
+        "vue": "^2.6.11",
+        "winston": "^3.2.1"
+      },
+      "dependencies": {
+        "vue": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
+          "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ=="
+        }
+      }
+    },
     "nwsapi": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
@@ -9644,6 +9742,11 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "one-time": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
+      "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
     },
     "onetime": {
       "version": "5.1.0",
@@ -13334,6 +13437,11 @@
         }
       }
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -13509,6 +13617,11 @@
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "true-case-path": {
       "version": "1.0.3",
@@ -15034,6 +15147,62 @@
       "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
       "requires": {
         "string-width": "^4.0.0"
+      }
+    },
+    "winston": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
+      "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
+      "requires": {
+        "async": "^2.6.1",
+        "diagnostics": "^1.1.1",
+        "is-stream": "^1.1.0",
+        "logform": "^2.1.1",
+        "one-time": "0.0.4",
+        "readable-stream": "^3.1.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.3.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        }
+      }
+    },
+    "winston-transport": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.3.0.tgz",
+      "integrity": "sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==",
+      "requires": {
+        "readable-stream": "^2.3.6",
+        "triple-beam": "^1.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -38,12 +38,14 @@
     "nuxt-fontawesome": "0.4.0",
     "nuxt-i18n": "6.3.0",
     "nuxt-matomo": "1.2.3",
+    "nuxt-winston-log": "1.1.0",
     "prismic-dom": "^2.1.0",
     "prismic-javascript": "^2.1.1",
     "prismic-vue": "git+https://github.com/prismicio/prismic-vue.git#nuxt",
     "vue-burger-menu": "2.0.2",
     "vue-chartjs": "3.4.2",
-    "vue-js-modal": "1.3.33"
+    "vue-js-modal": "1.3.33",
+    "winston": "3.2.1"
   },
   "devDependencies": {
     "@nuxtjs/eslint-config": "^1.0.1",

--- a/plugins/link-resolver.js
+++ b/plugins/link-resolver.js
@@ -1,5 +1,3 @@
-const defaultLocale = 'fr-fr'
-
 export default function(doc) {
   const staticRoute = [
     'mediation',
@@ -13,16 +11,12 @@ export default function(doc) {
     'legal-notices'
   ]
   if (staticRoute.includes(doc.type)) {
-    return doc.lang === defaultLocale
-      ? `/${doc.uid}`
-      : `/${doc.lang}/${doc.uid}`
+    return `/${doc.uid}`
   }
   if (doc.type === 'news_item') {
-    return doc.lang === defaultLocale
-      ? `/actualites/${doc.uid}`
-      : `${doc.lang}/news/${doc.uid}`
+    return `/actualites/${doc.uid}`
   }
   if (doc.type === 'index') {
-    return doc.lang === defaultLocale ? `/` : `${doc.lang}/`
+    return `/`
   }
 }

--- a/store/index.js
+++ b/store/index.js
@@ -1,4 +1,5 @@
 import { documents, documentFetcher } from '~/services/document-fetcher'
+import localeDomains from '~/config/locale-domains'
 
 export const state = () => ({
   organizationNavItems: [],
@@ -8,7 +9,8 @@ export const state = () => ({
   bottomItems: [],
   resourcesNavItems: [],
   aboutNavItems: [],
-  hotNews: null
+  hotNews: null,
+  localeDomains
 })
 export const actions = {
   async nuxtServerInit({ commit }, { app }) {


### PR DESCRIPTION
## :unicorn: Problème
Le site actuel est le même quelque soit le domaine ou la langue.

## :robot: Solution
Le plugin `nuxt-i18n` permet de configurer un domaine différent par locale.
Il est choisi d'utiliser pix.org pour la locale `fr` (French dans prismic) et pix.fr pour la locale `fr-fr` (Français - France dans prismic).

## :rainbow: Remarques
Cette PR ne s'occupe que de la mise en place des deux domaines.
Le contenu et la structure des deux sites feront l'objet de nouvelles PR.

## :sparkles: Review App
https://site-pr115.review.pix.fr
et
https://site-pr115.review.pix.org
