### PR TITLE
[FEATURE] Afficher la marianne que pour le site franco-français (PIX-667).

### DIFF
--- a/components/header-nav.vue
+++ b/components/header-nav.vue
@@ -20,7 +20,11 @@
                 src="/images/pix-logo.svg"
               />
             </nuxt-link>
-            <img alt="Logo de la Marianne" src="/images/marianne-logo.svg" />
+            <img
+              v-if="showFrenchGovLogo"
+              alt="Logo de la Marianne"
+              src="/images/marianne-logo.svg"
+            />
           </div>
         </div>
       </div>
@@ -35,7 +39,11 @@
                 src="/images/pix-logo.svg"
               />
             </nuxt-link>
-            <img alt="Logo de la Marianne" src="/images/marianne-logo.svg" />
+            <img
+              v-if="showFrenchGovLogo"
+              alt="Logo de la Marianne"
+              src="/images/marianne-logo.svg"
+            />
             <div class="desktop">
               <main-nav :main-nav-items="mainNavItems" />
             </div>
@@ -65,7 +73,11 @@ export default {
     'topItems',
     'bottomItems',
     'middleItems'
-  ])
+  ]),
+  data() {
+    const showFrenchGovLogo = this.$i18n.locale === 'fr-fr'
+    return { showFrenchGovLogo }
+  }
 }
 </script>
 


### PR DESCRIPTION
## :unicorn: Problème
Ne pas afficher la marianne sur le site .org

## :robot: Solution
Dans header-nav, vérifier la locale et afficher la marianne seulement si 'fr-fr'

## :sparkles: Review App
https://site-pr116.review.pix.fr/
https://site-pr116.review.pix.org/