### PR TITLE
[FEATURE] Retirer des liens du site .org (PIX-702)

### DIFF
--- a/components/organization-nav.vue
+++ b/components/organization-nav.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="nav-switch">
+  <div v-if="organizationNavItems.length > 1" class="nav-switch">
     <div class="container padding-container">
       <div
         v-for="item in organizationNavItems"


### PR DESCRIPTION
## :unicorn: Problème
- Retirer "Enseignement supérieur"
- Retirer "Enseignement scolaire"
- Retirer "Devenir centre de certification"

## :robot: Solution
- Sur Prismic, retirer ces éléments de la page lorsque l'on est sur `.org`
- La suppression des liens laisse un bandeau gris vide: dans cette PR, ce bandeau est supprimé s'il est vide

## :sparkles: Review App
https://site-pr117.review.pix.fr/
https://site-pr117.review.pix.org/
