### PR TITLE
[FEATURE] Pouvoir afficher 6 éléments dans les items de la home (PIX-705).

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -238,7 +238,7 @@ export default {
           text-align: center;
 
           @include device-is('large-mobile') {
-            width: 20%;
+            width: 33%;
             padding: 0 38px;
           }
           @include device-is('tablet') {
@@ -256,6 +256,15 @@ export default {
                 max-height: 146px;
               }
             }
+          }
+        }
+        &__item:nth-child(1):nth-last-child(5),
+        &__item:nth-child(2):nth-last-child(4),
+        &__item:nth-child(3):nth-last-child(3),
+        &__item:nth-child(4):nth-last-child(2),
+        &__item:nth-child(5):nth-last-child(1) {
+          @include device-is('large-mobile') {
+            width: 20%;
           }
         }
       }


### PR DESCRIPTION
## :unicorn: Problème
Le nombre d'élément dans la partie Le projet Pix sur la home est différent entre pix.fr et pix.org. Le style CSS pour 5 éléments ne rend pas bien avec 6 éléments

## :robot: Solution
- Cette partie est gérer en flex, de base avec 20% de la largeur pour chaque item, donc les 5.
- Cette largeur est passé à 33%, pour afficher 3 items par ligne (donc pour 6, 2 lignes de 3 items)
- Dans le cas des 5 items, le width passe à 20% comme avant.

Dans le CSS, l'utilisation de `__item:nth-child(1):nth-last-child(5)` permet de choisir l'item qui est le premier de la liste, et le 5eme en partant de la fin, donc le 1er item d'une liste de 5. Cela permet de mettre le CSS que sur les items d'une liste de 5.

## :sparkles: Review App
https://site-pr118.review.pix.fr/ avec 5 éléments
https://site-pr118.review.pix.org/ avec 6 éléments