### PR TITLE
[BUGFIX] Adapter la taille des icones de la home (PIX-742).

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -247,13 +247,11 @@ export default {
 
           p {
             &.block-img {
-              height: 146px;
-
               display: flex;
               justify-content: center;
 
               img {
-                max-height: 146px;
+                max-height: 105px;
               }
             }
           }


### PR DESCRIPTION
## :unicorn: Problème
Les images de la page d'accueil sont étirées sur IE.

![image](https://user-images.githubusercontent.com/2989532/83785841-2f773900-a692-11ea-896c-208a3b6c0b96.png)

## :robot: Solution
Utiliser des images svg qui ont toutes la même hauteur.
Spécifier cette hauteur dans le css.

## :rainbow: Remarques
RAS

## :sparkles: Review App
https://site-pr120.review.pix.org/