### PR TITLE
[FEATURE] Ajouter l'attribut lang (PIX-833).

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -11,6 +11,9 @@ export default {
    ** Headers of the page
    */
   head: {
+    htmlAttrs: {
+      lang: 'fr'
+    },
     title: 'Pix - Cultivez vos compétences numériques',
     meta: [
       { charset: 'utf-8' },


### PR DESCRIPTION
## :unicorn: Problème
Pour l'accessiblité, on a besoin de rajouter un tag indiquant la langue dans laquelle la page est rédigée.

## :robot: Solution
Ajouter un attribut `lang` sur le tag `html`

## :rainbow: Remarques
Pour l'instant,  on a que `fr`, donc il est en dur. Quand on en saura davantage sur comment on décide de la langue de la page, il faudra rendre cette valeur dynamique.

## :sparkles: Review App
https://pix-site-integration-pr.scalingo.io
Ouvrir la console, inspecter la page et voir l'attribut `lang="fr"` sur la balise html.