### PR TITLE
[A11Y] Revoir la gestion des alt sur la page pix.fr (PIX-907)

### DIFF
--- a/components/app-footer.vue
+++ b/components/app-footer.vue
@@ -2,14 +2,14 @@
   <footer>
     <div class="container padding-container">
       <div class="sitelogo">
-        <a href="/"
-          ><img class="mb-2 logo" alt="pix" src="/images/pix-logo.svg"
+        <a href="/" title="Retour à l'accueil Pix"
+          ><img class="mb-2 logo" alt="" src="/images/pix-logo.svg"
         /></a>
         <div>
           <img
             style="margin-left: -4px;"
             class="ministere"
-            alt="ministere de l education"
+            alt="Soutenu par le ministère de l'éducation"
             src="/images/ministere-logo-2.svg"
           />
         </div>

--- a/components/header-nav.vue
+++ b/components/header-nav.vue
@@ -22,7 +22,7 @@
             </nuxt-link>
             <img
               v-if="showFrenchGovLogo"
-              alt="Logo de la Marianne"
+              alt="Service public d'État"
               src="/images/marianne-logo.svg"
             />
           </div>
@@ -41,7 +41,7 @@
             </nuxt-link>
             <img
               v-if="showFrenchGovLogo"
-              alt="Logo de la Marianne"
+              alt="Service public d'État"
               src="/images/marianne-logo.svg"
             />
             <div class="desktop">

--- a/components/pop-in-campaigns.vue
+++ b/components/pop-in-campaigns.vue
@@ -7,13 +7,13 @@
       <template v-if="!isClosed">
         <img
           class="pop-in-campaigns-content__close"
-          alt="close button"
+          alt="Fermer le panneau des campagnes"
           src="/images/close-icon.svg"
           @click="togglePopIn()"
         />
         <img
           class="pop-in-campaigns-content__logo"
-          alt="Logo rejoindre une campagne"
+          alt=""
           src="/images/logo-join-campaign.svg"
         />
       </template>


### PR DESCRIPTION
## :unicorn: Problème
Les images ont des attributs `alt`qui ne sont pas clairs.

## :robot: Solution
Changer les textes des attributs `alt` de la homepage

## :rainbow: Remarques
- Prismic prévoit un input `alt` associée à une image. Mais lorsqu'elle est laissée vide, l'attribut `alt` n'est pas remonté dans le html

## :sparkles: Review App
https://pix-site-review-pr124.osc-fr1.scalingo.io
