### PR TITLE
[FEATURE ] Formulaire verification certificat (Pix 949)

### DIFF
--- a/assets/scss/globals/_colors.scss
+++ b/assets/scss/globals/_colors.scss
@@ -6,13 +6,16 @@ $grey-5: #666666;
 $grey-6: #444444;
 $grey-7: #dddddd;
 $grey-8: #96a0af;
+$grey-9: rgb(107, 119, 140);
 
 $blue-1: #3d68ff;
 $blue-2: #12a3ff;
 $blue-3: #3257d9;
 $blue-4: #388aff;
+$blue-5: #172b4d;
 
 $error: rgb(153, 0, 0);
+$error-2: #ffdbcc;
 
 $purple-1: #985fff;
 

--- a/assets/scss/globals/_colors.scss
+++ b/assets/scss/globals/_colors.scss
@@ -1,22 +1,24 @@
 $grey-1: #222222;
 $grey-2: #555555;
-$grey-3: #F5F5F5;
-$grey-4: #CCCCCC;
+$grey-3: #f5f5f5;
+$grey-4: #cccccc;
 $grey-5: #666666;
 $grey-6: #444444;
-$grey-7: #DDDDDD;
+$grey-7: #dddddd;
 $grey-8: #96a0af;
 
-$blue-1: #3D68FF;
-$blue-2: #12A3FF;
-$blue-3: #3257D9;
-$blue-4: #388AFF;
+$blue-1: #3d68ff;
+$blue-2: #12a3ff;
+$blue-3: #3257d9;
+$blue-4: #388aff;
 
-$purple-1: #985FFF;
+$error: rgb(153, 0, 0);
+
+$purple-1: #985fff;
 
 $pix-yellow: #ffcb00;
 
 $black: #000000;
-$white: #FFFFFF;
+$white: #ffffff;
 
 $gradient-purple: linear-gradient(135.25deg, $blue-4 0%, $purple-1 100%);

--- a/pages/_simple-page.vue
+++ b/pages/_simple-page.vue
@@ -40,6 +40,8 @@ export default {
       )
       return { currentPagePath, newsItem, documentId: newsItem.id }
     } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error({ e })
       error({ statusCode: 404, message: 'Page not found' })
     }
   },

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -72,6 +72,8 @@ export default {
         documentId: document.id,
       }
     } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error({ e })
       error({ statusCode: 404, message: 'Page not found' })
     }
   },

--- a/pages/higher-education.vue
+++ b/pages/higher-education.vue
@@ -118,6 +118,8 @@ export default {
         keyNumbersId: keyNumbers.id,
       }
     } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error({ e })
       error({ statusCode: 404, message: 'Page not found' })
     }
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -48,6 +48,8 @@ export default {
         documentId: document.id,
       }
     } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error({ e })
       error({ statusCode: 404, message: 'Page not found' })
     }
   },

--- a/pages/legal-notices.vue
+++ b/pages/legal-notices.vue
@@ -53,6 +53,8 @@ export default {
         documentId: document.id,
       }
     } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error({ e })
       error({ statusCode: 404, message: 'Page not found' })
     }
   },

--- a/pages/news/_slug.vue
+++ b/pages/news/_slug.vue
@@ -33,6 +33,8 @@ export default {
       )
       return { currentPagePath, newsItem, documentId: newsItem.id }
     } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error({ e })
       error({ statusCode: 404, message: 'Page not found' })
     }
   },

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -45,6 +45,8 @@ export default {
       const newsItems = await documentFetcher(app.i18n, req).findNewsItems()
       return { newsItems }
     } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error({ e })
       error({ statusCode: 404, message: 'Page not found' })
     }
   },

--- a/pages/preview.vue
+++ b/pages/preview.vue
@@ -8,9 +8,15 @@
 import { documentFetcher } from '~/services/document-fetcher'
 export default {
   name: 'Preview',
-  async asyncData({ query, redirect }) {
-    const url = await documentFetcher().getPreviewUrl(query.token)
-    redirect(url)
+  async asyncData({ query, redirect, error }) {
+    try {
+      const url = await documentFetcher().getPreviewUrl(query.token)
+      redirect(url)
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error({ e })
+      error({ statusCode: 404, message: 'Page not found' })
+    }
   },
 }
 </script>

--- a/pages/school-education.vue
+++ b/pages/school-education.vue
@@ -146,6 +146,8 @@ export default {
         keyNumbersId: keyNumbers.id,
       }
     } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error({ e })
       error({ statusCode: 404, message: 'Page not found' })
     }
   },

--- a/pages/skills.vue
+++ b/pages/skills.vue
@@ -49,6 +49,8 @@ export default {
         documentId: document.id,
       }
     } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error({ e })
       error({ statusCode: 404, message: 'Page not found' })
     }
   },

--- a/pages/stats.vue
+++ b/pages/stats.vue
@@ -88,6 +88,8 @@ export default {
         chartsData,
       }
     } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error({ e })
       error({ statusCode: 404, message: 'Page not found' })
     }
   },

--- a/pages/terms-of-service.vue
+++ b/pages/terms-of-service.vue
@@ -45,6 +45,8 @@ export default {
         documentId: document.id,
       }
     } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error({ e })
       error({ statusCode: 404, message: 'Page not found' })
     }
   },

--- a/pages/verify-certification-score.vue
+++ b/pages/verify-certification-score.vue
@@ -3,15 +3,16 @@
     <main class="page-body">
       <div class="container lg">
         <h1 class="title">{{ title }}</h1>
-        <form @submit="submit">
+        <form novalidate @submit="submit">
           <div class="input-field">
             <label for="code">{{ verificationCodeLabel }}</label>
             <input
               id="code"
               v-model="code"
-              :class="hasCodeRegexError && getRegexErrorClass"
+              :class="{ 'regex-error': hasCodeRegexError }"
               type="text"
               required="true"
+              :pattern="codeRegex"
               name="verificationCode"
             />
             <p v-if="hasCodeRegexError" class="error-paragraph">
@@ -23,9 +24,10 @@
             <input
               id="score"
               v-model="score"
-              :class="hasScoreRegexError && getRegexErrorClass"
+              :class="{ 'regex-error': hasScoreRegexError }"
               type="text"
               required="true"
+              :pattern="scoreRegex"
               name="candidateScore"
             />
             <p v-if="hasScoreRegexError" class="error-paragraph">
@@ -82,8 +84,8 @@ export default {
       score: '',
       code: '',
       errors: [],
-      codeRegex: /^P-[0-9]{5}$/i,
-      scoreRegex: /^[0-9]{1,3}$/,
+      codeRegex: '^[P,p]-[0-9]{5}$',
+      scoreRegex: '^[0-9]{1,3}$',
       hasCodeRegexError: false,
       hasScoreRegexError: false,
       formSent: false,
@@ -101,9 +103,6 @@ export default {
     },
     candidateScoreLabel() {
       return this.document.score_declare_du_candidat
-    },
-    getRegexErrorClass() {
-      return 'regex-error'
     },
     fas() {
       return fas
@@ -123,10 +122,13 @@ export default {
       return !this.hasCodeRegexError && !this.hasScoreRegexError
     },
     isCodeValid() {
-      return this.codeRegex.test(this.code)
+      const regex = new RegExp(this.codeRegex)
+      return regex.test(this.code)
     },
     isScoreValid() {
-      return this.scoreRegex.test(this.score)
+      const regex = new RegExp(this.scoreRegex)
+
+      return regex.test(this.score)
     },
   },
   head() {

--- a/pages/verify-certification-score.vue
+++ b/pages/verify-certification-score.vue
@@ -162,18 +162,20 @@ export default {
       display: flex;
       flex-direction: column;
       input {
+        padding: 0 8px;
+        font-size: 1rem;
         border: 2px solid rgb(107, 119, 140);
         border-radius: 4px;
         max-width: 475px;
         height: 41px;
       }
       .regex-error {
-        border: 2px solid red;
+        border: 2px solid $error;
       }
       .error-paragraph {
-        color: red;
-        font-size: 10px;
+        color: $error;
         margin: 0;
+        font-size: 14px;
       }
     }
     button {
@@ -183,7 +185,7 @@ export default {
     }
   }
   .form-sent {
-    margin-top: 53px;
+    margin-top: 32px;
     background-color: rgb(255, 219, 204);
     border-radius: 4px;
     height: 46px;
@@ -191,11 +193,11 @@ export default {
     width: 436px;
     text-align: center;
     svg {
-      color: rgb(153, 0, 0);
+      color: $error;
       margin-right: 6px;
     }
     span {
-      color: rgb(153, 0, 0);
+      color: $error;
       font-family: 'Roboto', Arial, sans-serif;
       font-size: 14px;
       font-weight: normal;
@@ -204,27 +206,8 @@ export default {
       width: 380px;
     }
   }
-  .form-sent {
-    margin-top: 53px;
-    background-color: rgb(255, 219, 204);
-    border-radius: 4px;
-    height: 46px;
-    line-height: 46px;
-    width: 436px;
-    text-align: center;
-    svg {
-      color: rgb(153, 0, 0);
-      margin-right: 6px;
-    }
-    span {
-      color: rgb(153, 0, 0);
-      font-family: 'Roboto';
-      font-size: 14px;
-      font-weight: normal;
-      height: 22px;
-      letter-spacing: 0.15px;
-      width: 380px;
-    }
+  .error {
+    color: $error;
   }
 }
 </style>

--- a/pages/verify-certification-score.vue
+++ b/pages/verify-certification-score.vue
@@ -5,8 +5,9 @@
         <h1 class="title">{{ title }}</h1>
         <form @submit="submit">
           <div class="input-field">
-            <label>{{ verificationCodeLabel }}</label>
+            <label for="code">{{ verificationCodeLabel }}</label>
             <input
+              id="code"
               v-model="code"
               :class="hasCodeRegexError && getRegexErrorClass"
               type="text"
@@ -18,8 +19,9 @@
             </p>
           </div>
           <div class="input-field">
-            <label>{{ candidateScoreLabel }}</label>
+            <label for="score">{{ candidateScoreLabel }}</label>
             <input
+              id="score"
               v-model="score"
               :class="hasScoreRegexError && getRegexErrorClass"
               type="text"

--- a/pages/verify-certification-score.vue
+++ b/pages/verify-certification-score.vue
@@ -50,7 +50,7 @@ import { fas } from '@fortawesome/free-solid-svg-icons'
 import { documentFetcher } from '~/services/document-fetcher'
 
 export default {
-  name: 'VerifyCertificatioScore',
+  name: 'VerifyCertificationScore',
   nuxtI18n: {
     paths: {
       'fr-fr': '/verifier-score-certification',
@@ -157,7 +157,7 @@ export default {
     flex-direction: column;
     label {
       font-family: 'Roboto', Arial, sans-serif;
-      color: rgb(23, 43, 77);
+      color: $blue-5;
     }
     .input-field {
       margin-bottom: 24px;
@@ -166,7 +166,7 @@ export default {
       input {
         padding: 0 8px;
         font-size: 1rem;
-        border: 2px solid rgb(107, 119, 140);
+        border: 2px solid $grey-9;
         border-radius: 4px;
         max-width: 475px;
         height: 41px;
@@ -188,7 +188,7 @@ export default {
   }
   .form-sent {
     margin-top: 32px;
-    background-color: rgb(255, 219, 204);
+    background-color: $error-2;
     border-radius: 4px;
     height: 46px;
     line-height: 46px;

--- a/pages/verify-certification-score.vue
+++ b/pages/verify-certification-score.vue
@@ -6,13 +6,29 @@
         <form @submit="checkForm">
           <div class="input-field">
             <label>{{ verificationCodeLabel }}</label>
-            <input v-model="code" type="text" name="verificationCode" />
-            <p v-if="hasCodeError" class="error">Code requis</p>
+            <input
+              v-model="code"
+              :class="hasCodeRegexError && getRegexErrorClass"
+              type="text"
+              required="true"
+              name="verificationCode"
+            />
+            <p v-if="hasCodeRegexError" class="error-paragraph">
+              Votre code de vérification ne correspond pas au format: P-XXXXX
+            </p>
           </div>
           <div class="input-field">
             <label>{{ candidateScoreLabel }}</label>
-            <input v-model="score" type="text" name="candidateScore" />
-            <p v-if="hasScoreError" class="error">Score requis</p>
+            <input
+              v-model="score"
+              :class="hasScoreRegexError && getRegexErrorClass"
+              type="text"
+              required="true"
+              name="candidateScore"
+            />
+            <p v-if="hasScoreRegexError" class="error-paragraph">
+              Le score du candidat doit être composé de 3 chiffres
+            </p>
           </div>
           <button class="btn-primary" type="submit">
             {{ buttonLabel }}
@@ -38,6 +54,10 @@ export default {
       score: '',
       code: '',
       errors: [],
+      codeRegex: /^P-[0-9]{5}$/i,
+      scoreRegex: /^[0-9]{1,3}$/i,
+      hasCodeRegexError: false,
+      hasScoreRegexError: false,
     }
   },
   computed: {
@@ -53,31 +73,38 @@ export default {
     candidateScoreLabel() {
       return this.document.score_declare_du_candidat
     },
-    hasCodeError() {
-      return this.containsError(this.errors, 'code')
-    },
-    hasScoreError() {
-      return this.containsError(this.errors, 'score')
+    getRegexErrorClass() {
+      return 'regex-error'
     },
   },
   methods: {
     checkForm(e) {
-      this.errors = []
-      if (this.code && this.score) {
-        return true
-      }
-
-      if (!this.code) {
-        this.errors.push('code')
-      }
-      if (!this.score) {
-        this.errors.push('score')
-      }
       e.preventDefault()
+
+      this.matchesCodeRegex()
+      this.matchesScoreRegex()
+
+      if (!this.hasCodeRegexError && !this.hasScoreRegexError) {
+        alert('Formulaire envoyé')
+      }
     },
 
-    containsError(arr, error) {
-      return arr.includes(error)
+    matchesCodeRegex() {
+      if (!this.codeRegex.test(this.code)) {
+        this.hasCodeRegexError = true
+        return false
+      }
+      this.hasCodeRegexError = false
+      return true
+    },
+
+    matchesScoreRegex() {
+      if (!this.scoreRegex.test(this.score)) {
+        this.hasScoreRegexError = true
+        return false
+      }
+      this.hasScoreRegexError = false
+      return true
     },
   },
   async asyncData({ app, error, req, currentPagePath }) {
@@ -134,7 +161,10 @@ export default {
         max-width: 475px;
         height: 41px;
       }
-      .error {
+      .regex-error {
+        border: 2px solid red;
+      }
+      .error-paragraph {
         color: red;
         font-size: 10px;
         margin: 0;
@@ -143,7 +173,7 @@ export default {
     button {
       width: 175px;
       max-height: 36px;
-      line-height: 36px;
+      line-height: 100%;
     }
   }
 }

--- a/pages/verify-certification-score.vue
+++ b/pages/verify-certification-score.vue
@@ -119,6 +119,7 @@ export default {
         documentId: document.id,
       }
     } catch (e) {
+      // eslint-disable-next-line no-console
       console.error({ e })
       error({ statusCode: 404, message: 'Page not found' })
     }

--- a/pages/verify-certification-score.vue
+++ b/pages/verify-certification-score.vue
@@ -1,36 +1,46 @@
 <template>
   <div class="page competences">
     <main class="page-body">
-      <div class="container lg">
-        <h1 class="title">{{ title }}</h1>
-        <form novalidate @submit="submit">
-          <div class="input-field">
+      <div class="container lg certificate-verification-page">
+        <h1 class="certificate-verification-page__title">{{ title }}</h1>
+        <form
+          class="certificate-verification-page__form"
+          novalidate
+          @submit="submit"
+        >
+          <div class="certificate-verification-page__input-field">
             <label for="code">{{ verificationCodeLabel }}</label>
             <input
               id="code"
               v-model="code"
-              :class="{ 'regex-error': hasCodeRegexError }"
+              :class="[hasCodeRegexError ? 'regex-error' : 'no-regex-error']"
               type="text"
               required="true"
               :pattern="codeRegex"
               name="verificationCode"
             />
-            <p v-if="hasCodeRegexError" class="error-paragraph">
+            <p
+              v-if="hasCodeRegexError"
+              class="certificate-verification-page__error-for-input"
+            >
               Votre code de vérification ne correspond pas au format: P-XXXXX
             </p>
           </div>
-          <div class="input-field">
+          <div class="certificate-verification-page__input-field">
             <label for="score">{{ candidateScoreLabel }}</label>
             <input
               id="score"
               v-model="score"
-              :class="{ 'regex-error': hasScoreRegexError }"
+              :class="[hasScoreRegexError ? 'regex-error' : 'no-regex-error']"
               type="text"
               required="true"
               :pattern="scoreRegex"
               name="candidateScore"
             />
-            <p v-if="hasScoreRegexError" class="error-paragraph">
+            <p
+              v-if="hasScoreRegexError"
+              class="certificate-verification-page__error-for-input"
+            >
               Le score du candidat doit être composé de 3 chiffres
             </p>
           </div>
@@ -38,7 +48,7 @@
             {{ buttonLabel }}
           </button>
         </form>
-        <div v-if="formSent" class="form-sent">
+        <div v-if="formSent" class="certificate-verification-page__form-sent">
           <fa :icon="fas.faExclamationTriangle" />
           <span>Il n'y a pas de certificat Pix correspondant</span>
         </div>
@@ -141,75 +151,91 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.title {
-  font-family: 'Open Sans', Arial, sans-serif;
-  font-size: 62px;
-  height: 164px;
-  line-height: 82px;
-  font-weight: 300;
-  margin-bottom: 50px;
-  max-width: 490px;
-}
 .page-body {
-  form {
-    width: 50%;
-    display: flex;
-    flex-direction: column;
-    label {
-      font-family: 'Roboto', Arial, sans-serif;
-      color: $blue-5;
+  .certificate-verification-page {
+    &__title {
+      font-family: 'Open Sans', Arial, sans-serif;
+      font-size: 62px;
+      height: 164px;
+      line-height: 82px;
+      font-weight: 300;
+      margin-bottom: 50px;
+      max-width: 490px;
     }
-    .input-field {
+
+    &__form {
+      width: 50%;
+      display: flex;
+      flex-direction: column;
+
+      button {
+        width: 175px;
+        max-height: 36px;
+        line-height: 100%;
+      }
+    }
+
+    &__input-field {
       margin-bottom: 24px;
       display: flex;
       flex-direction: column;
+
+      label {
+        font-family: 'Roboto', Arial, sans-serif;
+        color: $blue-5;
+      }
+
+      .no-regex-error {
+        border: 2px solid $grey-9;
+      }
+
+      .regex-error {
+        border: 2px solid $error;
+      }
+
       input {
         padding: 0 8px;
         font-size: 1rem;
-        border: 2px solid $grey-9;
         border-radius: 4px;
         max-width: 475px;
         height: 41px;
       }
-      .regex-error {
-        border: 2px solid $error;
-      }
-      .error-paragraph {
-        color: $error;
-        margin: 0;
-        font-size: 14px;
-      }
     }
-    button {
-      width: 175px;
-      max-height: 36px;
-      line-height: 100%;
-    }
-  }
-  .form-sent {
-    margin-top: 32px;
-    background-color: $error-2;
-    border-radius: 4px;
-    height: 46px;
-    line-height: 46px;
-    width: 436px;
-    text-align: center;
-    svg {
+
+    &__error-for-input {
       color: $error;
-      margin-right: 6px;
-    }
-    span {
-      color: $error;
-      font-family: 'Roboto', Arial, sans-serif;
+      margin: 0;
       font-size: 14px;
-      font-weight: normal;
-      height: 22px;
-      letter-spacing: 0.15px;
-      width: 380px;
     }
-  }
-  .error {
-    color: $error;
+
+    &__form-sent {
+      margin-top: 32px;
+      background-color: $error-2;
+      border-radius: 4px;
+      height: 46px;
+      line-height: 46px;
+      width: 436px;
+      text-align: center;
+
+      svg {
+        color: $error;
+        margin-right: 6px;
+      }
+
+      span {
+        color: $error;
+        font-family: 'Roboto', Arial, sans-serif;
+        font-size: 14px;
+        font-weight: normal;
+        height: 22px;
+        letter-spacing: 0.15px;
+        width: 380px;
+      }
+    }
+
+    .error {
+      color: $error;
+    }
   }
 }
 </style>

--- a/pages/verify-certification-score.vue
+++ b/pages/verify-certification-score.vue
@@ -117,18 +117,16 @@ export default {
       }
     },
     checkForm() {
-      this.hasCodeRegexError = !this.testCodeRegex()
-      this.hasScoreRegexError = !this.testScoreRegex()
+      this.hasCodeRegexError = !this.isCodeValid()
+      this.hasScoreRegexError = !this.isScoreValid()
 
       return !this.hasCodeRegexError && !this.hasScoreRegexError
     },
-    testCodeRegex() {
-      const codeIsCorrect = this.codeRegex.test(this.code)
-      return codeIsCorrect
+    isCodeValid() {
+      return this.codeRegex.test(this.code)
     },
-    testScoreRegex() {
-      const scoreIsCorrect = this.scoreRegex.test(this.score)
-      return scoreIsCorrect
+    isScoreValid() {
+      return this.scoreRegex.test(this.score)
     },
   },
   head() {

--- a/pages/verify-certification-score.vue
+++ b/pages/verify-certification-score.vue
@@ -4,12 +4,16 @@
       <div class="container lg">
         <h1 class="title">{{ title }}</h1>
         <form @submit="checkForm">
-          <label>{{ verificationCodeLabel }}</label>
-          <input v-model="code" type="text" name="verificationCode" />
-          <p v-if="hasCodeError" class="error">Code requis</p>
-          <label>{{ candidateScoreLabel }}</label>
-          <input v-model="score" type="text" name="candidateScore" />
-          <p v-if="hasScoreError" class="error">Score requis</p>
+          <div class="input-field">
+            <label>{{ verificationCodeLabel }}</label>
+            <input v-model="code" type="text" name="verificationCode" />
+            <p v-if="hasCodeError" class="error">Code requis</p>
+          </div>
+          <div class="input-field">
+            <label>{{ candidateScoreLabel }}</label>
+            <input v-model="score" type="text" name="candidateScore" />
+            <p v-if="hasScoreError" class="error">Score requis</p>
+          </div>
           <button class="btn-primary" type="submit">
             {{ buttonLabel }}
           </button>
@@ -120,15 +124,27 @@ export default {
       font-family: 'Roboto', Arial, sans-serif;
       color: rgb(23, 43, 77);
     }
-    input {
-      border: 2px solid rgb(107, 119, 140);
-      border-radius: 4px;
-      max-width: 475px;
+    .input-field {
       margin-bottom: 24px;
+      display: flex;
+      flex-direction: column;
+      input {
+        border: 2px solid rgb(107, 119, 140);
+        border-radius: 4px;
+        max-width: 475px;
+        height: 41px;
+      }
+      .error {
+        color: red;
+        font-size: 10px;
+        margin: 0;
+      }
     }
-  }
-  .error {
-    color: red;
+    button {
+      width: 175px;
+      max-height: 36px;
+      line-height: 36px;
+    }
   }
 }
 </style>

--- a/pages/verify-certification-score.vue
+++ b/pages/verify-certification-score.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="page competences">
+    <main class="page-body">
+      <div class="container lg">
+        <h1 class="title">{{ title }}</h1>
+        <form>
+          <label>{{ verificationCodeLabel }}</label>
+          <input
+            v-model="verificationCode"
+            type="text"
+            name="verificationCode"
+          />
+          <label>{{ candidateScoreLabel }}</label>
+          <input v-model="candidateScore" type="text" name="candidateScore" />
+          <button class="btn-primary" type="submit">
+            {{ buttonLabel }}
+          </button>
+        </form>
+      </div>
+    </main>
+  </div>
+</template>
+
+<script>
+import { documentFetcher } from '~/services/document-fetcher'
+export default {
+  name: 'VerifyScore',
+  nuxtI18n: {
+    paths: {
+      'fr-fr': '/verifier-score-certification',
+      'en-gb': '/verify-certification-score',
+    },
+  },
+  data() {
+    return {
+      candidateScore: 510,
+      verificationCode: 'P-XXXXX',
+      errors: [],
+    }
+  },
+  computed: {
+    buttonLabel() {
+      return this.document.button_label
+    },
+    title() {
+      return this.document.title
+    },
+    verificationCodeLabel() {
+      return this.document.code_de_verification
+    },
+    candidateScoreLabel() {
+      return this.document.score_declare_du_candidat
+    },
+  },
+  // components: { SectionSlice },
+  async asyncData({ app, error, req, currentPagePath }) {
+    try {
+      const document = await documentFetcher(app.i18n, req).getScoreCertifForm()
+      if (process.client) window.prismic.setupEditButton()
+      console.log(document.data)
+
+      return {
+        currentPagePath,
+        meta: document.data.meta,
+        document: document.data,
+        documentId: document.id,
+      }
+    } catch (e) {
+      console.error({ e })
+      error({ statusCode: 404, message: 'Page not found' })
+    }
+  },
+  head() {
+    const meta = this.$getMeta(this.meta, this.currentPagePath, this.$prismic)
+    return {
+      meta,
+    }
+  },
+}
+</script>
+
+<style scoped lang="scss">
+.title {
+  font-family: 'Open Sans', Arial, sans-serif;
+  font-size: 62px;
+  height: 164px;
+  line-height: 82px;
+  font-weight: 300;
+  margin-bottom: 50px;
+  max-width: 490px;
+}
+.page-body {
+  form {
+    width: 50%;
+    display: flex;
+    flex-direction: column;
+    label {
+      font-family: 'Roboto', Arial, sans-serif;
+      color: rgb(23, 43, 77);
+    }
+    input {
+      border: 2px solid rgb(107, 119, 140);
+      border-radius: 4px;
+      max-width: 475px;
+      margin-bottom: 24px;
+    }
+  }
+}
+</style>

--- a/pages/verify-certification-score.vue
+++ b/pages/verify-certification-score.vue
@@ -115,26 +115,18 @@ export default {
       }
     },
     checkForm() {
-      this.testCodeRegex()
-      this.testScoreRegex()
+      this.hasCodeRegexError = !this.testCodeRegex()
+      this.hasScoreRegexError = !this.testScoreRegex()
+
       return !this.hasCodeRegexError && !this.hasScoreRegexError
     },
     testCodeRegex() {
-      if (!this.codeRegex.test(this.code)) {
-        this.hasCodeRegexError = true
-        return false
-      }
-      this.hasCodeRegexError = false
-      return true
+      const codeIsCorrect = this.codeRegex.test(this.code)
+      return codeIsCorrect
     },
-
     testScoreRegex() {
-      if (!this.scoreRegex.test(this.score)) {
-        this.hasScoreRegexError = true
-        return false
-      }
-      this.hasScoreRegexError = false
-      return true
+      const scoreIsCorrect = this.scoreRegex.test(this.score)
+      return scoreIsCorrect
     },
   },
   head() {

--- a/pages/verify-certification-score.vue
+++ b/pages/verify-certification-score.vue
@@ -3,15 +3,13 @@
     <main class="page-body">
       <div class="container lg">
         <h1 class="title">{{ title }}</h1>
-        <form>
+        <form @submit="checkForm">
           <label>{{ verificationCodeLabel }}</label>
-          <input
-            v-model="verificationCode"
-            type="text"
-            name="verificationCode"
-          />
+          <input v-model="code" type="text" name="verificationCode" />
+          <p v-if="hasCodeError" class="error">Code requis</p>
           <label>{{ candidateScoreLabel }}</label>
-          <input v-model="candidateScore" type="text" name="candidateScore" />
+          <input v-model="score" type="text" name="candidateScore" />
+          <p v-if="hasScoreError" class="error">Score requis</p>
           <button class="btn-primary" type="submit">
             {{ buttonLabel }}
           </button>
@@ -33,8 +31,8 @@ export default {
   },
   data() {
     return {
-      candidateScore: 510,
-      verificationCode: 'P-XXXXX',
+      score: '',
+      code: '',
       errors: [],
     }
   },
@@ -51,13 +49,37 @@ export default {
     candidateScoreLabel() {
       return this.document.score_declare_du_candidat
     },
+    hasCodeError() {
+      return this.containsError(this.errors, 'code')
+    },
+    hasScoreError() {
+      return this.containsError(this.errors, 'score')
+    },
   },
-  // components: { SectionSlice },
+  methods: {
+    checkForm(e) {
+      this.errors = []
+      if (this.code && this.score) {
+        return true
+      }
+
+      if (!this.code) {
+        this.errors.push('code')
+      }
+      if (!this.score) {
+        this.errors.push('score')
+      }
+      e.preventDefault()
+    },
+
+    containsError(arr, error) {
+      return arr.includes(error)
+    },
+  },
   async asyncData({ app, error, req, currentPagePath }) {
     try {
       const document = await documentFetcher(app.i18n, req).getScoreCertifForm()
       if (process.client) window.prismic.setupEditButton()
-      console.log(document.data)
 
       return {
         currentPagePath,
@@ -104,6 +126,9 @@ export default {
       max-width: 475px;
       margin-bottom: 24px;
     }
+  }
+  .error {
+    color: red;
   }
 }
 </style>

--- a/plugins/link-resolver.js
+++ b/plugins/link-resolver.js
@@ -9,6 +9,7 @@ export default function (doc) {
     'cgu_page',
     'statistiques',
     'legal-notices',
+    'verify-certification-score',
   ]
   if (staticRoute.includes(doc.type)) {
     return `/${doc.uid}`

--- a/services/document-fetcher.js
+++ b/services/document-fetcher.js
@@ -19,7 +19,7 @@ export const documents = {
 }
 
 export function documentFetcher(i18n = { defaultLocale: 'fr-fr' }, req) {
-  const language = i18n.locale || i18n.defaultLocale
+  const lang = i18n.locale || i18n.defaultLocale
   return {
     get: (documentName) => {
       return getSingle(documentName)
@@ -27,7 +27,7 @@ export function documentFetcher(i18n = { defaultLocale: 'fr-fr' }, req) {
     getEmployers: async () => {
       const api = await getApi()
       const document = api.getSingle('employers', {
-        lang: language,
+        lang,
         fetchLinks: [
           'distributor_item.description',
           'distributor_item.footer',
@@ -46,7 +46,7 @@ export function documentFetcher(i18n = { defaultLocale: 'fr-fr' }, req) {
           page,
           pageSize,
           orderings: '[my.news_item.date desc]',
-          lang: language,
+          lang,
         }
       )
       return documents.results
@@ -55,8 +55,24 @@ export function documentFetcher(i18n = { defaultLocale: 'fr-fr' }, req) {
       const api = await getApi()
       const document = await api.query(
         Prismic.Predicates.at('my.news_item.uid', slug),
-        { lang: language }
+        { lang }
       )
+      return document.results[0]
+    },
+    getScoreCertifForm: async (slug) => {
+      const api = await getApi()
+      const document = await api.query(
+        Prismic.Predicates.at(
+          'document.type',
+          'verify-certification-score-form'
+        ),
+        { lang }
+      )
+
+      if (!document.results) {
+        return {}
+      }
+
       return document.results[0]
     },
     getPreviewUrl: async (previewToken) => {
@@ -67,7 +83,7 @@ export function documentFetcher(i18n = { defaultLocale: 'fr-fr' }, req) {
       const api = await getApi()
       const document = await api.query(
         Prismic.Predicates.at('my.simple_page.uid', uid),
-        { lang: language }
+        { lang }
       )
       return document.results[0]
     },
@@ -75,7 +91,7 @@ export function documentFetcher(i18n = { defaultLocale: 'fr-fr' }, req) {
 
   async function getSingle(type) {
     const api = await getApi()
-    return api.getSingle(type, { lang: language })
+    return api.getSingle(type, { lang })
   }
 
   function getApi() {

--- a/services/document-fetcher.js
+++ b/services/document-fetcher.js
@@ -21,9 +21,7 @@ export const documents = {
 export function documentFetcher(i18n = { defaultLocale: 'fr-fr' }, req) {
   const lang = i18n.locale || i18n.defaultLocale
   return {
-    get: (documentName) => {
-      return getSingle(documentName)
-    },
+    get: getSingle,
     getEmployers: async () => {
       const api = await getApi()
       const document = api.getSingle('employers', {
@@ -59,7 +57,7 @@ export function documentFetcher(i18n = { defaultLocale: 'fr-fr' }, req) {
       )
       return document.results[0]
     },
-    getScoreCertifForm: async (slug) => {
+    getVerifyCertificationForm: async () => {
       const api = await getApi()
       const document = await api.query(
         Prismic.Predicates.at(

--- a/tests/pages/__snapshots__/verify-certification-score.test.js.snap
+++ b/tests/pages/__snapshots__/verify-certification-score.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Verify Certification Score Page renders properly 1`] = `
+"<div class=\\"page competences\\">
+  <main class=\\"page-body\\">
+    <div class=\\"container lg\\">
+      <h1 class=\\"title\\">title</h1>
+      <form>
+        <div class=\\"input-field\\"><label>code_de_verification</label> <input type=\\"text\\" required=\\"required\\" name=\\"verificationCode\\" class=\\"\\">
+          <!---->
+        </div>
+        <div class=\\"input-field\\"><label>score_declare_du_candidat</label> <input type=\\"text\\" required=\\"required\\" name=\\"candidateScore\\" class=\\"\\">
+          <!---->
+        </div> <button type=\\"submit\\" class=\\"btn-primary\\">
+          button_label
+        </button>
+      </form>
+      <!---->
+    </div>
+  </main>
+</div>"
+`;

--- a/tests/pages/__snapshots__/verify-certification-score.test.js.snap
+++ b/tests/pages/__snapshots__/verify-certification-score.test.js.snap
@@ -3,13 +3,13 @@
 exports[`Verify Certification Score Page renders properly 1`] = `
 "<div class=\\"page competences\\">
   <main class=\\"page-body\\">
-    <div class=\\"container lg\\">
-      <h1 class=\\"title\\">title</h1>
-      <form novalidate=\\"novalidate\\">
-        <div class=\\"input-field\\"><label for=\\"code\\">code_de_verification</label> <input id=\\"code\\" type=\\"text\\" required=\\"required\\" pattern=\\"^[P,p]-[0-9]{5}$\\" name=\\"verificationCode\\" class=\\"\\">
+    <div class=\\"container lg certificate-verification-page\\">
+      <h1 class=\\"certificate-verification-page__title\\">title</h1>
+      <form novalidate=\\"novalidate\\" class=\\"certificate-verification-page__form\\">
+        <div class=\\"certificate-verification-page__input-field\\"><label for=\\"code\\">code_de_verification</label> <input id=\\"code\\" type=\\"text\\" required=\\"required\\" pattern=\\"^[P,p]-[0-9]{5}$\\" name=\\"verificationCode\\" class=\\"no-regex-error\\">
           <!---->
         </div>
-        <div class=\\"input-field\\"><label for=\\"score\\">score_declare_du_candidat</label> <input id=\\"score\\" type=\\"text\\" required=\\"required\\" pattern=\\"^[0-9]{1,3}$\\" name=\\"candidateScore\\" class=\\"\\">
+        <div class=\\"certificate-verification-page__input-field\\"><label for=\\"score\\">score_declare_du_candidat</label> <input id=\\"score\\" type=\\"text\\" required=\\"required\\" pattern=\\"^[0-9]{1,3}$\\" name=\\"candidateScore\\" class=\\"no-regex-error\\">
           <!---->
         </div> <button type=\\"submit\\" class=\\"btn-primary\\">
           button_label

--- a/tests/pages/__snapshots__/verify-certification-score.test.js.snap
+++ b/tests/pages/__snapshots__/verify-certification-score.test.js.snap
@@ -5,11 +5,11 @@ exports[`Verify Certification Score Page renders properly 1`] = `
   <main class=\\"page-body\\">
     <div class=\\"container lg\\">
       <h1 class=\\"title\\">title</h1>
-      <form>
-        <div class=\\"input-field\\"><label>code_de_verification</label> <input type=\\"text\\" required=\\"required\\" name=\\"verificationCode\\" class=\\"\\">
+      <form novalidate=\\"novalidate\\">
+        <div class=\\"input-field\\"><label for=\\"code\\">code_de_verification</label> <input id=\\"code\\" type=\\"text\\" required=\\"required\\" pattern=\\"^[P,p]-[0-9]{5}$\\" name=\\"verificationCode\\" class=\\"\\">
           <!---->
         </div>
-        <div class=\\"input-field\\"><label>score_declare_du_candidat</label> <input type=\\"text\\" required=\\"required\\" name=\\"candidateScore\\" class=\\"\\">
+        <div class=\\"input-field\\"><label for=\\"score\\">score_declare_du_candidat</label> <input id=\\"score\\" type=\\"text\\" required=\\"required\\" pattern=\\"^[0-9]{1,3}$\\" name=\\"candidateScore\\" class=\\"\\">
           <!---->
         </div> <button type=\\"submit\\" class=\\"btn-primary\\">
           button_label

--- a/tests/pages/verify-certification-score.test.js
+++ b/tests/pages/verify-certification-score.test.js
@@ -1,0 +1,82 @@
+import { getInitialised } from './utils'
+import { documentFetcher } from '~/services/document-fetcher'
+
+jest.mock('~/services/document-fetcher')
+
+describe('Verify Certification Score Page', () => {
+  let wrapper
+  const ERROR_MESSAGE_CODE_INVALID =
+    'Votre code de vérification ne correspond pas au format: P-XXXXX'
+  const ERROR_MESSAGE_SCORE_INVALID =
+    'Le score du candidat doit être composé de 3 chiffres'
+
+  const CORRECT_SCORE = 999
+  const CORRECT_CODE = 'P-99999'
+
+  beforeEach(async () => {
+    documentFetcher.mockReturnValue({
+      getVerifyCertificationForm: () =>
+        Promise.resolve({
+          data: {
+            title: 'title',
+            code_de_verification: 'code_de_verification',
+            score_declare_du_candidat: 'score_declare_du_candidat',
+            button_label: 'button_label',
+            id: '',
+            meta: '',
+          },
+        }),
+    })
+    wrapper = await getInitialised('verify-certification-score', {
+      stubs: ['fa'],
+    })
+  })
+  test('mounts properly', () => {
+    expect(wrapper.vm).toBeTruthy()
+  })
+
+  test('renders properly', () => {
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  test('The display an error if code is invalid', async () => {
+    await wrapper.setData({
+      code: 'XXX',
+      score: CORRECT_SCORE,
+    })
+
+    wrapper.find('form').trigger('submit.prevent')
+    await wrapper.vm.$forceUpdate()
+
+    expect(wrapper.html()).toContain(ERROR_MESSAGE_CODE_INVALID)
+  })
+
+  test('The display an error if score is invalid', async () => {
+    await wrapper.setData({
+      code: CORRECT_CODE,
+      score: 999999,
+    })
+
+    wrapper.find('form').trigger('submit.prevent')
+    await wrapper.vm.$forceUpdate()
+
+    expect(wrapper.html()).toContain(ERROR_MESSAGE_SCORE_INVALID)
+  })
+
+  test('There form is commited if score and code are valid ', async () => {
+    await wrapper.setData({
+      code: CORRECT_CODE,
+      score: CORRECT_SCORE,
+    })
+
+    wrapper.find('form').trigger('submit.prevent')
+    await wrapper.vm.$forceUpdate()
+
+    expect(wrapper.html()).not.toContain(ERROR_MESSAGE_SCORE_INVALID)
+    expect(wrapper.html()).not.toContain(ERROR_MESSAGE_CODE_INVALID)
+    expect(wrapper.vm.formSent).toEqual(true)
+    expect(wrapper.html()).toContain(
+      "Il n'y a pas de certificat Pix correspondant"
+    )
+  })
+})

--- a/tests/services/document-fetcher.test.js
+++ b/tests/services/document-fetcher.test.js
@@ -70,12 +70,13 @@ describe('DocumentFetcher', () => {
 
   test('it should get employers page with distributors informations', async () => {
     // Given
+    const expected = { uid: 'navigation' }
     const prismicApi = {
       getSingle: jest.fn(() => ({ uid: 'navigation' })),
     }
     Prismic.getApi.mockResolvedValue(prismicApi)
     // When
-    await documentFetcher().getEmployers()
+    const result = await documentFetcher().getEmployers()
     // Then
     expect(prismicApi.getSingle).toBeCalledWith('employers', {
       lang: 'fr-fr',
@@ -87,5 +88,59 @@ describe('DocumentFetcher', () => {
         'distributor_item.name',
       ],
     })
+    expect(result).toEqual(expected)
+  })
+
+  test('it should get verify certification form page', async () => {
+    // Given
+    const expectedValue = Symbol('VALUE')
+    const expectedPredicatesAtValue = Symbol('AT')
+    const prismicApi = {
+      query: jest.fn(() => ({ results: [expectedValue] })),
+    }
+    Prismic.getApi.mockResolvedValue(prismicApi)
+
+    const prismicPredicates = {
+      at: jest.fn(() => expectedPredicatesAtValue),
+    }
+    Prismic.Predicates = prismicPredicates
+
+    // When
+    const response = await documentFetcher().getVerifyCertificationForm()
+    // Then
+    expect(prismicApi.query).toBeCalledWith(expectedPredicatesAtValue, {
+      lang: 'fr-fr',
+    })
+    expect(prismicPredicates.at).toBeCalledWith(
+      'document.type',
+      'verify-certification-score-form'
+    )
+    expect(response).toEqual(expectedValue)
+  })
+
+  test('it should get simplePage by UID', async () => {
+    // Given
+    const expectedValue = Symbol('VALUE')
+    const expectedPredicatesAtValue = Symbol('AT')
+    const uid = Symbol('UID')
+    const prismicApi = {
+      query: jest.fn(() => ({ results: [expectedValue] })),
+    }
+    Prismic.getApi.mockResolvedValue(prismicApi)
+
+    const prismicPredicates = {
+      at: jest.fn(() => expectedPredicatesAtValue),
+    }
+    Prismic.Predicates = prismicPredicates
+
+    // When
+    const response = await documentFetcher().getSimplePageByUid(uid)
+
+    // Then
+    expect(prismicApi.query).toBeCalledWith(expectedPredicatesAtValue, {
+      lang: 'fr-fr',
+    })
+    expect(prismicPredicates.at).toBeCalledWith('my.simple_page.uid', uid)
+    expect(response).toEqual(expectedValue)
   })
 })


### PR DESCRIPTION
## :unicorn: Problème
L’un des objectifs de l'épix Partage et contrôle du certificat est de permettre à un tiers de vérifier l’authenticité d’un certificat Pix. Pour cela, un utilisateur non connecté doit pouvoir accéder à une page pour entrer le code de vérification et le score déclaré du candidat afin de visualiser une version simplifiée du certificat du candidat.

Dans un premier temps, cette page de vérification ne sera pas accessible depuis pix site le temps d’implémenter la totalité de la fonctionnalité.

## :robot: Solution
Implémenter la page de vérification : https://share.goabstract.com/92b751b8-a959-480c-b038-7e35f695f672?collectionLayerId=e1829588-ab70-49f2-a516-5539ac66673c&mode=design

les 2 champs sont obligatoires

si l’utilisateur clique sur le bouton “Vérifier le score” alors que l’un des champs est vide, afficher le message d’erreur “_Les 2 champs sont requis_”.

si l’utilisateur clique sur “Vérifier le score” et que les 2 champs sont renseignés, plusieurs cas : 

CAS KO 

1 : code de vérification faux

2 : code de vérification OK mais qui ne match pas avec le score déclaré du candidat 

Dans les 2 cas, afficher un message d’erreur “_Aucun certificat Pix ne correspond. Merci de vérifier les informations renseignées._” - design https://share.goabstract.com/92b751b8-a959-480c-b038-7e35f695f672?collectionLayerId=cc8b80a2-1ad1-4094-94e1-0d7c44708373&mode=design

CAS OK - le code de vérification et le score déclaré du candidat matchent : afficher “Ce certificat existe !” (la version simplifiée du certificat sera affichée dans un autre ticket)

## :rainbow: Remarques
- Pas d'appel API sur ce ticket
- Ajout de tests pour les autres pages

## :sparkles: Review App
https://pix-site-integration-pr.scalingo.io
