### PR TITLE
[FEATURE] Refonte du site vitrine: bannière sur la page d'accueil (PIX-1007)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ dist
 # IDE / Editor
 .idea
 .editorconfig
+.vscode/*
 
 # Service worker
 sw.*

--- a/assets/scss/globals/_breakpoints.scss
+++ b/assets/scss/globals/_breakpoints.scss
@@ -1,7 +1,8 @@
 $breakpoints: (
   'large-mobile': (min-width: 600px),
   'tablet': (min-width: 768px),
-  'desktop': (min-width: 960px)
+  'desktop': (min-width: 960px),
+  'large-screen': (min-width: 1281px)
 ) !default;
 
 /*

--- a/assets/scss/globals/_colors.scss
+++ b/assets/scss/globals/_colors.scss
@@ -7,6 +7,8 @@ $grey-6: #444444;
 $grey-7: #dddddd;
 $grey-8: #96a0af;
 $grey-9: rgb(107, 119, 140);
+$grey-10: #6b778c;
+$grey-11: #414657;
 
 $blue-1: #3d68ff;
 $blue-2: #12a3ff;

--- a/components/slices/banner.vue
+++ b/components/slices/banner.vue
@@ -113,7 +113,7 @@ export default {
 <style lang="scss">
 .banner {
   font-family: 'Open Sans', Arial, sans-serif;
-  padding: 80px 0;
+  padding: 64px 0;
   text-align: center;
   margin: 0 auto;
 
@@ -125,15 +125,15 @@ export default {
   }
 
   &__title h1 {
-    font-size: 2.875rem;
-    line-height: 3.813rem;
-    font-weight: 300;
     color: $grey-11;
+    font-size: 2.125rem;
+    line-height: 2.75rem;
+    font-weight: 400;
   }
 
   &__content p {
-    font-size: 1.25rem;
-    line-height: 2rem;
+    font-size: 1rem;
+    line-height: 1.625rem;
     color: $grey-10;
     margin: 16px 0 24px;
   }
@@ -188,9 +188,24 @@ export default {
   }
 
   @include device-is('large-mobile') {
+    padding: 80px 0;
+
+    &__title h1 {
+      font-size: 2.875rem;
+      line-height: 3.813rem;
+      font-weight: 300;
+      letter-spacing: -0.15px;
+    }
+
+    &__content p {
+      font-size: 1.25rem;
+      line-height: 2rem;
+    }
+
     .banner__button-group {
       flex-direction: row;
     }
+
     .banner__button {
       width: initial;
       margin: 0 10px;
@@ -198,18 +213,26 @@ export default {
   }
 
   @include device-is('large-screen') {
-    &--main {
-      margin-right: 60px;
+    &__title h1 {
+      font-size: 3.875rem;
+      line-height: 5.125rem;
+      font-weight: 300;
+      letter-spacing: -0.5px;
+    }
+
+    &__main {
+      width: 504px;
     }
 
     &--with-image {
       display: flex;
+      justify-content: space-between;
       max-width: 1140px;
       text-align: left;
 
       img:nth-child(2) {
         display: block;
-        max-width: 400px;
+        max-width: 510px;
       }
 
       .banner__button-group {

--- a/components/slices/banner.vue
+++ b/components/slices/banner.vue
@@ -5,15 +5,28 @@
         <prismic-rich-text :field="title" class="banner__title" />
         <prismic-rich-text :field="textContent" class="banner__content" />
         <div class="banner__button-group">
-          <pix-link
-            v-for="(link, index) in links"
-            :key="`item-${index}`"
-            :field="link.bannerlinkurl"
-            class="banner__button"
-            :class="videoClass(link)"
-          >
-            {{ link.bannerlinktext }}
-          </pix-link>
+          <div v-for="(link, index) in links" :key="`item-${index}`">
+            <pix-link
+              v-if="!isVideo(link)"
+              :field="link.bannerlinkurl"
+              class="banner__button"
+              :class="videoClass(link)"
+            >
+              {{ link.bannerlinktext }}
+            </pix-link>
+            <template v-if="isVideo(link)">
+              <button
+                class="banner__button banner__button-video"
+                @click="openVideoModal()"
+              >
+                <fa :icon="fas.faPlayCircle" />
+                {{ link.bannerlinktext }}
+              </button>
+              <modal ref="modal" name="videoModal" height="auto">
+                <VideoSlice :video-url="link.bannerlinkurl" />
+              </modal>
+            </template>
+          </div>
         </div>
       </div>
       <prismic-image v-if="hasImage" :field="imageUrl" />
@@ -22,8 +35,11 @@
 </template>
 
 <script>
+import VideoSlice from './video'
+
 export default {
   name: 'Banner',
+  components: { VideoSlice },
   props: {
     content: {
       type: Object,
@@ -64,10 +80,14 @@ export default {
     }
   },
   methods: {
-    videoClass(link) {
+    openVideoModal() {
+      this.$modal.show('videoModal')
+    },
+    isVideo(link) {
       return link.bannerlinkurl.url.includes('pix-videos/')
-        ? 'banner__video'
-        : ''
+    },
+    videoClass(link) {
+      return this.isVideo(link) ? 'banner__video' : ''
     },
   },
 }
@@ -110,6 +130,7 @@ export default {
     height: 44px;
     margin: 0 10px;
     font-family: 'Roboto', Arial, sans-serif;
+    font-size: 16px;
     background-color: $blue-1;
     color: $white;
     font-size: 1rem;
@@ -122,12 +143,25 @@ export default {
     justify-content: center;
     align-items: center;
 
-    &.banner__video {
+    &:hover {
+      cursor: pointer;
+      background-color: $blue-3;
+    }
+
+    &.banner__button-video {
       border-radius: 4px;
       border: 1.5px solid $grey-11;
       height: 44px;
       color: $grey-11;
       background-color: $white;
+
+      svg {
+        margin-right: 10px;
+      }
+
+      &:hover {
+        background-color: $grey-3;
+      }
     }
   }
 

--- a/components/slices/banner.vue
+++ b/components/slices/banner.vue
@@ -20,7 +20,7 @@
                 class="banner__button banner__button-video"
                 @click="openVideoModal()"
               >
-                <fa :icon="fas.faPlayCircle" />
+                <fa icon="play-circle" />
                 {{ link.bannerlinktext }}
               </button>
               <modal ref="modal" name="videoModal" height="auto">

--- a/components/slices/banner.vue
+++ b/components/slices/banner.vue
@@ -1,14 +1,18 @@
 <template>
-  <section>
-    <prismic-rich-text :field="title" />
-    <prismic-rich-text :field="textContent" />
-    <ul>
-      <li v-for="(link, index) in links" :key="`item-${index}`">
-        <pix-link :field="link.bannerlinkurl">
-          {{ link.bannerlinktext }}
-        </pix-link>
-      </li>
-    </ul>
+  <section class="banner">
+    <prismic-rich-text :field="title" class="banner__title" />
+    <prismic-rich-text :field="textContent" class="banner__content" />
+    <div>
+      <pix-link
+        v-for="(link, index) in links"
+        :key="`item-${index}`"
+        :field="link.bannerlinkurl"
+        class="btn-primary"
+        :class="videoCssClass(link)"
+      >
+        {{ link.bannerlinktext }}
+      </pix-link>
+    </div>
   </section>
 </template>
 
@@ -38,7 +42,51 @@ export default {
       return this.content.primary.bannerimagebackground
     },
   },
+  methods: {
+    videoCssClass(link) {
+      if (link.bannerlinkurl.url.includes('pix-videos/')) {
+        return 'banner__video'
+      }
+      return ''
+    },
+  },
 }
 </script>
 
-<style scoped></style>
+<style lang="scss">
+.banner {
+  font-family: 'Open Sans', Arial, sans-serif;
+  padding: 80px 0;
+  text-align: center;
+  margin: 0 auto;
+
+  &__title h1 {
+    font-size: 2.875rem;
+    line-height: 3.813rem;
+    font-weight: 300;
+    color: $grey-11;
+  }
+
+  &__content p {
+    font-size: 1.25rem;
+    line-height: 2rem;
+    color: $grey-10;
+    margin: 16px 0 24px;
+  }
+
+  .btn-primary {
+    height: 44px;
+    line-height: 44px;
+    margin: 0 10px;
+
+    &.banner__video {
+      border-radius: 4px;
+      border: 1.5px solid $grey-11;
+      height: 44px;
+      width: 167px;
+      color: $grey-11;
+      background-color: $white;
+    }
+  }
+}
+</style>

--- a/components/slices/banner.vue
+++ b/components/slices/banner.vue
@@ -1,21 +1,23 @@
 <template>
-  <section :class="['banner', { 'banner--with-image': hasImage }]">
-    <div class="banner__main">
-      <prismic-rich-text :field="title" class="banner__title" />
-      <prismic-rich-text :field="textContent" class="banner__content" />
-      <div class="banner__button-group">
-        <pix-link
-          v-for="(link, index) in links"
-          :key="`item-${index}`"
-          :field="link.bannerlinkurl"
-          class="banner__button"
-          :class="videoClass(link)"
-        >
-          {{ link.bannerlinktext }}
-        </pix-link>
+  <section :class="{ 'banner-with-background': hasBackgroundImage }">
+    <div :class="['banner', { 'banner--with-image': hasImage }]">
+      <div class="banner__main">
+        <prismic-rich-text :field="title" class="banner__title" />
+        <prismic-rich-text :field="textContent" class="banner__content" />
+        <div class="banner__button-group">
+          <pix-link
+            v-for="(link, index) in links"
+            :key="`item-${index}`"
+            :field="link.bannerlinkurl"
+            class="banner__button"
+            :class="videoClass(link)"
+          >
+            {{ link.bannerlinktext }}
+          </pix-link>
+        </div>
       </div>
+      <prismic-image v-if="hasImage" :field="imageUrl" />
     </div>
-    <prismic-image v-if="hasImage" :field="imageUrl" />
   </section>
 </template>
 
@@ -43,12 +45,23 @@ export default {
         this.content.primary.bannerimage && this.content.primary.bannerimage.url
       )
     },
+    hasBackgroundImage() {
+      return (
+        this.content.primary.bannerbackground &&
+        this.content.primary.bannerbackground.url
+      )
+    },
     imageUrl() {
       return this.content.primary.bannerimage
     },
-    backgroundImageUrl() {
-      return this.content.primary.bannerimagebackground
-    },
+  },
+  mounted() {
+    if (this.hasBackgroundImage) {
+      const banner = document.getElementsByClassName(
+        'banner-with-background'
+      )[0]
+      banner.style.background = `center no-repeat url(${this.content.primary.bannerbackground.url})`
+    }
   },
   methods: {
     videoClass(link) {

--- a/components/slices/banner.vue
+++ b/components/slices/banner.vue
@@ -4,6 +4,7 @@
       <div class="banner__main">
         <prismic-rich-text :field="title" class="banner__title" />
         <prismic-rich-text :field="textContent" class="banner__content" />
+        <slot></slot>
         <div class="banner__button-group">
           <div v-for="(link, index) in links" :key="`item-${index}`">
             <pix-link

--- a/components/slices/banner.vue
+++ b/components/slices/banner.vue
@@ -1,18 +1,21 @@
 <template>
-  <section class="banner">
-    <prismic-rich-text :field="title" class="banner__title" />
-    <prismic-rich-text :field="textContent" class="banner__content" />
-    <div>
-      <pix-link
-        v-for="(link, index) in links"
-        :key="`item-${index}`"
-        :field="link.bannerlinkurl"
-        class="btn-primary"
-        :class="videoCssClass(link)"
-      >
-        {{ link.bannerlinktext }}
-      </pix-link>
+  <section :class="['banner', { 'banner--with-image': hasImage }]">
+    <div class="banner__main">
+      <prismic-rich-text :field="title" class="banner__title" />
+      <prismic-rich-text :field="textContent" class="banner__content" />
+      <div class="banner__button-group">
+        <pix-link
+          v-for="(link, index) in links"
+          :key="`item-${index}`"
+          :field="link.bannerlinkurl"
+          class="banner__button"
+          :class="videoClass(link)"
+        >
+          {{ link.bannerlinktext }}
+        </pix-link>
+      </div>
     </div>
+    <prismic-image v-if="hasImage" :field="imageUrl" />
   </section>
 </template>
 
@@ -35,6 +38,11 @@ export default {
     links() {
       return this.content.items
     },
+    hasImage() {
+      return (
+        this.content.primary.bannerimage && this.content.primary.bannerimage.url
+      )
+    },
     imageUrl() {
       return this.content.primary.bannerimage
     },
@@ -43,11 +51,10 @@ export default {
     },
   },
   methods: {
-    videoCssClass(link) {
-      if (link.bannerlinkurl.url.includes('pix-videos/')) {
-        return 'banner__video'
-      }
-      return ''
+    videoClass(link) {
+      return link.bannerlinkurl.url.includes('pix-videos/')
+        ? 'banner__video'
+        : ''
     },
   },
 }
@@ -59,6 +66,13 @@ export default {
   padding: 80px 0;
   text-align: center;
   margin: 0 auto;
+
+  &__main {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin-right: 60px;
+  }
 
   &__title h1 {
     font-size: 2.875rem;
@@ -74,18 +88,51 @@ export default {
     margin: 16px 0 24px;
   }
 
-  .btn-primary {
+  .banner__button-group {
+    display: flex;
+    justify-content: center;
+  }
+
+  .banner__button {
     height: 44px;
-    line-height: 44px;
     margin: 0 10px;
+    font-family: 'Roboto', Arial, sans-serif;
+    background-color: $blue-1;
+    color: $white;
+    font-size: 1rem;
+    max-width: 250px;
+    border: 1.5px solid transparent;
+    border-radius: 4px;
+    padding: 0 20px;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
     &.banner__video {
       border-radius: 4px;
       border: 1.5px solid $grey-11;
       height: 44px;
-      width: 167px;
       color: $grey-11;
       background-color: $white;
+    }
+  }
+
+  &--with-image {
+    display: flex;
+    max-width: 1140px;
+    text-align: left;
+
+    img:nth-child(2) {
+      max-width: 400px;
+    }
+
+    .banner__button-group {
+      justify-content: left;
+    }
+
+    .banner__button {
+      margin: 0 20px 0 0;
     }
   }
 }

--- a/components/slices/banner.vue
+++ b/components/slices/banner.vue
@@ -36,6 +36,7 @@
 
 <script>
 import VideoSlice from './video'
+import { LARGE_SCREEN_MIN_WIDTH } from '~/config/breakpoints'
 
 export default {
   name: 'Banner',
@@ -73,10 +74,13 @@ export default {
   },
   mounted() {
     if (this.hasBackgroundImage) {
-      const banner = document.getElementsByClassName(
-        'banner-with-background'
-      )[0]
-      banner.style.background = `center no-repeat url(${this.content.primary.bannerbackground.url})`
+      this.changeBackgroundImage()
+      window.addEventListener('resize', this.changeBackgroundImage)
+    }
+  },
+  beforeDestroy() {
+    if (this.bannerWithBackgroundImageClass) {
+      window.removeEventListener('resize', this.changeBackgroundImage)
     }
   },
   methods: {
@@ -88,6 +92,18 @@ export default {
     },
     videoClass(link) {
       return this.isVideo(link) ? 'banner__video' : ''
+    },
+    changeBackgroundImage() {
+      const banner = document.getElementsByClassName(
+        'banner-with-background'
+      )[0]
+      if (screen.width <= LARGE_SCREEN_MIN_WIDTH) {
+        banner.style.background = `no-repeat url(${this.content.primary.bannerbackground.url})`
+        banner.style.backgroundSize = '100%'
+        banner.style.backgroundPosition = 'top right'
+      } else {
+        banner.style.background = 'none'
+      }
     },
   },
 }
@@ -104,7 +120,7 @@ export default {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    margin-right: 60px;
+    margin: 0 32px;
   }
 
   &__title h1 {
@@ -124,20 +140,21 @@ export default {
   .banner__button-group {
     display: flex;
     justify-content: center;
+    align-items: center;
+    flex-direction: column;
   }
 
   .banner__button {
     height: 44px;
-    margin: 0 10px;
     font-family: 'Roboto', Arial, sans-serif;
-    font-size: 16px;
     background-color: $blue-1;
     color: $white;
     font-size: 1rem;
-    max-width: 250px;
+    width: 240px;
     border: 1.5px solid transparent;
     border-radius: 4px;
     padding: 0 20px;
+    margin: 5px 0;
 
     display: flex;
     justify-content: center;
@@ -165,21 +182,42 @@ export default {
     }
   }
 
-  &--with-image {
-    display: flex;
-    max-width: 1140px;
-    text-align: left;
+  &--with-image img {
+    display: none;
+  }
 
-    img:nth-child(2) {
-      max-width: 400px;
-    }
-
+  @include device-is('large-mobile') {
     .banner__button-group {
-      justify-content: left;
+      flex-direction: row;
+    }
+    .banner__button {
+      width: initial;
+      margin: 0 10px;
+    }
+  }
+
+  @include device-is('large-screen') {
+    &--main {
+      margin-right: 60px;
     }
 
-    .banner__button {
-      margin: 0 20px 0 0;
+    &--with-image {
+      display: flex;
+      max-width: 1140px;
+      text-align: left;
+
+      img:nth-child(2) {
+        display: block;
+        max-width: 400px;
+      }
+
+      .banner__button-group {
+        justify-content: left;
+      }
+
+      .banner__button {
+        margin: 0 20px 0 0;
+      }
     }
   }
 }

--- a/components/slices/banner.vue
+++ b/components/slices/banner.vue
@@ -1,0 +1,44 @@
+<template>
+  <section>
+    <prismic-rich-text :field="title" />
+    <prismic-rich-text :field="textContent" />
+    <ul>
+      <li v-for="(link, index) in links" :key="`item-${index}`">
+        <pix-link :field="link.bannerlinkurl">
+          {{ link.bannerlinktext }}
+        </pix-link>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<script>
+export default {
+  name: 'Banner',
+  props: {
+    content: {
+      type: Object,
+      default: null,
+    },
+  },
+  computed: {
+    title() {
+      return this.content.primary.bannertitle
+    },
+    textContent() {
+      return this.content.primary.bannercontent
+    },
+    links() {
+      return this.content.items
+    },
+    imageUrl() {
+      return this.content.primary.bannerimage
+    },
+    backgroundImageUrl() {
+      return this.content.primary.bannerimagebackground
+    },
+  },
+}
+</script>
+
+<style scoped></style>

--- a/components/slices/hero-banner.vue
+++ b/components/slices/hero-banner.vue
@@ -9,7 +9,7 @@
       </pix-link>
       <template v-if="hasVideo">
         <div :class="buttonClass" @click="openVideoModal()">
-          <fa :icon="fas.faPlayCircle" />
+          <fa icon="play-circle" />
           {{ $prismic.richTextAsPlain(videoButtonText) }}
         </div>
         <modal ref="modal" name="videoModal" height="auto">
@@ -21,7 +21,6 @@
 </template>
 
 <script>
-import { fas } from '@fortawesome/free-solid-svg-icons'
 import VideoSlice from './video'
 
 export default {
@@ -73,9 +72,6 @@ export default {
     },
     videoButtonText() {
       return this.content.primary.video_button_title
-    },
-    fas() {
-      return fas
     },
   },
   methods: {

--- a/config/breakpoints.js
+++ b/config/breakpoints.js
@@ -1,0 +1,1 @@
+export const LARGE_SCREEN_MIN_WIDTH = 1280

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -100,7 +100,15 @@ export default {
         imports: [
           {
             set: '@fortawesome/free-solid-svg-icons',
-            icons: ['faCog', 'faCalendar', 'faHome', 'faCircle', 'faCheck'],
+            icons: [
+              'faCalendar',
+              'faCheck',
+              'faCircle',
+              'faCog',
+              'faExclamationTriangle',
+              'faHome',
+              'faPlayCircle',
+            ],
           },
         ],
       },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,14 +1,18 @@
 <template>
   <div class="index">
-    <pop-in-campaigns :content="document[3]" />
-    <hero-banner
-      :section-class="'index__hero-banner'"
-      :background-class="'hero-banner__background'"
-      :content-class="'hero-banner__content'"
-      :button-class="'hero-banner-content__button'"
-      :content="document[0]"
-    >
-    </hero-banner>
+    <pop-in-campaigns :content="popInCampaignDocument" />
+    <div v-if="bannerDocument.slice_type === 'hero-banner'">
+      <hero-banner
+        v-if="bannerDocument.slice_type === 'hero-banner'"
+        :section-class="'index__hero-banner'"
+        :background-class="'hero-banner__background'"
+        :content-class="'hero-banner__content'"
+        :button-class="'hero-banner-content__button'"
+        :content="bannerDocument"
+      >
+      </hero-banner>
+    </div>
+    <banner v-else :content="bannerDocument"></banner>
 
     <img-text-column-slice
       :content="document[1]"
@@ -35,8 +39,30 @@ import HeroBanner from '~/components/slices/hero-banner'
 import ImgTextColumnSlice from '~/components/slices/img-text-column'
 import SectionSlice from '~/components/slices/section'
 import PopInCampaigns from '~/components/pop-in-campaigns'
+import Banner from '~/components/slices/banner'
+
 export default {
-  components: { PopInCampaigns, HeroBanner, SectionSlice, ImgTextColumnSlice },
+  components: {
+    PopInCampaigns,
+    HeroBanner,
+    SectionSlice,
+    ImgTextColumnSlice,
+    Banner,
+  },
+  computed: {
+    demoDocument() {
+      return this.document[1]
+    },
+    featuresDocument() {
+      return this.document[2]
+    },
+    popInCampaignDocument() {
+      return this.document[3]
+    },
+    bannerDocument() {
+      return this.document[0]
+    },
+  },
   async asyncData({ app, error, req, currentPagePath }) {
     try {
       const document = await documentFetcher(app.i18n, req).get(documents.index)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -49,20 +49,6 @@ export default {
     ImgTextColumnSlice,
     Banner,
   },
-  computed: {
-    demoDocument() {
-      return this.document[1]
-    },
-    featuresDocument() {
-      return this.document[2]
-    },
-    popInCampaignDocument() {
-      return this.document[3]
-    },
-    bannerDocument() {
-      return this.document[0]
-    },
-  },
   async asyncData({ app, error, req, currentPagePath }) {
     try {
       const document = await documentFetcher(app.i18n, req).get(documents.index)
@@ -78,6 +64,20 @@ export default {
       console.error({ e })
       error({ statusCode: 404, message: 'Page not found' })
     }
+  },
+  computed: {
+    demoDocument() {
+      return this.document[1]
+    },
+    featuresDocument() {
+      return this.document[2]
+    },
+    popInCampaignDocument() {
+      return this.document[3]
+    },
+    bannerDocument() {
+      return this.document[0]
+    },
   },
   head() {
     const meta = this.$getMeta(this.meta, this.currentPagePath, this.$prismic)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -15,14 +15,14 @@
     <banner v-else :content="bannerDocument"></banner>
 
     <img-text-column-slice
-      :content="document[1]"
+      :content="demoDocument"
       :section-class="'section-demo'"
       :container-class="'section-demo__container'"
       :button-class="'section-demo__button'"
     ></img-text-column-slice>
 
     <section-slice
-      :content="document[2]"
+      :content="featuresDocument"
       :section-class="'index__features'"
       :container-class="'features__container'"
       :flex-container-class="'features-container__list'"

--- a/pages/verify-certification-score.vue
+++ b/pages/verify-certification-score.vue
@@ -49,7 +49,7 @@
           </button>
         </form>
         <div v-if="formSent" class="certificate-verification-page__form-sent">
-          <fa :icon="fas.faExclamationTriangle" />
+          <fa icon="exclamation-triangle" />
           <span>Il n'y a pas de certificat Pix correspondant</span>
         </div>
       </div>
@@ -58,7 +58,6 @@
 </template>
 
 <script>
-import { fas } from '@fortawesome/free-solid-svg-icons'
 import { documentFetcher } from '~/services/document-fetcher'
 
 export default {
@@ -113,9 +112,6 @@ export default {
     },
     candidateScoreLabel() {
       return this.document.score_declare_du_candidat
-    },
-    fas() {
-      return fas
     },
   },
   methods: {

--- a/tests/pages/__snapshots__/index.test.js.snap
+++ b/tests/pages/__snapshots__/index.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Index Page renders properly 1`] = `
 "<div class=\\"index\\">
   <pop-in-campaigns-stub content=\\"[object Object]\\"></pop-in-campaigns-stub>
-  <hero-banner-stub content=\\"[object Object]\\" sectionclass=\\"index__hero-banner\\" backgroundclass=\\"hero-banner__background\\" contentclass=\\"hero-banner__content\\" buttonclass=\\"hero-banner-content__button\\"></hero-banner-stub>
+  <banner-stub content=\\"[object Object]\\"></banner-stub>
   <img-text-column-slice-stub content=\\"[object Object]\\" sectionclass=\\"section-demo\\" containerclass=\\"section-demo__container\\" buttonclass=\\"section-demo__button\\"></img-text-column-slice-stub>
   <section-slice-stub content=\\"[object Object]\\" sectionclass=\\"index__features\\" containerclass=\\"features__container\\" flexcontainerclass=\\"features-container__list\\" flexcontentclass=\\"features-container-list__item\\" buttonclass=\\"\\"></section-slice-stub>
   <prismic-edit-button-stub></prismic-edit-button-stub>


### PR DESCRIPTION
## :unicorn: Problème
La refonte du site vise à améliorer les points suivants:
- Le site n'est pas adapté aux écrans larges (>1280)
- Mettre à jour le contenu pour présenter Pix et tenir compte de l’évolution du projet (offre pro etc)
- Coherence de notre image vis à vis de la charte
- Rendre collaboratif le contenu pour le pôle com

## :robot: Solution
Cette PR concerne la refonte de la bannière de la page d'accueil.

## :rainbow: Remarques
- Le composant `banner` est réutilisable, il tire ses infos de prismic:
  - un `bannertitle`
  - un `bannercontent`
  - un `bannerImage`
  - un `bannerBackground`
- Le background-image peut ne pas apparaître si le resize se fait via le navigateur sans recharger la page
- Le test est KO car il dépends de la questions 1 ci-dessous

QUESTIONS :
- Pour la mise en production de Pix-site : est-ce qu'on fait morceaux par morceaux  OU tout le nouveau design de Pix Site d'un coup ?
- Voir avec Vincent, Gul pour la gestion des versions dans le premier cas ? 
- Devrait-on utiliser `css-grid-layout` (https://developer.mozilla.org/fr/docs/Web/CSS/CSS_Grid_Layout) ? -> Oui mais dans une prochaine PR "refacto" pour ne pas ralentir celle ci

- @QuentinChapelain-ui Devrait-on uniformiser les breakpoints entre pix-site et pix-app ?

Pour les tests :  npm run test -- -u


## :sparkles: Review App
https://pix-site-review-pr129.osc-fr1.scalingo.io
