### PR TITLE
[FEATURE] Traduction de contenu hors PRISMIC (PIX-1073).

### DIFF
--- a/components/app-footer.vue
+++ b/components/app-footer.vue
@@ -4,17 +4,23 @@
       <div class="sitelogo">
         <div :class="{ sitelogo__row: showUnescoLogo === true }">
           <a href="/" class="sitelogo-row__item">
-            <img alt="Retour à l'accueil Pix" src="/images/pix-logo.svg" />
+            <img
+              :alt="$t('alt.footer.pix-homepage')"
+              src="/images/pix-logo.svg"
+            />
           </a>
           <div v-if="showUnescoLogo" class="sitelogo-row__item">
-            <img alt="Soutenu par l'Unesco" src="/images/unesco_logo.svg" />
+            <img
+              :alt="$t('alt.footer.backed-by-unesco')"
+              src="/images/unesco_logo.svg"
+            />
           </div>
         </div>
         <div :class="{ sitelogo__row: showUnescoLogo === true }">
           <div class="sitelogo-row__item">
             <img
               class="ministere"
-              alt="Soutenu par le ministère de l'éducation"
+              :alt="$t('alt.footer.backed-by-education-ministry')"
               src="/images/ministere-logo.svg"
             />
           </div>

--- a/components/header-nav.vue
+++ b/components/header-nav.vue
@@ -15,14 +15,14 @@
           <div class="switch">
             <nuxt-link to="/">
               <img
-                alt="Accueil du site pix.fr"
+                :alt="$t('alt.header-nav.pix-homepage')"
                 class="logo"
                 src="/images/pix-logo.svg"
               />
             </nuxt-link>
             <img
               v-if="showFrenchGovLogo"
-              alt="Service public d'État"
+              :alt="$t('alt.header-nav.public-service')"
               src="/images/marianne-logo.svg"
             />
           </div>
@@ -34,14 +34,14 @@
           <div class="container padding-container">
             <nuxt-link to="/">
               <img
-                alt="Accueil du site pix.fr"
+                :alt="$t('alt.header-nav.pix-homepage')"
                 class="logo"
                 src="/images/pix-logo.svg"
               />
             </nuxt-link>
             <img
               v-if="showFrenchGovLogo"
-              alt="Service public d'État"
+              :alt="$t('alt.header-nav.public-service')"
               src="/images/marianne-logo.svg"
             />
             <div class="desktop">

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -39,6 +39,25 @@ export default {
   engineering: 'Engineering',
   event: 'Event',
   feature: 'Feature',
+  'page-titles': {
+    about: 'Who are we ? | Pix',
+    'contact-digital-mediation': 'Request for information | Pix',
+    'higher-education': 'Higher education | Pix',
+    'higher-education-establishment-registration':
+      'Slot inquiry | Pix Orga sup',
+    index: 'Accueil | Pix',
+    'legal-notices': 'Legal notice | Pix',
+    news: 'Actualités | Pix',
+    'pix-certification-application':
+      'Application for accreditation as a certification center | Pix',
+    'pix-orga-higher-school-registration':
+      'Finalise slot inquiry | Pix Orga sup',
+    'pix-orga-registration': 'Request for information | Pix pro',
+    'school-education': 'School education | Pix',
+    skills: 'Skills | Pix',
+    stats: 'Key figures | Pix',
+    'terms-of-service': 'Terms of service | Pix',
+  },
   'preview-page-load': 'Preview page loading...',
   society: 'Society',
   'about-title': 'About',

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -23,10 +23,23 @@ export default {
   },
   'news-page-title': 'News',
   'news-page-no-news': 'No news available for the moment.',
+  alt: {
+    'pix-homepage': 'Back to Pix homepage',
+    footer: {
+      'back-to-homepage': 'Back to Pix homepage',
+      'backed-by-unesco': 'Backed by Unesco',
+      'backed-by-education-ministry':
+        'Backed by the French Ministry of Education',
+    },
+    'header-nav': {
+      'public-service': 'Public State Service',
+    },
+  },
   announcement: 'Announcement',
   engineering: 'Engineering',
   event: 'Event',
   feature: 'Feature',
+  'preview-page-load': 'Preview page loading...',
   society: 'Society',
   'about-title': 'About',
   'resources-title': 'Resources',

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -38,6 +38,25 @@ export default {
   engineering: 'Ingénierie',
   event: 'Événement',
   feature: 'Nouveauté',
+  'page-titles': {
+    about: 'Qui sommes-nous ? | Pix',
+    'contact-digital-mediation': "Demande d'information | Pix",
+    'higher-education': 'Enseignement supérieur | Pix',
+    'higher-education-establishment-registration':
+      "Demande d'espace | Pix Orga sup",
+    index: 'Accueil | Pix',
+    'legal-notices': 'Mentions légales | Pix',
+    news: 'Actualités | Pix',
+    'pix-certification-application':
+      "Demande d'agrément comme centre de certification | Pix",
+    'pix-orga-higher-school-registration':
+      "Finaliser la demande d'espace | Pix Orga sup",
+    'pix-orga-registration': "Demande d'information | Pix pro",
+    'school-education': 'Enseignement scolaire | Pix',
+    skills: 'Compétences | Pix',
+    stats: 'Chiffres clés | Pix',
+    'terms-of-service': "Conditions générales d'utilisation | Pix",
+  },
   'preview-page-load': 'Chargement de la page de prévisualisation...',
   society: 'Société',
   'about-title': 'A propos',

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -23,10 +23,22 @@ export default {
   },
   'news-page-title': 'Actualités',
   'news-page-no-news': "Il n’y a pas encore d'actualités",
+  alt: {
+    footer: {
+      'pix-homepage': "Retour à l'accueil Pix",
+      'backed-by-unesco': "Soutenu par l'Unesco",
+      'backed-by-education-ministry': "Soutenu par le ministère de l'éducation",
+    },
+    'header-nav': {
+      'pix-homepage': 'Accueil du site pix.fr',
+      'public-service': "Service public d'État",
+    },
+  },
   announcement: 'Annonce',
   engineering: 'Ingénierie',
   event: 'Événement',
   feature: 'Nouveauté',
+  'preview-page-load': 'Chargement de la page de prévisualisation...',
   society: 'Société',
   'about-title': 'A propos',
   'resources-title': 'Ressources',

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -38,6 +38,25 @@ export default {
   engineering: 'Ingénierie',
   event: 'Événement',
   feature: 'Nouveauté',
+  'page-titles': {
+    about: 'Qui sommes-nous ? | Pix',
+    'contact-digital-mediation': "Demande d'information | Pix",
+    'higher-education': 'Enseignement supérieur | Pix',
+    'higher-education-establishment-registration':
+      "Demande d'espace | Pix Orga sup",
+    index: 'Accueil | Pix',
+    'legal-notices': 'Mentions légales | Pix',
+    news: 'Actualités | Pix',
+    'pix-certification-application':
+      "Demande d'agrément comme centre de certification | Pix",
+    'pix-orga-higher-school-registration':
+      "Finaliser la demande d'espace | Pix Orga sup",
+    'pix-orga-registration': "Demande d'information | Pix pro",
+    'school-education': 'Enseignement scolaire | Pix',
+    skills: 'Compétences | Pix',
+    stats: 'Chiffres clés | Pix',
+    'terms-of-service': "Conditions générales d'utilisation | Pix",
+  },
   'preview-page-load': 'Chargement de la page de prévisualisation...',
   society: 'Société',
   'about-title': 'A propos',

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -23,10 +23,22 @@ export default {
   },
   'news-page-title': 'Actualités',
   'news-page-no-news': "Il n’y a pas encore d'actualités",
+  alt: {
+    footer: {
+      'pix-homepage': "Retour à l'accueil Pix",
+      'backed-by-unesco': "Soutenu par l'Unesco",
+      'backed-by-education-ministry': "Soutenu par le ministère de l'éducation",
+    },
+    'header-nav': {
+      'pix-homepage': 'Accueil du site pix.fr',
+      'public-service': "Service public d'État",
+    },
+  },
   announcement: 'Annonce',
   engineering: 'Ingénierie',
   event: 'Événement',
   feature: 'Nouveauté',
+  'preview-page-load': 'Chargement de la page de prévisualisation...',
   society: 'Société',
   'about-title': 'A propos',
   'resources-title': 'Ressources',

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -79,7 +79,7 @@ export default {
   },
   head() {
     const meta = this.$getMeta(this.meta, this.currentPagePath, this.$prismic)
-    const pageTitle = 'Qui sommes-nous ? | Pix'
+    const pageTitle = this.$t('page-titles.about')
     return {
       title: pageTitle,
       meta,

--- a/pages/formable-pages/contact-digital-mediation.vue
+++ b/pages/formable-pages/contact-digital-mediation.vue
@@ -21,7 +21,7 @@ export default {
     },
   },
   head() {
-    const pageTitle = "Demande d'information | Pix"
+    const pageTitle = this.$t('page-titles.contact-digital-mediation')
     return {
       title: pageTitle,
     }

--- a/pages/formable-pages/higher-education-establishment-registration.vue
+++ b/pages/formable-pages/higher-education-establishment-registration.vue
@@ -21,7 +21,9 @@ export default {
     },
   },
   head() {
-    const pageTitle = 'Demande d’espace | Pix Orga sup'
+    const pageTitle = this.$t(
+      'page-titles.higher-education-establishment-registration'
+    )
     return {
       title: pageTitle,
     }

--- a/pages/formable-pages/pix-certification-application.vue
+++ b/pages/formable-pages/pix-certification-application.vue
@@ -21,7 +21,7 @@ export default {
     },
   },
   head() {
-    const pageTitle = "Demande d'agrément comme centre de certification | Pix"
+    const pageTitle = this.$t('page-titles.pix-certification-application')
     return {
       title: pageTitle,
     }

--- a/pages/formable-pages/pix-orga-higher-school-registration.vue
+++ b/pages/formable-pages/pix-orga-higher-school-registration.vue
@@ -21,7 +21,7 @@ export default {
     },
   },
   head() {
-    const pageTitle = "Finaliser la demande d'espace | Pix Orga sup"
+    const pageTitle = this.$t('page-titles.pix-orga-higher-school-registration')
     return {
       title: pageTitle,
     }

--- a/pages/formable-pages/pix-orga-registration.vue
+++ b/pages/formable-pages/pix-orga-registration.vue
@@ -21,7 +21,7 @@ export default {
     },
   },
   head() {
-    const pageTitle = "Demande d'information | Pix pro"
+    const pageTitle = this.$t('page-titles.pix-orga-registration')
     return {
       title: pageTitle,
     }

--- a/pages/higher-education.vue
+++ b/pages/higher-education.vue
@@ -125,7 +125,7 @@ export default {
   },
   head() {
     const meta = this.$getMeta(this.meta, this.currentPagePath, this.$prismic)
-    const pageTitle = 'Enseignement supérieur | Pix'
+    const pageTitle = this.$t('page-titles.higher-education')
     return {
       title: pageTitle,
       meta,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -81,7 +81,7 @@ export default {
   },
   head() {
     const meta = this.$getMeta(this.meta, this.currentPagePath, this.$prismic)
-    const pageTitle = 'Accueil | Pix'
+    const pageTitle = this.$t('page-titles.index')
     return {
       title: pageTitle,
       meta,

--- a/pages/legal-notices.vue
+++ b/pages/legal-notices.vue
@@ -60,7 +60,7 @@ export default {
   },
   head() {
     const meta = this.$getMeta(this.meta, this.currentPagePath, this.$prismic)
-    const pageTitle = 'Mentions légales | Pix'
+    const pageTitle = this.$t('page-titles.legal-notices')
     return {
       title: pageTitle,
       meta,

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -51,7 +51,7 @@ export default {
     }
   },
   head() {
-    const pageTitle = 'Actualités | Pix'
+    const pageTitle = this.$t('page-titles.news')
     return {
       title: pageTitle,
     }

--- a/pages/preview.vue
+++ b/pages/preview.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="outer-container">
-    <p>Chargement de la page de prévisualisation...</p>
+    <p>{{ $t('preview-page-load') }}</p>
   </div>
 </template>
 

--- a/pages/school-education.vue
+++ b/pages/school-education.vue
@@ -153,7 +153,7 @@ export default {
   },
   head() {
     const meta = this.$getMeta(this.meta, this.currentPagePath, this.$prismic)
-    const pageTitle = 'Enseignement scolaire | Pix'
+    const pageTitle = this.$t('page-titles.school-education')
     return {
       title: pageTitle,
       meta,

--- a/pages/skills.vue
+++ b/pages/skills.vue
@@ -56,7 +56,7 @@ export default {
   },
   head() {
     const meta = this.$getMeta(this.meta, this.currentPagePath, this.$prismic)
-    const pageTitle = 'Compétences | Pix'
+    const pageTitle = this.$t('page-titles.skills')
     return {
       title: pageTitle,
       meta,

--- a/pages/stats.vue
+++ b/pages/stats.vue
@@ -95,7 +95,7 @@ export default {
   },
   head() {
     const meta = this.$getMeta(this.meta, this.currentPagePath, this.$prismic)
-    const pageTitle = 'Chiffres clés | Pix'
+    const pageTitle = this.$t('page-titles.stats')
     return {
       title: pageTitle,
       meta,

--- a/pages/terms-of-service.vue
+++ b/pages/terms-of-service.vue
@@ -52,7 +52,7 @@ export default {
   },
   head() {
     const meta = this.$getMeta(this.meta, this.currentPagePath, this.$prismic)
-    const pageTitle = "Conditions générales d'utilisation | Pix"
+    const pageTitle = this.$t('page-titles.terms-of-service')
     return {
       title: pageTitle,
       meta,


### PR DESCRIPTION
## :unicorn: Problème
De nombreux éléments textuels présents dans le code, dans les balises ALT, ainsi que des titres de pages n'étaient pas traduits en anglais.

## :robot: Solution
Ajout d'une traduction pour chacun de ces éléments dans les fichiers de traduction (FR/EN) dans le dossier /lang.

## :rainbow: Remarques
L'organisation du fichier de traduction est ouverte à discussion. Les traductions en anglais me semblent également assez approximatives.

## :sparkles: Review App
https://pix-site-review-pr131.osc-fr1.scalingo.io
