### PR TITLE
[FEATURE] Ré-implémenter le sélecteur de langues (PIX-1079).

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,6 @@ Domain name for `.org` extension.
 - type: String
 - default: none
 
-`FORWARDED_HOST`
-Indicates whether host is forwarded.
-Shall be set to `true` on Review Apps.
-
-- presence: optional
-- type: Boolean
-- default: false
-
 ## Build Setup
 
 ```bash

--- a/components/language-dropdown.vue
+++ b/components/language-dropdown.vue
@@ -1,5 +1,12 @@
 <template>
-  <div v-if="availableLocale.length > 1" class="language-dropdown">
+  <div
+    v-if="
+      availableLocales.length > 1 &&
+      $config.languageSwitchEnabled &&
+      $config.isOrgDomainExtension
+    "
+    class="language-dropdown"
+  >
     <dropdown-button
       :options="options"
       :selected="currentLanguage"
@@ -18,11 +25,11 @@ export default {
     DropdownButton,
   },
   data() {
-    const availableLocale = this.$i18n.locales.map((locale) => {
+    const availableLocales = this.$i18n.locales.map((locale) => {
       return { name: this.$t(locale.code), lang: locale.code }
     })
     return {
-      availableLocale,
+      availableLocales,
     }
   },
   computed: {
@@ -30,12 +37,12 @@ export default {
       return this.$i18n.locale || this.$i18n.defaultLocale
     },
     currentLanguage() {
-      return this.availableLocale.find(
+      return this.availableLocales.find(
         (locale) => locale.lang === this.currentLocale
       )
     },
     options() {
-      return this.availableLocale.filter(
+      return this.availableLocales.filter(
         (locale) => locale.lang !== this.currentLocale
       )
     },
@@ -44,7 +51,7 @@ export default {
   methods: {
     languageDidChange(selectedLocale) {
       this.$i18n.setLocale(selectedLocale.lang)
-      const page = this.switchLocalePath()
+      const page = this.switchLocalePath(selectedLocale.lang)
       this.$router.push(page)
     },
   },

--- a/components/language-dropdown.vue
+++ b/components/language-dropdown.vue
@@ -1,9 +1,9 @@
 <template>
   <div
     v-if="
-      availableLocale.length > 1 &&
+      nonFrenchFranceLocales.length > 1 &&
       $config.languageSwitchEnabled &&
-      $config.isOrgDomainExtension
+      domainAllowsLanguageSwitch
     "
     class="language-dropdown"
   >
@@ -28,8 +28,11 @@ export default {
     const availableLocales = this.$i18n.locales.map((locale) => {
       return { name: this.$t(locale.code), lang: locale.code }
     })
+    const nonFrenchFranceLocales = availableLocales.filter(
+      (locale) => locale.lang !== 'fr-fr'
+    )
     return {
-      availableLocales,
+      nonFrenchFranceLocales,
     }
   },
   computed: {
@@ -37,14 +40,17 @@ export default {
       return this.$i18n.locale || this.$i18n.defaultLocale
     },
     currentLanguage() {
-      return this.availableLocales.find(
+      return this.nonFrenchFranceLocales.find(
         (locale) => locale.lang === this.currentLocale
       )
     },
     options() {
-      return this.availableLocales.filter(
+      return this.nonFrenchFranceLocales.filter(
         (locale) => locale.lang !== this.currentLocale
       )
+    },
+    domainAllowsLanguageSwitch() {
+      return this.$store.state.host === this.$config.orgDomain
     },
   },
   methods: {

--- a/components/language-dropdown.vue
+++ b/components/language-dropdown.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="
-      availableLocales.length > 1 &&
+      availableLocale.length > 1 &&
       $config.languageSwitchEnabled &&
       $config.isOrgDomainExtension
     "
@@ -47,7 +47,6 @@ export default {
       )
     },
   },
-
   methods: {
     languageDidChange(selectedLocale) {
       this.$i18n.setLocale(selectedLocale.lang)

--- a/components/organization-nav.vue
+++ b/components/organization-nav.vue
@@ -1,5 +1,6 @@
 <template>
   <div v-if="organizationNavItems.length > 1" class="nav-switch">
+    <language-dropdown />
     <div class="container padding-container">
       <div
         v-for="item in organizationNavItems"
@@ -15,7 +16,12 @@
 </template>
 
 <script>
+import LanguageDropdown from '~/components/language-dropdown'
+
 export default {
+  components: {
+    LanguageDropdown,
+  },
   props: {
     organizationNavItems: {
       type: Array,

--- a/components/organization-nav.vue
+++ b/components/organization-nav.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="organizationNavItems.length > 1" class="nav-switch">
+  <div class="nav-switch">
     <language-dropdown />
     <div class="container padding-container">
       <div

--- a/config/locale-domains.js
+++ b/config/locale-domains.js
@@ -1,5 +1,0 @@
-export default {
-  'fr-fr': process.env.DOMAIN_FR,
-  'en-gb': process.env.DOMAIN_ORG,
-  fr: process.env.DOMAIN_ORG,
-}

--- a/config/locale-domains.js
+++ b/config/locale-domains.js
@@ -1,4 +1,5 @@
 export default {
   'fr-fr': process.env.DOMAIN_FR,
+  'en-gb': process.env.DOMAIN_ORG,
   fr: process.env.DOMAIN_ORG,
 }

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -33,8 +33,8 @@ export default {
       'pix-homepage': 'Back to Pix homepage',
     },
     'header-nav': {
+      'pix-homepage': 'Pix homepage',
       'public-service': 'Public State Service',
-      'pix-homepage': 'Accueil du site pix.fr',
     },
   },
   announcement: 'Announcement',

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -1,4 +1,5 @@
 export default {
+  fr: 'Francophone',
   'en-gb': 'English',
   'fr-fr': 'Français',
   'contact-digital-mediation': {
@@ -24,15 +25,16 @@ export default {
   'news-page-title': 'News',
   'news-page-no-news': 'No news available for the moment.',
   alt: {
-    'pix-homepage': 'Back to Pix homepage',
     footer: {
       'back-to-homepage': 'Back to Pix homepage',
       'backed-by-unesco': 'Backed by Unesco',
       'backed-by-education-ministry':
         'Backed by the French Ministry of Education',
+      'pix-homepage': 'Back to Pix homepage',
     },
     'header-nav': {
       'public-service': 'Public State Service',
+      'pix-homepage': 'Accueil du site pix.fr',
     },
   },
   announcement: 'Announcement',

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -1,4 +1,5 @@
 export default {
+  fr: 'Francophone',
   'fr-fr': 'Français',
   'en-gb': 'English',
   'contact-digital-mediation': {

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -1,4 +1,5 @@
 export default {
+  fr: 'Francophone',
   'fr-fr': 'Français',
   'en-gb': 'English',
   'contact-digital-mediation': {

--- a/middleware/current-page-path.js
+++ b/middleware/current-page-path.js
@@ -1,18 +1,10 @@
+import getHostFromRequest from '~/services/get-host-from-request'
+
 export default function (context) {
   const { req, route } = context
-  const host = _getHostFromRequest(req)
-    ? _getHostFromRequest(req)
+  const host = getHostFromRequest(req)
+    ? getHostFromRequest(req)
     : window.location.host
 
   context.currentPagePath = `${host}${route.path}`
-}
-
-function _getHostFromRequest(req) {
-  if (!req) {
-    return
-  }
-  const headers = req.headers
-  return headers['x-forwarded-host']
-    ? headers['x-forwarded-host']
-    : headers.host
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -4,6 +4,10 @@ import PrismicConfig from './prismic.config'
 
 export default {
   mode: 'universal',
+  publicRuntimeConfig: {
+    languageSwitchEnabled: process.env.LANGUAGE_SWITCH_ENABLED || false,
+    isOrgDomainExtension: process.env.DOMAIN_ORG || false,
+  },
   server: {
     port: process.env.PORT || 5000,
   },
@@ -146,6 +150,11 @@ export default {
         code: 'fr',
         file: 'fr.js',
         domain: localeDomains.fr,
+      },
+      {
+        code: 'en-gb',
+        file: 'en-gb.js',
+        domain: localeDomains['en-gb'],
       },
     ],
     lazy: true,

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -5,7 +5,7 @@ export default {
   mode: 'universal',
   publicRuntimeConfig: {
     languageSwitchEnabled: process.env.LANGUAGE_SWITCH_ENABLED || false,
-    isOrgDomainExtension: process.env.DOMAIN_ORG || false,
+    orgDomain: process.env.DOMAIN_ORG || 'pix.org',
   },
   server: {
     port: process.env.PORT || 5000,
@@ -151,6 +151,10 @@ export default {
     langDir: 'lang/',
     vueI18n: {
       fallbackLocale: 'fr-fr',
+    },
+    detectBrowserLanguage: {
+      useCookie: true,
+      alwaysRedirect: true,
     },
   },
   router: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,5 +1,4 @@
 import { transports } from 'winston'
-import localeDomains from './config/locale-domains'
 import PrismicConfig from './prismic.config'
 
 export default {
@@ -88,13 +87,7 @@ export default {
     '@nuxtjs/axios',
     '@nuxtjs/dotenv',
     '@nuxtjs/style-resources',
-    [
-      'nuxt-i18n',
-      {
-        differentDomains: true,
-        forwardedHost: process.env.FORWARDED_HOST || false,
-      },
-    ],
+    'nuxt-i18n',
     '@nuxtjs/moment',
     ['nuxt-matomo', { matomoUrl: 'https://stats.pix.fr/', siteId: 1 }],
     [
@@ -144,17 +137,14 @@ export default {
       {
         code: 'fr-fr',
         file: 'fr-fr.js',
-        domain: localeDomains['fr-fr'],
       },
       {
         code: 'fr',
         file: 'fr.js',
-        domain: localeDomains.fr,
       },
       {
         code: 'en-gb',
         file: 'en-gb.js',
-        domain: localeDomains['en-gb'],
       },
     ],
     lazy: true,

--- a/pages/_simple-page.vue
+++ b/pages/_simple-page.vue
@@ -31,9 +31,7 @@ export default {
       'en-gb': '/:uid',
     },
   },
-  async asyncData({ params, app, req, error, route }) {
-    const host = req ? req.headers.host : window.location.host
-    const currentPagePath = `${host}${route.path}`
+  async asyncData({ params, app, req, error, currentPagePath }) {
     try {
       const newsItem = await documentFetcher(app.i18n, req).getSimplePageByUid(
         params.uid

--- a/services/get-host-from-request.js
+++ b/services/get-host-from-request.js
@@ -1,0 +1,9 @@
+export default function getHostFromRequest(req) {
+  if (!req) {
+    return
+  }
+  const headers = req.headers
+  return headers['x-forwarded-host']
+    ? headers['x-forwarded-host']
+    : headers.host
+}

--- a/store/index.js
+++ b/store/index.js
@@ -1,3 +1,4 @@
+import getHostFromRequest from '~/services/get-host-from-request'
 import { documents, documentFetcher } from '~/services/document-fetcher'
 
 export const state = () => ({
@@ -9,17 +10,29 @@ export const state = () => ({
   resourcesNavItems: [],
   aboutNavItems: [],
   hotNews: null,
+  host: null,
 })
 export const actions = {
-  async nuxtServerInit({ commit }, { app }) {
+  async nuxtServerInit({ commit }, { app, req }) {
     commit('updateNavigation', await getNavigation(app.i18n))
     commit('updateHotNews', await getHotNews(app.i18n))
+    commit('updateHost', req)
   },
   async updateNavigation({ commit }, i18n) {
     commit('updateNavigation', await getNavigation(i18n))
   },
 }
 export const mutations = {
+  updateHost(state, req) {
+    const host = getHostFromRequest(req)
+    state.host = host.split(':')[0]
+    if (
+      state.host === this.$config.orgDomain &&
+      this.$i18n.locale === 'fr-fr'
+    ) {
+      this.$i18n.setLocale('en-gb')
+    }
+  },
   updateNavigation(state, navigations) {
     function navItems(response, type) {
       return response.data.body.filter((body) => body.primary.type === type)

--- a/store/index.js
+++ b/store/index.js
@@ -1,5 +1,4 @@
 import { documents, documentFetcher } from '~/services/document-fetcher'
-import localeDomains from '~/config/locale-domains'
 
 export const state = () => ({
   organizationNavItems: [],
@@ -10,7 +9,6 @@ export const state = () => ({
   resourcesNavItems: [],
   aboutNavItems: [],
   hotNews: null,
-  localeDomains,
 })
 export const actions = {
   async nuxtServerInit({ commit }, { app }) {


### PR DESCRIPTION
## :unicorn: Problème

Le site Pix.org va avoir une version anglaise. 
Pour nous aider dans cette modification, nous devons pouvoir changer de langue sur le site et avoir un moyen de changer de langue sur https://site.integration.pix.org/
/!\ Ce moyen ne doit pas fonctionner sur la prod
/!\ Ce moyen doit être disponible seulement sur .org

## :robot: Solution

Appel du composant language-dropdown déjà existant dans le code et ajout d'une variable d'environnement.

## Tester

Aller sur la review App en .fr
Noter l'absence de sélecteur de langue dans la barre de navigation dans le coin supérieur gauche de l'écran.
Changer l'adresse .fr par .org

## :sparkles: Review App
https://site-pr132.review.pix.fr/
