### PR TITLE
[BUGFIX] Enlever la détection du langage du navigateur. 

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -152,10 +152,6 @@ export default {
     vueI18n: {
       fallbackLocale: 'fr-fr',
     },
-    detectBrowserLanguage: {
-      useCookie: true,
-      alwaysRedirect: true,
-    },
   },
   router: {
     middleware: 'current-page-path',


### PR DESCRIPTION
## :unicorn: Problème
Nous forçons le site à utiliser la langue du navigateur. Les personnes peuvent avoir mis leur navigateur en anglais mais ne désire pas forcément avoir tous les sites en anglais. 

## :robot: Solution
Retirer ce comportement

## :sparkles: Review App
https://pix-site-integration-pr.scalingo.io
