### PR TITLE
[BUGFIX] Avoir de base la locale a FR quand on est sur .org.

### DIFF
--- a/store/index.js
+++ b/store/index.js
@@ -30,7 +30,7 @@ export const mutations = {
       state.host === this.$config.orgDomain &&
       this.$i18n.locale === 'fr-fr'
     ) {
-      this.$i18n.setLocale('en-gb')
+      this.$i18n.setLocale('fr')
     }
   },
   updateNavigation(state, navigations) {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, si on est sur .org, la locale de base est 'fr-fr' et se transforme en 'en-gb'

## :robot: Solution
Modifier pour que ce soit 'fr' dans ce cas

## :sparkles: Review App
La review-app se comporte comme un .org
Il n'y a pas de marianne en haut, mais on est bien en FR
https://pix-site-review-pr136.osc-fr1.scalingo.io/