### PR TITLE
[BUGFIX] S'assurer de l'affichage du menu gris et du switch de langue selon les contextes (PIX-1144).

### DIFF
--- a/components/organization-nav.vue
+++ b/components/organization-nav.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="nav-switch">
+  <div v-if="showLanguageDropdown || frenchDomain" class="nav-switch">
     <language-dropdown />
-    <div class="container padding-container">
+    <div v-if="frenchDomain" class="container padding-container">
       <div
         v-for="item in organizationNavItems"
         :key="item.id"
@@ -26,6 +26,15 @@ export default {
     organizationNavItems: {
       type: Array,
       default: null,
+    },
+  },
+  computed: {
+    showLanguageDropdown() {
+      return this.$config.languageSwitchEnabled
+    },
+
+    frenchDomain() {
+      return !(this.$store.state.host === this.$config.orgDomain)
     },
   },
 }


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, sur https://site.integration.pix.org/, quand je clique sur "Qui sommes nous ?", les liens "Enseignement scolaire" et "Enseignement supérieur" réapparaisse. 


## :robot: Solution

Je veux afficher les liens seulement sur le site .fr
Je veux voir le bandeau gris : 
- Si je suis sur le site FR
- Ou si j'ai le switch de langage à afficher

## :sparkles: Review App
https://site-pr138.review.pix.org/