### PR TITLE
[BUGFIX] Remettre le bon style pour les boutons (PIX-1142).

### DIFF
--- a/assets/scss/components/_app-navbar.scss
+++ b/assets/scss/components/_app-navbar.scss
@@ -23,11 +23,11 @@
 
       a {
         margin-left: 3px;
-        color: $grey-1 !important;
+        color: $grey-1;
         margin-right: 18px;
 
         &:hover {
-          color: $blue-1 !important;
+          color: $blue-1;
         }
       }
 

--- a/assets/scss/globals/_buttons.scss
+++ b/assets/scss/globals/_buttons.scss
@@ -1,4 +1,4 @@
-@mixin colorizeButton($fontColor, $borderColor, $bgColor, $hoverBgColor) {
+@mixin colorizeButton($fontColor, $borderColor, $bgColor, $hoverBgColor, $hoverFontColor) {
   color: $fontColor;
   border-color: $borderColor;
   background-color: $bgColor;
@@ -6,6 +6,7 @@
   &:hover {
     cursor: pointer;
     background-color: $hoverBgColor;
+    color: $hoverFontColor !important;
   }
 }
 
@@ -23,13 +24,25 @@
 
   transition: background-color 0.3s ease;
 
-  @include colorizeButton($white, transparent, $blue-1, $blue-3);
+  @include colorizeButton($white, transparent, $blue-1, $blue-3, $white);
 
   &.button-video {
-    @include colorizeButton($grey-11, $grey-11, $white, $grey-20);
+    @include colorizeButton($grey-11, $grey-11, $white, $grey-20, $grey-11);
     svg { margin-right: 10px; }
   }
+  &--oval {
+    border-radius: 20px;
+    border: 1px solid;
+    padding: 0 25px;
+    height:40px;
+    text-transform: uppercase;
+    font-size: 0.8125rem;
+    letter-spacing: 0.0625rem;
+
+    @include colorizeButton($blue-1, $blue-1, $white, $blue-1, $white);
+  }
 }
+
 
 @include device-is('tablet') {
   .button {

--- a/components/main-nav.vue
+++ b/components/main-nav.vue
@@ -11,7 +11,7 @@
         'regular',
         { 'text-black': index < mainNavItems.length - 1 },
         { 'link-separator-left': index === mainNavItems.length - 3 },
-        { 'btn-nav': index === mainNavItems.length - 1 },
+        { 'button button--oval btn-nav': index === mainNavItems.length - 1 },
       ]"
     >
       {{ $prismic.richTextAsPlain(item.primary.title) }}


### PR DESCRIPTION
## :unicorn: Problème
Lors d'un nettoyage CSS concernant les boutons, le style du bouton s'inscrire a disparu

## :robot: Solution
- Dans les styles des buttons, ajouter un style pour le Ovale
- Dans les styles des buttons, gérer la couleur des textes du hover pour pouvoir le mettre à blanc
- Retirer le !important sur les lien nav (car le button est bien un a:hove de nav), mais on a du mettre le !important dans le bouton, car `.nav a:hover` a un poid plus important que `.button--oval:hover`

## :sparkles: Review App
https://site-pr139.review.pix.org/