### PR TITLE
[BUGFIX] Les liens en FR redirigeaient vers du FR-FR (PIX-1145).

### DIFF
--- a/components/pix-link.vue
+++ b/components/pix-link.vue
@@ -26,14 +26,14 @@ export default {
 
       if (this.field.link_type === 'Document') {
         template = `
-          <router-link to="${url}">
+          <router-link to="${this.localePath(url)}">
             <slot/>
           </router-link>
         `
       } else if (relativeLinkPrefix) {
         const relativeUrl = url.replace(relativeLinkPrefix, '')
         template = `
-          <router-link to="${relativeUrl}">
+          <router-link to="${this.localePath(relativeUrl)}">
             <slot/>
           </router-link>
         `

--- a/pages/_simple-page.vue
+++ b/pages/_simple-page.vue
@@ -27,6 +27,7 @@ export default {
   name: 'SimplePage',
   nuxtI18n: {
     paths: {
+      fr: '/:uid',
       'fr-fr': '/:uid',
       'en-gb': '/:uid',
     },

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -57,6 +57,7 @@ export default {
   components: { HeroBanner, SectionColumnSlice, SectionSlice },
   nuxtI18n: {
     paths: {
+      fr: '/qui-sommes-nous',
       'fr-fr': '/qui-sommes-nous',
       'en-gb': '/about',
     },

--- a/pages/formable-pages/contact-digital-mediation.vue
+++ b/pages/formable-pages/contact-digital-mediation.vue
@@ -16,6 +16,7 @@ export default {
   components: { FormablePage },
   nuxtI18n: {
     paths: {
+      fr: '/formulaire/contact-mediation-numerique',
       'fr-fr': '/formulaire/contact-mediation-numerique',
       'en-gb': '/form/contact-digital-mediation',
     },

--- a/pages/formable-pages/higher-education-establishment-registration.vue
+++ b/pages/formable-pages/higher-education-establishment-registration.vue
@@ -16,6 +16,7 @@ export default {
   components: { FormablePage },
   nuxtI18n: {
     paths: {
+      fr: '/formulaire/inscription-etablissement-superieur',
       'fr-fr': '/formulaire/inscription-etablissement-superieur',
       'en-gb': '/form/higher-education-establishment-registration',
     },

--- a/pages/formable-pages/pix-certification-application.vue
+++ b/pages/formable-pages/pix-certification-application.vue
@@ -16,6 +16,7 @@ export default {
   components: { FormablePage },
   nuxtI18n: {
     paths: {
+      fr: '/formulaire/demande-agrement-centre-certification',
       'fr-fr': '/formulaire/demande-agrement-centre-certification',
       'en-gb': '/form/pix-certification-application',
     },

--- a/pages/formable-pages/pix-orga-higher-school-registration.vue
+++ b/pages/formable-pages/pix-orga-higher-school-registration.vue
@@ -16,6 +16,7 @@ export default {
   components: { FormablePage },
   nuxtI18n: {
     paths: {
+      fr: '/formulaire/finalisation-pix-orga-sup',
       'fr-fr': '/formulaire/finalisation-pix-orga-sup',
       'en-gb': '/form/pix-orga-higher-school-registration',
     },

--- a/pages/formable-pages/pix-orga-registration.vue
+++ b/pages/formable-pages/pix-orga-registration.vue
@@ -16,6 +16,7 @@ export default {
   components: { FormablePage },
   nuxtI18n: {
     paths: {
+      fr: '/formulaire/contact-pix-pro',
       'fr-fr': '/formulaire/contact-pix-pro',
       'en-gb': '/form/pix-orga-registration',
     },

--- a/pages/help.vue
+++ b/pages/help.vue
@@ -4,6 +4,7 @@ export default {
   name: 'Help',
   nuxtI18n: {
     paths: {
+      fr: '/aide',
       'fr-fr': '/aide',
       'en-gb': '/help',
     },

--- a/pages/higher-education.vue
+++ b/pages/higher-education.vue
@@ -94,6 +94,7 @@ export default {
   name: 'HigherEducation',
   nuxtI18n: {
     paths: {
+      fr: '/enseignement-superieur',
       'fr-fr': '/enseignement-superieur',
       'en-gb': '/higher-education',
     },

--- a/pages/legal-notices.vue
+++ b/pages/legal-notices.vue
@@ -35,6 +35,7 @@ export default {
   name: 'LegalNotices',
   nuxtI18n: {
     paths: {
+      fr: '/mentions-legales',
       'fr-fr': '/mentions-legales',
       'en-gb': '/en-gb/legal-notices',
     },

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -33,6 +33,7 @@ export default {
   name: 'Index',
   nuxtI18n: {
     paths: {
+      fr: '/actualites',
       'fr-fr': '/actualites',
       'en-gb': '/news',
     },

--- a/pages/school-education.vue
+++ b/pages/school-education.vue
@@ -123,6 +123,7 @@ export default {
   name: 'SchoolEducation',
   nuxtI18n: {
     paths: {
+      fr: '/enseignement-scolaire',
       'fr-fr': '/enseignement-scolaire',
       'en-gb': '/school-education',
     },

--- a/pages/skills.vue
+++ b/pages/skills.vue
@@ -31,6 +31,7 @@ export default {
   name: 'Skills',
   nuxtI18n: {
     paths: {
+      fr: '/competences',
       'fr-fr': '/competences',
       'en-gb': '/skills',
     },

--- a/pages/stats.vue
+++ b/pages/stats.vue
@@ -27,6 +27,7 @@ export default {
   name: 'Stats',
   nuxtI18n: {
     paths: {
+      fr: '/stats',
       'fr-fr': '/stats',
       'en-gb': '/stats',
     },

--- a/pages/terms-of-service.vue
+++ b/pages/terms-of-service.vue
@@ -28,6 +28,7 @@ export default {
   name: 'TermsOfService',
   nuxtI18n: {
     paths: {
+      fr: '/conditions-generales-d-utilisation',
       'fr-fr': '/conditions-generales-d-utilisation',
       'en-gb': '/terms-of-service',
     },

--- a/pages/verify-certification-score.vue
+++ b/pages/verify-certification-score.vue
@@ -64,6 +64,7 @@ export default {
   name: 'VerifyCertificationScore',
   nuxtI18n: {
     paths: {
+      fr: '/verifier-score-certification',
       'fr-fr': '/verifier-score-certification',
       'en-gb': '/verify-certification-score',
     },


### PR DESCRIPTION
## :unicorn: Problème
Sur site.integration.pix.org :
Si vous arrivez dessus, vous êtes bien sur du FR (exemple : pas de lien “Centre d’aide” dans le menu
Mais dès que je change de page, le texte coté Prismic remonté est celui du FR-FR : le centre d’aide apparait, il y a beaucoup d’actualités etc..


## :robot: Solution
- Ajouter un path clair pour les pages en fr
- Utiliser localePath lors de la création des liens via `pix-link``

## :rainbow: Remarques

> When rendering internal links in your app using <nuxt-link>, you need to get proper URLs for the current locale. To do this, nuxt-i18n registers a global mixin that provides some helper functions:
>localePath – Returns the localized URL for a given page. The first parameter can be either the path or name of the route or an object for more complex routes. A locale code can be passed as the second parameter to generate a link for a specific language:

- En anglais, beaucoup de liens cassent car les pages ne sont pas prêtes coté Prismic. Le switch de langue ne sera disponible que sur intégration pour aider à la création de ces pages.

## :sparkles: Review App
https://site-pr140.review.pix.fr/ et https://site-pr140.review.pix.org/

Sur .org, j'ai retirer le switch de langue pour avoir un rendu comme la prod.