### PR TITLE
[BUGFIX] Correction d'une régression visuelle sur la page "/competences" 

### DIFF
--- a/pages/skills.vue
+++ b/pages/skills.vue
@@ -136,5 +136,9 @@ export default {
       }
     }
   }
+
+  .section__flex-content {
+    max-width: 100%;
+  }
 }
 </style>


### PR DESCRIPTION
## :unicorn: Problème

Une régression visuelle s'est glissée suite au commit [#7eea1ac](https://github.com/1024pix/pix-site/commit/7eea1acdbb42873158212573a65676d3496347cf).

![image](https://user-images.githubusercontent.com/265963/90900760-2f9def80-e3ca-11ea-8dab-449ddc9883b0.png)

## :robot: Solution

Dans la mesure ou le Slice "Section" est utilisée dans plusieurs pages, la meilleure solution trouvée est de surcharger le style spécifiquement pour la page "competences".

## :rainbow: Remarques

Il aurait été préférable d'avoir des tests de non-régression visuelle au niveau du rendu utilisateur, mais nous n'avons pas d'outillage en ce sens (Jest Snapshot se limite à vérifier du DOM).

## :sparkles: Review App

https://pix-site-review-pr144.osc-fr1.scalingo.io/competences
