### PR TITLE
[TECH] Déplacement de toutes les slices de index.vue dans slice-zone

### DIFF
--- a/components/slices/SliceZone.vue
+++ b/components/slices/SliceZone.vue
@@ -10,17 +10,64 @@
       <template v-if="slice.slice_type === 'web_snippet'">
         <web-snippet :slice="slice" />
       </template>
+      <template v-if="slice.slice_type === 'pop-in'">
+        <pop-in-campaigns :content="slice" />
+      </template>
+      <template v-if="slice.slice_type === 'banner'">
+        <banner :content="slice"></banner>
+      </template>
+      <template v-if="slice.slice_type === 'old-banner'">
+        <hero-banner
+          :section-class="'index__hero-banner'"
+          :background-class="'hero-banner__background'"
+          :content-class="'hero-banner__content'"
+          :button-class="'hero-banner-content__button'"
+          :content="slice"
+        >
+        </hero-banner>
+      </template>
+      <template v-if="slice.slice_type === 'old-demo'">
+        <img-text-column-slice
+          :content="slice"
+          :section-class="'section-demo'"
+          :container-class="'section-demo__container'"
+          :button-class="'section-demo__button'"
+        ></img-text-column-slice>
+      </template>
+      <template v-if="slice.slice_type === 'old-features'">
+        <section-slice
+          :content="slice"
+          :section-class="'index__features'"
+          :container-class="'features__container'"
+          :flex-container-class="'features-container__list'"
+          :flex-content-class="'features-container-list__item'"
+        >
+        </section-slice>
+      </template>
     </section>
   </div>
 </template>
 
 <script>
+import Banner from '@/components/slices/Banner'
+import HeroBanner from '@/components/slices/HeroBanner'
+import ImgTextColumnSlice from '@/components/slices/ImgTextColumn'
 import MultipleColumn from '@/components/slices/MultipleColumn'
+import PopInCampaigns from '@/components/PopInCampaigns'
+import SectionSlice from '@/components/slices/Section'
 import WebSnippet from '@/components/slices/WebSnippet'
 
 export default {
   name: 'SliceZone',
-  components: { WebSnippet, MultipleColumn },
+  components: {
+    Banner,
+    HeroBanner,
+    ImgTextColumnSlice,
+    MultipleColumn,
+    PopInCampaigns,
+    SectionSlice,
+    WebSnippet,
+  },
   props: {
     slices: {
       type: Array,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,52 +1,16 @@
 <template>
   <div class="index">
-    <pop-in-campaigns :content="popInCampaignDocument" />
-    <div v-if="bannerDocument.slice_type === 'hero-banner'">
-      <hero-banner
-        v-if="bannerDocument.slice_type === 'hero-banner'"
-        :section-class="'index__hero-banner'"
-        :background-class="'hero-banner__background'"
-        :content-class="'hero-banner__content'"
-        :button-class="'hero-banner-content__button'"
-        :content="bannerDocument"
-      >
-      </hero-banner>
-    </div>
-    <banner v-else :content="bannerDocument"></banner>
-
-    <img-text-column-slice
-      :content="demoDocument"
-      :section-class="'section-demo'"
-      :container-class="'section-demo__container'"
-      :button-class="'section-demo__button'"
-    ></img-text-column-slice>
-
-    <section-slice
-      :content="featuresDocument"
-      :section-class="'index__features'"
-      :container-class="'features__container'"
-      :flex-container-class="'features-container__list'"
-      :flex-content-class="'features-container-list__item'"
-    >
-    </section-slice>
+    <slice-zone :slices="slices" />
   </div>
 </template>
 
 <script>
 import { documents, documentFetcher } from '~/services/document-fetcher'
-import HeroBanner from '@/components/slices/HeroBanner'
-import ImgTextColumnSlice from '@/components/slices/ImgTextColumn'
-import SectionSlice from '@/components/slices/Section'
-import PopInCampaigns from '@/components/PopInCampaigns'
-import Banner from '@/components/slices/Banner'
+import SliceZone from '@/components/slices/SliceZone'
 
 export default {
   components: {
-    PopInCampaigns,
-    HeroBanner,
-    SectionSlice,
-    ImgTextColumnSlice,
-    Banner,
+    SliceZone,
   },
   async asyncData({ app, error, req, currentPagePath }) {
     try {
@@ -65,17 +29,19 @@ export default {
     }
   },
   computed: {
-    bannerDocument() {
-      return this.document[0]
-    },
-    demoDocument() {
-      return this.document[1]
-    },
-    featuresDocument() {
-      return this.document[2]
-    },
-    popInCampaignDocument() {
-      return this.document[3]
+    slices() {
+      return this.document.map((slice, index) => {
+        if (slice.slice_type === 'hero-banner') {
+          slice.slice_type = 'old-banner'
+        }
+        if (index === 1 && slice.slice_type === 'section') {
+          slice.slice_type = 'old-demo'
+        }
+        if (index === 2 && slice.slice_type === 'section') {
+          slice.slice_type = 'old-features'
+        }
+        return slice
+      })
     },
   },
   head() {

--- a/tests/pages/__snapshots__/index.test.js.snap
+++ b/tests/pages/__snapshots__/index.test.js.snap
@@ -2,9 +2,6 @@
 
 exports[`Index Page renders properly 1`] = `
 "<div class=\\"index\\">
-  <pop-in-campaigns-stub content=\\"[object Object]\\"></pop-in-campaigns-stub>
-  <banner-stub content=\\"[object Object]\\"></banner-stub>
-  <img-text-column-slice-stub content=\\"[object Object]\\" sectionclass=\\"section-demo\\" containerclass=\\"section-demo__container\\" buttonclass=\\"section-demo__button\\"></img-text-column-slice-stub>
-  <section-slice-stub content=\\"[object Object]\\" sectionclass=\\"index__features\\" containerclass=\\"features__container\\" flexcontainerclass=\\"features-container__list\\" flexcontentclass=\\"features-container-list__item\\" buttonclass=\\"section__button\\"></section-slice-stub>
+  <slice-zone-stub slices=\\"[object Object],[object Object],[object Object],[object Object]\\"></slice-zone-stub>
 </div>"
 `;


### PR DESCRIPTION
## :unicorn: Problème
Il est difficile de travailler avec les anciens et nouveaux slices sur Prismic.

## :robot: Solution
Avec cette PR, dans le Prismic draft, il est possible de **supprimer** les slices non utilisées.

## :rainbow: Remarques
Les slices destinées à être supprimées à terme sont de type `old-XYZ` (ex: old-banner, old-features).

## :sparkles: Review App
https://pix-site-review-pr149.osc-fr1.scalingo.io
Sur Prismic draft: charger le cookie et visualiser la RA.
Sur Prismic contenu de prod: charger le cookie et visualiser la RA.