### PR TITLE
[TECH] Suppression de prismic-edit-button dans les tests

### DIFF
--- a/tests/pages/about.test.js
+++ b/tests/pages/about.test.js
@@ -17,9 +17,7 @@ describe('About Page', () => {
           },
         }),
     })
-    wrapper = await getInitialised('about', {
-      stubs: ['prismic-edit-button'],
-    })
+    wrapper = await getInitialised('about')
   })
   test('mounts properly', () => {
     expect(wrapper.vm).toBeTruthy()

--- a/tests/pages/higher-education.test.js
+++ b/tests/pages/higher-education.test.js
@@ -34,7 +34,7 @@ describe('Higher Education Page', () => {
     })
 
     wrapper = await getInitialised('higher-education', {
-      stubs: ['prismic-edit-button', 'prismic-rich-text', 'pix-link'],
+      stubs: ['prismic-rich-text', 'pix-link'],
       computed: {
         $prismic() {
           return { asText: () => {} }

--- a/tests/pages/index.test.js
+++ b/tests/pages/index.test.js
@@ -17,9 +17,7 @@ describe('Index Page', () => {
           },
         }),
     })
-    wrapper = await getInitialised('index', {
-      stubs: ['prismic-edit-button'],
-    })
+    wrapper = await getInitialised('index')
   })
   test('mounts properly', () => {
     expect(wrapper.vm).toBeTruthy()

--- a/tests/pages/legal-notices.test.js
+++ b/tests/pages/legal-notices.test.js
@@ -23,7 +23,7 @@ describe('Legal Notices Page', () => {
         }),
     })
     wrapper = await getInitialised('legal-notices', {
-      stubs: ['prismic-edit-button', 'prismic-rich-text'],
+      stubs: ['prismic-rich-text'],
     })
   })
   test('mounts properly', () => {

--- a/tests/pages/school-education.test.js
+++ b/tests/pages/school-education.test.js
@@ -21,7 +21,7 @@ describe('School Education Page', () => {
     })
 
     wrapper = await getInitialised('school-education', {
-      stubs: ['prismic-edit-button', 'prismic-rich-text', 'prismic-image'],
+      stubs: ['prismic-rich-text', 'prismic-image'],
     })
   })
   test('mounts properly', () => {

--- a/tests/pages/skills.test.js
+++ b/tests/pages/skills.test.js
@@ -21,7 +21,7 @@ describe('Skills Page', () => {
     })
 
     wrapper = await getInitialised('skills', {
-      stubs: ['prismic-edit-button', 'prismic-rich-text'],
+      stubs: ['prismic-rich-text'],
     })
   })
   test('mounts properly', () => {

--- a/tests/pages/terms-of-service.test.js
+++ b/tests/pages/terms-of-service.test.js
@@ -21,7 +21,7 @@ describe('Terms of Service Page', () => {
     })
 
     wrapper = await getInitialised('terms-of-service', {
-      stubs: ['prismic-edit-button', 'prismic-rich-text'],
+      stubs: ['prismic-rich-text'],
     })
   })
   test('mounts properly', () => {


### PR DESCRIPTION
## :unicorn: Problème
D'après la doc d'upgrade de Prismic https://prismic.io/docs/vuejs/getting-started/the-new-prismic-nuxt-module#19_0-extra-previews-and-edit-buttons, il n'y a plus besoin de déclarer `prismic-edit-button`.

## :robot: Solution
Supprimer ces déclararations dans les tests

## :sparkles: Review App
https://pix-site-integration-pr.scalingo.io
