### PR TITLE
[FEATURE] Rendre la page index contribuable (PIX-1126)

### DIFF
--- a/components/slices/SliceZone.vue
+++ b/components/slices/SliceZone.vue
@@ -45,7 +45,7 @@
         </section-slice>
       </template>
       <template v-if="slice.slice_type === 'features'">
-        <FeaturesSlice :content="slice" />
+        <features-slice :content="slice" />
       </template>
     </section>
   </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -34,10 +34,10 @@ export default {
         if (slice.slice_type === 'hero-banner') {
           slice.slice_type = 'old-banner'
         }
-        if (index === 1 && slice.slice_type === 'section') {
+        if (slice.slice_label === 'demo') {
           slice.slice_type = 'old-demo'
         }
-        if (index === 2 && slice.slice_type === 'section') {
+        if (slice.slice_label === 'features') {
           slice.slice_type = 'old-features'
         }
         return slice


### PR DESCRIPTION
## :unicorn: Problème
La `slice-zone` permettait d'avoir des slices plus flexibles: il était possible de les réordonner, d'en créer et d'en supprimer sans casser les autres environnements de développement *seulement lorsqu'il s'agit de nouveaux slices*.
Concernant les anciens slices, on se base sur leur position. Il est donc impossible de les réordonner par exemple.

## :robot: Solution
Ne plus se baser sur la position des anciens slices:
- ajout de labels sur le bloc `section` de Prismic qui peut prendre `demo`, `features` ou vide.
- lecture de ce `slice_type` côté front pour déterminer le type de slice

## :rainbow: Remarques
- renommage de `FeaturesSlice` dans le template en `features-slice`
- modifier le champs `slice_type` dans le Prismic prod
- lorsque `slice_type` est laissé à vide, le bloc ne s'affiche plus

## :sparkles: Review App
https://pix-site-review-pr152.osc-fr1.scalingo.io
