### PR TITLE
[BUGFIX] Forcer la langue française sur pix.fr.

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -73,7 +73,7 @@ export default {
     '@nuxtjs/axios',
     '@nuxtjs/dotenv',
     '@nuxtjs/style-resources',
-    'nuxt-i18n',
+    ['nuxt-i18n', { detectBrowserLanguage: false }],
     '@nuxtjs/moment',
     ['nuxt-matomo', { matomoUrl: 'https://stats.pix.fr/', siteId: 1 }],
     [


### PR DESCRIPTION
## :unicorn: Problème
Sur le navigateur Edge, la première fois qu'un utilisateur se rend sur `https://pix.fr`, il est redirigé sur `https://pix.fr/en-gb`.
Le site est alors bien en français, mais si on choisit de se connecter ou créer un compte, on est redirigé sur `app.pix.org`, en langue anglaise.
On devrait toujours être redirigé sur `app.pix.fr`, et rester en langue française.

## :robot: Solution
La détection de la langue lors de la première connexion est faite par le plugin `nuxt-i18n`.
Il faut désactiver la détection avec l'option `detectBrowserLanguage` à `false`. (cf https://i18n.nuxtjs.org/options-reference)

## :rainbow: Remarques
Aucune idée de pourquoi le pb n'existe que sur Edge.

## :sparkles: Review App
https://site-pr153.review.pix.fr
