### PR TITLE
[BUGFIX] Fix le titre et les bullets points de la liste du slice article (PIX-1190)

### DIFF
--- a/components/slices/Article.vue
+++ b/components/slices/Article.vue
@@ -264,17 +264,13 @@ export default {
     }
   }
 
-  &__title {
-    height: 46px;
-
-    & h2 {
-      color: $blue-5;
-      font-size: 2rem;
-      font-weight: $font-normal;
-      letter-spacing: 0.00875rem;
-      line-height: 2.875rem;
-      margin-top: 0;
-    }
+  &__title h2 {
+    color: $blue-5;
+    font-size: 2rem;
+    font-weight: $font-normal;
+    letter-spacing: 0.00875rem;
+    line-height: 2.875rem;
+    margin-top: 0;
   }
 }
 </style>

--- a/components/slices/Article.vue
+++ b/components/slices/Article.vue
@@ -232,9 +232,18 @@ export default {
 .article-content {
   &__description {
     margin: 16px 0 24px 0;
+    color: $grey-10;
+
+    ul {
+      list-style: none;
+      padding: 0;
+
+      li:before {
+        color: $grey-10;
+      }
+    }
 
     & p {
-      color: $grey-10;
       font-size: 1.25rem;
       font-weight: $font-normal;
       letter-spacing: 0;


### PR DESCRIPTION
## :unicorn: Problème
- Lorsque le titre du slice article est trop long et passe sur deux lignes, alors il se superpose avec le texte en dessous
- Lorsque l'on spécifie une liste avec des bullets points sur Prismic, il s'affiche deux bullets points à la suite sur l'application

## :robot: Solution
- Supprimer la hauteur du titre pour éviter la superposition
- Les bullets points sont spécifié à la fois sur le `ul` et le `li`: ceux sur le `ul` sont supprimés.

## :rainbow: Remarques
Un style sur les bullets points dans `globals.scss` les imposent en bleu. Il a fallu les surcharger ici pour les avoir de la même couleurs que le texte de la liste.

## :sparkles: Review App
https://pix-site-review-pr154.osc-fr1.scalingo.io
