### PR TITLE
[BUGFIX] Fix les warnings console sur Firefox (PIX-1231)

### DIFF
--- a/components/slices/Features.vue
+++ b/components/slices/Features.vue
@@ -3,7 +3,7 @@
     <prismic-rich-text v-if="hasTitle" class="features__title" :field="title" />
     <div class="features__wrapper" :style="[background]">
       <div
-        v-for="(featuresInARow, rowIndex) in featuresByRow()"
+        v-for="(featuresInARow, rowIndex) in featuresByRow"
         :key="`item-${rowIndex}`"
         class="features-wrapper__row"
       >
@@ -43,6 +43,11 @@ export default {
       default: null,
     },
   },
+  data() {
+    return {
+      featuresByRow: [],
+    }
+  },
   computed: {
     background() {
       return {
@@ -64,8 +69,11 @@ export default {
       return this.slice.primary.features_title
     },
   },
+  mounted() {
+    this.featuresByRow = this.splitFeaturesIntoRows()
+  },
   methods: {
-    nbFeaturesInRow() {
+    findNbFeaturesInRow() {
       if (process.client) {
         const isExtraLargeScreen = screen.width >= EXTRA_LARGE_SCREEN_MIN_WIDTH
         const isDesktopScreen = screen.width <= DESKTOP_MIN_WIDTH
@@ -81,9 +89,9 @@ export default {
 
       return 3
     },
-    featuresByRow() {
+    splitFeaturesIntoRows() {
       const rows = []
-      const chunkSize = this.nbFeaturesInRow()
+      const chunkSize = this.findNbFeaturesInRow()
       for (let i = 0; i < this.paragraphs.length; i += chunkSize) {
         rows.push(this.paragraphs.slice(i, i + chunkSize))
       }


### PR DESCRIPTION
## :unicorn: Problème
Le bloc features généraient des warnings sur Firefox:
![image](https://user-images.githubusercontent.com/11294487/92252645-d1473580-eece-11ea-8ca7-9602fb9c7264.png)

## :robot: Solution
Cela est dû à la modification du DOM a posteriori (depuis la méthode `featuresByRow`).
Les modifications sont désormais faites une seule fois, dans le `mounted`.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :sparkles: Review App
https://pix-site-review-pr163.osc-fr1.scalingo.io
