### PR TITLE
[FEATURE] Deployer pix-pro sur les reviews app (PIX-1263)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,4 @@
 
 ## :sparkles: Review App
 https://site-pr000.review.pix.fr/
+https://pro-pr000.review.pix.fr/

--- a/README.md
+++ b/README.md
@@ -38,15 +38,12 @@ Domain name for `.org` extension.
 # install dependencies
 $ npm run install
 
-# serve with hot reload at localhost:3000
-$ npm run dev
+# serve with hot reload at localhost:5000
+$ npm run dev:site
 
 # build for production and launch server
-$ npm run build
-$ npm run start
-
-# generate static project
-$ npm run generate
+$ npm run build:site
+$ npm run start:site
 ```
 
 ## Build Setup pix-pro
@@ -55,15 +52,32 @@ $ npm run generate
 # install dependencies
 $ npm run install
 
-# serve with hot reload at localhost:3000
+# serve with hot reload at localhost:5000
 $ npm run dev:pro
 
 # build for production and launch server
 $ npm run build:pro
 $ npm run start:pro
+```
 
-# generate static project
-$ npm run generate
+
+## Build Setup sur Scalingo
+
+```bash
+# install dependencies
+$ npm run install
+
+# build for production and launch server
+$ npm run build
+$ npm run start
+```
+
+La variable d'environnement `SITE` doit être assignée en fonction du site à déployer
+
+```bash
+SITE=pix-site
+# ou
+SITE=pix-pro
 ```
 
 ## Conventions de nommage

--- a/package.json
+++ b/package.json
@@ -16,15 +16,17 @@
   "scripts": {
     "clean": "rm -rf node_modules .nuxt",
     
-    "dev": "SITE=pix-site nuxt",
-    "build": "SITE=pix-site nuxt build",
-    "start": "SITE=pix-site nuxt start",
+    "build": "nuxt build",
+    "start": "nuxt start",
+
+    "dev:site": "SITE=pix-site nuxt",
+    "build:site": "SITE=pix-site nuxt build",
+    "start:site": "SITE=pix-site nuxt start",
     
     "dev:pro": "SITE=pix-pro nuxt",
     "build:pro": "SITE=pix-pro nuxt build",
     "start:pro": "SITE=pix-pro nuxt start",
 
-    "generate": "nuxt generate",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "test": "SITE=pix-site jest --no-coverage",
     "release": "npm run release:minor",


### PR DESCRIPTION
## :unicorn: Problème
Nous avons besoin de déployer pix-pro sur les reviews app

## :robot: Solution
- Ajout de la variable d'environnement `SITE` sur les review app `pix-site-review` et `pix-pro-review` sur scalingo.

- Modification du `package.json` pour avoir des commandes distinctes en fonction d'environnement et de l'application:

Par exemple:

```bash
npm run build # build l'application en fonction de la variable d'environnement SITE définie

npm run build:site  # build l'application pix-site (variable SITE pré-définie)

npm run build:pro  # build l'application pix-pro (variable SITE pré-définie)
```

- Modification du template de pull request pour prendre en compte pix-pro (le pix-review-router n'a pas encore été modifié)

## :rainbow: Remarques
RAS

## :sparkles: Review App

Pour tester. 

Vous devez voir pix-site ici: https://site-pr173.review.pix.fr/
Vous devez voir pix-pro ici: https://pix-pro-review-pr173.osc-fr1.scalingo.io/
