### PR TITLE
[CLEANUP] Ajout d'un component PixImage au dessus du PrismicImage (PIX-1323).

### DIFF
--- a/components/PixImage.vue
+++ b/components/PixImage.vue
@@ -1,0 +1,26 @@
+<template>
+  <prismic-image :field="image" :role="image.role" />
+</template>
+
+<script>
+export default {
+  name: 'PixImage',
+  props: {
+    field: {
+      required: true,
+      type: Object,
+      default: null,
+    },
+  },
+  computed: {
+    image() {
+      const image = Object.assign({}, this.field)
+      if (!image.alt) {
+        image.alt = ''
+        image.role = 'presentation'
+      }
+      return image
+    },
+  },
+}
+</script>

--- a/components/slices/Article.vue
+++ b/components/slices/Article.vue
@@ -43,12 +43,12 @@
           </pix-link>
         </div>
       </div>
-      <prismic-image
+      <pix-image
         v-if="containsTextAndImage && content.article_background.url"
         :field="content.article_background"
         class="article__secondary-content article-secondary-content__background"
       />
-      <prismic-image
+      <pix-image
         v-if="containsTextAndImage"
         :field="content.article_image"
         class="article__secondary-content article-secondary-content__image"

--- a/components/slices/Features.vue
+++ b/components/slices/Features.vue
@@ -12,7 +12,7 @@
           :key="`item-${featureIndex}`"
           class="features-wrapper__item"
         >
-          <prismic-image :field="feature.feature_image" />
+          <pix-image :field="feature.feature_image" />
           <div>
             <prismic-rich-text
               class="features-wrapper-item__title"

--- a/components/slices/ImgTextColumn.vue
+++ b/components/slices/ImgTextColumn.vue
@@ -2,7 +2,7 @@
   <section :class="sectionClass">
     <div :class="containerClass">
       <div v-if="hasImage" class="column">
-        <prismic-image :field="image" />
+        <pix-image :field="image" />
       </div>
       <div class="column">
         <prismic-rich-text :field="title" />

--- a/components/slices/LogosZone.vue
+++ b/components/slices/LogosZone.vue
@@ -6,9 +6,9 @@
       class="logos-zone__content"
     >
       <pix-link v-if="hasLink(logo)" :field="logo.url">
-        <prismic-image :field="logo.image" />
+        <pix-image :field="logo.image" />
       </pix-link>
-      <prismic-image v-else :field="logo.image" />
+      <pix-image v-else :field="logo.image" />
     </div>
   </div>
 </template>

--- a/components/slices/PageBanner.vue
+++ b/components/slices/PageBanner.vue
@@ -39,7 +39,7 @@
           </div>
         </div>
       </div>
-      <prismic-image
+      <pix-image
         v-if="hasImage"
         :field="imageUrl"
         class="row-block__side-content"

--- a/components/slices/PageSection.vue
+++ b/components/slices/PageSection.vue
@@ -3,7 +3,7 @@
     <div class="background"></div>
     <div :class="containerClass">
       <template v-if="hasImage">
-        <prismic-image :field="image" />
+        <pix-image :field="image" />
       </template>
       <prismic-rich-text :field="title" />
       <prismic-rich-text :field="description" />

--- a/components/slices/SectionColumn.vue
+++ b/components/slices/SectionColumn.vue
@@ -17,7 +17,7 @@
       </div>
       <div class="container-column">
         <div v-if="hasImage" :class="rightClass">
-          <prismic-image :field="image"></prismic-image>
+          <pix-image :field="image" />
         </div>
       </div>
     </div>

--- a/plugins/components.js
+++ b/plugins/components.js
@@ -1,4 +1,6 @@
 import Vue from 'vue'
 import PixLink from '@/components/PixLink'
+import PixImage from '@/components/PixImage'
 
 Vue.component('PixLink', PixLink)
+Vue.component('PixImage', PixImage)

--- a/tests/components/PixImage.test.js
+++ b/tests/components/PixImage.test.js
@@ -1,0 +1,56 @@
+import { shallowMount } from '@vue/test-utils'
+import PixImage from '~/components/PixImage'
+
+describe('Component: PixImage', () => {
+  let component
+
+  beforeEach(() => {
+    component = shallowMount(PixImage, {
+      stubs: { 'prismic-image': true },
+      props: { field: {} },
+    })
+  })
+
+  describe('Computed Property : Image', () => {
+    it('should return the same image object if there is an alt', () => {
+      // Given
+      const imageWithAlt = {
+        alt: 'Alternative Message',
+        copyright: null,
+        dimension: {
+          height: 345,
+          width: 453,
+        },
+        url: 'https://url.fr',
+      }
+
+      // When
+      component.setProps({ field: imageWithAlt })
+
+      // Then
+      expect(component.vm.image).toEqual(imageWithAlt)
+    })
+
+    it('should return the image object with empty alt and role when there is not alt', () => {
+      // Given
+      const imageWithoutAlt = {
+        alt: null,
+        copyright: null,
+        dimension: {
+          height: 345,
+          width: 453,
+        },
+        url: 'https://url.fr',
+      }
+      const expectedImage = Object.assign({}, imageWithoutAlt)
+      expectedImage.alt = ''
+      expectedImage.role = 'presentation'
+
+      // When
+      component.setProps({ field: imageWithoutAlt })
+
+      // Then
+      expect(component.vm.image).toEqual(expectedImage)
+    })
+  })
+})


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'aucun `alt` n'est précisé sur une image, le composant PrismicImage ne met pas de valeurs vide pour `alt`.

## :robot: Solution
Ajout d'un nouveau composant `PixImage`, qui passe les informations dans un `PrismicImage`. Si l'image à afficher n'a pas de texte alternative, elle en met un vide et ajoute le rôle "présentation", utile pour préciser que ce n'est que visuel.

## :rainbow: Remarques
- Cela permet de s'assurer que les Alt sont correctes

## :sparkles: Review App
https://site-pr176.review.pix.fr/
https://pro-pr176.review.pix.fr/
