### PR TITLE
[FEATURE] Création du bloc process (PIX-1198).

### DIFF
--- a/components/SliceZone.vue
+++ b/components/SliceZone.vue
@@ -50,11 +50,15 @@
       <template v-if="slice.slice_type === 'article'">
         <article-slice :slice="slice" :button-class="'section-demo__button'" />
       </template>
+      <template v-if="slice.slice_type === 'process'">
+        <process-slice :slice="slice" />
+      </template>
     </section>
   </div>
 </template>
 
 <script>
+import ProcessSlice from '@/components/slices/Process'
 import PageBanner from '@/components/slices/PageBanner'
 import ArticleSlice from '@/components/slices/Article'
 import HeroBanner from '@/components/slices/HeroBanner'
@@ -77,6 +81,7 @@ export default {
     PageSection,
     WebSnippet,
     FeaturesSlice,
+    ProcessSlice,
   },
   props: {
     slices: {

--- a/components/slices/Process.vue
+++ b/components/slices/Process.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="process">
+  <section class="process" :style="[background]">
     <prismic-rich-text
       v-if="hasTitle && shouldDisplayTitle"
       class="process__title"
@@ -62,6 +62,11 @@ export default {
     }
   },
   computed: {
+    background() {
+      return {
+        backgroundColor: `${this.slice.primary.process_background_color}`,
+      }
+    },
     items() {
       return this.slice.items
     },

--- a/components/slices/Process.vue
+++ b/components/slices/Process.vue
@@ -135,3 +135,208 @@ export default {
   },
 }
 </script>
+
+<style lang="scss">
+.process {
+  &__title h2 {
+    font-size: 2rem;
+    font-weight: $font-normal;
+    height: 49px;
+    letter-spacing: 0.009rem;
+    line-height: 49px;
+    text-align: center;
+    margin-top: 24px;
+    margin-bottom: 48px;
+  }
+
+  &__subtitle h3 {
+    position: relative;
+    top: 24px;
+    font-size: 1rem;
+    font-weight: $font-light;
+    height: 49px;
+    letter-spacing: 0.009rem;
+    line-height: 49px;
+    text-align: center;
+  }
+
+  &__wrapper {
+    padding: 48px 32px;
+  }
+
+  &-wrapper__row {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    margin-bottom: 24px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &-wrapper__item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 24px;
+    width: 293px;
+    padding: 24px;
+    box-shadow: 0 24px 32px 0 rgba($black, 0.03),
+      0 8px 32px 0 rgba($black, 0.06);
+    border-radius: 20px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    img {
+      height: 51px;
+      width: 51px;
+    }
+
+    p {
+      margin: 0;
+    }
+  }
+
+  &-wrapper-item {
+    &__title h1 {
+      width: 175px;
+      color: $grey-1;
+      font-size: 1.25rem;
+      letter-spacing: 0;
+      line-height: 30px;
+      font-weight: $font-semi-bold;
+      margin: 0 8px 16px 24px;
+    }
+
+    &__description {
+      width: 175px;
+      color: $grey-6;
+      font-size: 0.875rem;
+      letter-spacing: 0.009rem;
+      line-height: 22px;
+      margin-left: 24px;
+    }
+  }
+}
+
+@include device-is('tablet') {
+  .process {
+    &__title h1 {
+      margin-top: 60px;
+    }
+
+    &__subtitle h3 {
+      top: 0;
+      margin-bottom: 48px;
+    }
+
+    &__wrapper {
+      flex-direction: row;
+      padding: 80px 0;
+    }
+  }
+
+  .process-wrapper__item {
+    margin-bottom: 40px;
+
+    div:first-of-type {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    img {
+      margin-bottom: 24px;
+    }
+  }
+}
+
+@include device-is('desktop') {
+  .process {
+    &__title h1 {
+      margin-top: 60px;
+    }
+
+    &__wrapper {
+      padding: 80px 0 84px;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-around;
+    }
+  }
+
+  .process-wrapper {
+    &__row {
+      flex-direction: row;
+      justify-content: center;
+      align-items: baseline;
+    }
+
+    &__item {
+      padding: 32px 24px 56px 24px;
+      height: 273px;
+
+      display: block;
+      margin-right: 56px;
+      margin-bottom: 0;
+      text-align: center;
+      height: 100%;
+
+      img {
+        margin-right: 0;
+      }
+    }
+  }
+
+  .process-wrapper-item {
+    &__title h1 {
+      width: 245px;
+      font-size: 1.25rem;
+      margin-left: 0;
+    }
+
+    &__description {
+      margin-top: 8px;
+      width: 245px;
+      margin-left: 0;
+    }
+  }
+}
+
+@include device-is('large-screen') {
+  .process__wrapper {
+    padding: 0 98px 60px 98px;
+    width: 100%;
+    display: flex;
+    align-items: stretch;
+    flex-wrap: wrap;
+    justify-content: space-around;
+  }
+
+  .process-wrapper__item {
+    max-width: 293px;
+    padding: 32px 24px 50px 24px;
+    text-align: center;
+    height: 100%;
+
+    img {
+      height: 51px;
+      width: 51px;
+    }
+
+    &:last-of-type {
+      margin-right: 0;
+    }
+  }
+
+  .process-wrapper-item {
+    &__description {
+      margin-top: 8px;
+      width: 245px;
+    }
+  }
+}
+</style>

--- a/components/slices/Process.vue
+++ b/components/slices/Process.vue
@@ -90,16 +90,19 @@ export default {
         const isExtraLargeScreen =
           document.body.clientWidth >= EXTRA_LARGE_SCREEN_MIN_WIDTH
 
+        if (this.items.length === 3 && isLargeScreen) {
+          return 3
+        }
         if (this.items.length === 4) {
-          if (isExtraLargeScreen && !this.hasTitle) {
+          if (isExtraLargeScreen) {
             return 4
-          } else if (isLargeScreen && this.hasTitle) {
-            return 2
+          }
+          if (isLargeScreen) {
+            return 3
           }
         }
+        return 2
       }
-
-      return 3
     },
     splitItemsIntoRows() {
       const rows = []

--- a/components/slices/Process.vue
+++ b/components/slices/Process.vue
@@ -5,6 +5,7 @@
       class="process__title"
       :field="title"
     />
+    <prismic-rich-text v-else class="sr-only" :field="title" />
     <prismic-rich-text
       v-if="shouldUseSubtitle && hasSubtitle"
       class="process__subtitle"

--- a/components/slices/Process.vue
+++ b/components/slices/Process.vue
@@ -1,0 +1,114 @@
+<template>
+  <section class="process">
+    <prismic-rich-text v-if="hasTitle" class="process__title" :field="title" />
+    <prismic-rich-text
+      v-if="hasSubtitle"
+      class="process__subtitle"
+      :field="subtitle"
+    />
+    <div class="process__wrapper">
+      <div
+        v-for="(itemsByRow, rowIndex) in rows"
+        :key="`row-${rowIndex}`"
+        class="process-wrapper__row"
+      >
+        <div
+          v-for="(item, itemIndex) in itemsByRow"
+          :key="`item-${itemIndex}`"
+          class="process-wrapper__item"
+        >
+          <pix-image :field="item.item_image" />
+          <div>
+            <prismic-rich-text
+              class="process-wrapper-item__title"
+              :field="item.item_title"
+            />
+            <prismic-rich-text
+              class="process-wrapper-item__description"
+              :field="item.item_description"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script>
+import {
+  EXTRA_LARGE_SCREEN_MIN_WIDTH,
+  DESKTOP_MIN_WIDTH,
+} from '~/config/breakpoints'
+import PixImage from '@/components/PixImage'
+
+export default {
+  name: 'ProcessSlice',
+  components: {
+    PixImage,
+  },
+  props: {
+    slice: {
+      type: Object,
+      default: null,
+    },
+  },
+  data() {
+    return {
+      rows: [],
+    }
+  },
+  computed: {
+    items() {
+      return this.slice.items
+    },
+    hasTitle() {
+      return (
+        this.slice.primary.process_title &&
+        this.slice.primary.process_title.length
+      )
+    },
+    hasSubtitle() {
+      return (
+        this.slice.primary.process_subtitle &&
+        this.slice.primary.process_subtitle.length
+      )
+    },
+    title() {
+      return this.slice.primary.process_title
+    },
+    subtitle() {
+      return this.slice.primary.process_subtitle
+    },
+  },
+  mounted() {
+    this.rows = this.splitItemsIntoRows()
+  },
+  methods: {
+    findNbItemsInRow() {
+      if (process.client) {
+        const isLargeScreen = document.body.clientWidth >= DESKTOP_MIN_WIDTH
+        const isExtraLargeScreen =
+          document.body.clientWidth >= EXTRA_LARGE_SCREEN_MIN_WIDTH
+
+        if (this.items.length === 4) {
+          if (isExtraLargeScreen && !this.hasTitle) {
+            return 4
+          } else if (isLargeScreen && this.hasTitle) {
+            return 2
+          }
+        }
+      }
+
+      return 3
+    },
+    splitItemsIntoRows() {
+      const rows = []
+      const chunkSize = this.findNbItemsInRow()
+      for (let i = 0; i < this.items.length; i += chunkSize) {
+        rows.push(this.items.slice(i, i + chunkSize))
+      }
+      return rows
+    },
+  },
+}
+</script>

--- a/components/slices/Process.vue
+++ b/components/slices/Process.vue
@@ -15,21 +15,18 @@
       <div
         v-for="(itemsByRow, rowIndex) in rows"
         :key="`row-${rowIndex}`"
-        class="process-wrapper__row"
+        class="wrapper__row"
       >
         <div
           v-for="(item, itemIndex) in itemsByRow"
           :key="`item-${itemIndex}`"
-          class="process-wrapper__item"
+          class="wrapper__item"
         >
           <pix-image v-if="hasImage(item)" :field="item.item_image" />
           <div>
+            <prismic-rich-text class="item__title" :field="item.item_title" />
             <prismic-rich-text
-              class="process-wrapper-item__title"
-              :field="item.item_title"
-            />
-            <prismic-rich-text
-              class="process-wrapper-item__description"
+              class="item__description"
               :field="item.item_description"
             />
           </div>
@@ -164,8 +161,10 @@ export default {
   &__wrapper {
     padding: 48px 32px;
   }
+}
 
-  &-wrapper__row {
+.wrapper {
+  &__row {
     display: flex;
     align-items: center;
     flex-direction: column;
@@ -176,7 +175,7 @@ export default {
     }
   }
 
-  &-wrapper__item {
+  &__item {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -200,26 +199,26 @@ export default {
       margin: 0;
     }
   }
+}
 
-  &-wrapper-item {
-    &__title h1 {
-      width: 175px;
-      color: $grey-1;
-      font-size: 1.25rem;
-      letter-spacing: 0;
-      line-height: 30px;
-      font-weight: $font-semi-bold;
-      margin: 0 8px 16px 24px;
-    }
+.item {
+  &__title h1 {
+    width: 175px;
+    color: $grey-1;
+    font-size: 1.25rem;
+    letter-spacing: 0;
+    line-height: 30px;
+    font-weight: $font-semi-bold;
+    margin: 0 8px 16px 24px;
+  }
 
-    &__description {
-      width: 175px;
-      color: $grey-6;
-      font-size: 0.875rem;
-      letter-spacing: 0.009rem;
-      line-height: 22px;
-      margin-left: 24px;
-    }
+  &__description {
+    width: 175px;
+    color: $grey-6;
+    font-size: 0.875rem;
+    letter-spacing: 0.009rem;
+    line-height: 22px;
+    margin-left: 24px;
   }
 }
 
@@ -240,7 +239,7 @@ export default {
     }
   }
 
-  .process-wrapper__item {
+  .wrapper__item {
     margin-bottom: 40px;
 
     div:first-of-type {
@@ -269,7 +268,7 @@ export default {
     }
   }
 
-  .process-wrapper {
+  .wrapper {
     &__row {
       flex-direction: row;
       justify-content: center;
@@ -277,6 +276,10 @@ export default {
     }
 
     &__item {
+      &:first-of-type {
+        margin-left: 56px;
+      }
+
       padding: 32px 24px 56px 24px;
       height: 273px;
 
@@ -292,7 +295,7 @@ export default {
     }
   }
 
-  .process-wrapper-item {
+  .item {
     &__title h1 {
       width: 245px;
       font-size: 1.25rem;
@@ -317,23 +320,29 @@ export default {
     justify-content: space-around;
   }
 
-  .process-wrapper__item {
-    max-width: 293px;
-    padding: 32px 24px 50px 24px;
-    text-align: center;
-    height: 100%;
+  .wrapper {
+    &__item {
+      &:first-of-type {
+        margin-left: 0;
+      }
 
-    img {
-      height: 51px;
-      width: 51px;
-    }
+      max-width: 293px;
+      padding: 32px 24px 50px 24px;
+      text-align: center;
+      height: 100%;
 
-    &:last-of-type {
-      margin-right: 0;
+      img {
+        height: 51px;
+        width: 51px;
+      }
+
+      &:last-of-type {
+        margin-right: 0;
+      }
     }
   }
 
-  .process-wrapper-item {
+  .item {
     &__description {
       margin-top: 8px;
       width: 245px;

--- a/components/slices/Process.vue
+++ b/components/slices/Process.vue
@@ -1,8 +1,12 @@
 <template>
   <section class="process">
-    <prismic-rich-text v-if="hasTitle" class="process__title" :field="title" />
     <prismic-rich-text
-      v-if="hasSubtitle"
+      v-if="hasTitle && shouldDisplayTitle"
+      class="process__title"
+      :field="title"
+    />
+    <prismic-rich-text
+      v-if="shouldUseSubtitle && hasSubtitle"
       class="process__subtitle"
       :field="subtitle"
     />
@@ -17,7 +21,7 @@
           :key="`item-${itemIndex}`"
           class="process-wrapper__item"
         >
-          <pix-image :field="item.item_image" />
+          <pix-image v-if="hasImage(item)" :field="item.item_image" />
           <div>
             <prismic-rich-text
               class="process-wrapper-item__title"
@@ -61,16 +65,22 @@ export default {
     items() {
       return this.slice.items
     },
+    shouldDisplayTitle() {
+      return this.slice.primary.process_should_display_title
+    },
+    shouldUseSubtitle() {
+      return this.slice.primary.process_should_use_subtitle
+    },
     hasTitle() {
       return (
-        this.slice.primary.process_title &&
-        this.slice.primary.process_title.length
+        this.slice.primary.process_title.length &&
+        this.slice.primary.process_title[0].text.length
       )
     },
     hasSubtitle() {
       return (
-        this.slice.primary.process_subtitle &&
-        this.slice.primary.process_subtitle.length
+        this.slice.primary.process_subtitle.length &&
+        this.slice.primary.process_subtitle[0].text.length
       )
     },
     title() {
@@ -84,6 +94,11 @@ export default {
     this.rows = this.splitItemsIntoRows()
   },
   methods: {
+    hasImage(item) {
+      const isLengthDifferentThanZero = Object.keys(item.item_image).length
+      const isObjectConstructor = item.item_image.constructor === Object
+      return isLengthDifferentThanZero && isObjectConstructor
+    },
     findNbItemsInRow() {
       if (process.client) {
         const isLargeScreen = document.body.clientWidth >= DESKTOP_MIN_WIDTH


### PR DESCRIPTION
## :unicorn: Problème

Afin de rendre contribuable Pix-site, il nous faut ajouter un bloc process dont vous pourrez trouver les maquettes en cliquant sur le lien suivant : [maquettes](https://app.abstract.com/projects/c43b8749-ba3a-474e-a6c5-dbf76bade2ee/branches/e48d3386-0273-4049-8e2e-e05e78f59cb1/collections/dcbe584c-df39-4589-afd7-5842712713f6)

## :robot: Solution

- Création d'un nouveau Custom-Type sur Prismic importé sur le document **Index**
- Création d'un nouveau composant Vue sur Pix-site

## :rainbow: Remarques

:eyes: Afin d'améliorer la structure et donc l'accessibilité du site, et de la même manière que sur ce [ticket](https://1024pix.atlassian.net/secure/RapidBoard.jspa?rapidView=33&projectKey=PIX&modal=detail&selectedIssue=PIX-1309), il a été ajouté en dernier commit à cette PR la possibilité sur Prismic d'afficher les différents titres et sous-titres du bloc au travers d'un dropdown : 

- Affichage dans le cas du titre (car obligatoire et Prismic ne permet à priori pas de rendre un field obligatoire) [Doc officielle](https://prismic.io/blog/required-fields)
- Usage dans le cas du sous-titre (non demandé dans le cadre du bloc process mais utile pour un bloc ultérieur)

<img width="431" alt="Capture d’écran 2020-09-30 à 22 06 46" src="https://user-images.githubusercontent.com/36371437/94734296-4dffef00-0369-11eb-86c8-091e2597af89.png">

---- 

 :no_entry: Le système de flexbox, utilisé par le bloc features et sur lequel se base le bloc process pour la gestion du nombre de cards à rendre par ligne dans les formats tablettes et lorsque les cards ne rentrent pas sur une seule ligne au format desktop, ne permet pas de gérer la hauteur de lignes différentes.

----

Ainsi, les cards de deux lignes différentes pourront ne pas avoir la même taille en fonction de leur contenu mais seront toutefois de la même taille sur leurs lignes respectives.

:no_entry: Nous pouvons noter également une différence de breakpoints au nombre de 3 dans le SCSS global, contre 4 pour les maquettes et dorénavant pour Pix-Site (si validation de la modif de ce fichier dans cette PR)

--> Possibilité d'envisager d'aligner les breakpoints entre le CSS et l'UX/UI ? 

## :sparkles: Review App

https://site-pr179.review.pix.fr/
https://pro-pr179.review.pix.fr/
