### PR TITLE
[FEATURE] Modification du titre du bloc pour structure de page et a11y (PIX-1309)

### DIFF
--- a/components/slices/Features.vue
+++ b/components/slices/Features.vue
@@ -1,6 +1,11 @@
 <template>
   <section class="features">
-    <prismic-rich-text v-if="hasTitle" class="features__title" :field="title" />
+    <prismic-rich-text
+      v-if="shouldDisplayTitle && hasTitle"
+      class="features__title"
+      :field="title"
+    />
+    <prismic-rich-text v-else class="sr-only" :field="title" />
     <div class="features__wrapper" :style="[background]">
       <div
         v-for="(featuresInARow, rowIndex) in featuresByRow"
@@ -56,6 +61,9 @@ export default {
     },
     paragraphs() {
       return this.slice.items
+    },
+    shouldDisplayTitle() {
+      return this.slice.primary.features_should_display_title
     },
     hasTitle() {
       return (


### PR DESCRIPTION
## :unicorn: Problème

Actuellement le bloc Feature a un titre qui s'affiche seulement s'il existe.

Objectif : 
Le bloc Feature doit TOUJOURS avoir un titre, visible ou non. 
En effet, sans le titre du bloc Feature, il peut y avoir des problèmes de structure de page. 
Il faut donc que l'utilisateur puisse choisir si le titre est visible ou non.

## :robot: Solution

- Ajout d'un champ de sélection dans Prismic antérieur au titre pour demander si le titre doit être visible ou non.
- Ajout d'une condition au rendu avec un nouveau champ titre uniquement visible si le titre doit être masqué.

## :rainbow: Remarques

Afin de ne pas faire de repasse ultérieure sur le code, nous privilégions l'utilisation d'un nouveau composant `prismic-rich-text` en lieu et place d'un `h2`, dans l'éventualité où la team contenu souhaiterait modifier la balise du champ titre d'origine (par exemple remplacer `h2` par `h3`).

## :sparkles: Review App
https://site-pr181.review.pix.fr/
https://pro-pr181.review.pix.fr/
