### PR TITLE
[FIX] Correction des instructions d'installation des dépendances dans le README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Domain name for `.org` extension.
 
 ```bash
 # install dependencies
-$ npm run install
+$ npm install
 
 # serve with hot reload at localhost:5000
 $ npm run dev:site
@@ -50,7 +50,7 @@ $ npm run start:site
 
 ```bash
 # install dependencies
-$ npm run install
+$ npm install
 
 # serve with hot reload at localhost:5000
 $ npm run dev:pro
@@ -65,7 +65,7 @@ $ npm run start:pro
 
 ```bash
 # install dependencies
-$ npm run install
+$ npm install
 
 # build for production and launch server
 $ npm run build


### PR DESCRIPTION
## :unicorn: Problème
Les instructions pour installer les dépendances de pix-site étaient erronées.
Il est indiqué de faire `npm run install`

## :robot: Solution
Corriger par `npm install` partout où nécessaire

## :rainbow: Remarques

## :sparkles: Review App
https://site-pr000.review.pix.fr/
https://pro-pr000.review.pix.fr/
