### PR TITLE
[BUGFIX] La navigation ne s'affiche correctement sur les écrans intermédiaire. 

### DIFF
--- a/components/slices/NavigationZone.vue
+++ b/components/slices/NavigationZone.vue
@@ -134,6 +134,7 @@ class Navigation {
       line-height: 22px;
       padding: 0 10px 10px 10px;
       cursor: pointer;
+      white-space: nowrap;
 
       &.current-active-link {
         border-bottom: 2px solid $blue-1;


### PR DESCRIPTION
## :unicorn: Problème
La navigation ne s'affiche pas correctement sur les petits écrans.
<img width="1288" alt="Screenshot 2020-10-06 at 14 38 53" src="https://user-images.githubusercontent.com/26384707/95202481-aa3b9680-07e1-11eb-9d3f-3be19a2db9d0.png">


## :robot: Solution
Ajouter la propriété : `white-space: nowrap;` aux éléments de la navigation
<img width="1292" alt="Screenshot 2020-10-06 at 14 40 23" src="https://user-images.githubusercontent.com/26384707/95202641-e111ac80-07e1-11eb-89ae-5bcfeea584b0.png">

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :sparkles: Review App
https://site-pr184.review.pix.fr/
https://pro-pr184.review.pix.fr/

