### PR TITLE
[FEATURE] Ajouter un nouveau slice logos (PIX-1199).

### DIFF
--- a/components/SliceZone.vue
+++ b/components/SliceZone.vue
@@ -53,6 +53,9 @@
       <template v-if="slice.slice_type === 'process'">
         <process-slice :slice="slice" />
       </template>
+      <template v-if="slice.slice_type === 'logos'">
+        <logos-slice :slice="slice" />
+      </template>
     </section>
   </div>
 </template>
@@ -68,6 +71,7 @@ import PopInCampaigns from '@/components/slices/PopInCampaigns'
 import PageSection from '@/components/slices/PageSection'
 import WebSnippet from '@/components/slices/WebSnippet'
 import FeaturesSlice from '@/components/slices/Features'
+import LogosSlice from '@/components/slices/Logos'
 
 export default {
   name: 'SliceZone',
@@ -82,6 +86,7 @@ export default {
     WebSnippet,
     FeaturesSlice,
     ProcessSlice,
+    LogosSlice,
   },
   props: {
     slices: {

--- a/components/SliceZone.vue
+++ b/components/SliceZone.vue
@@ -53,8 +53,8 @@
       <template v-if="slice.slice_type === 'process'">
         <process-slice :slice="slice" />
       </template>
-      <template v-if="slice.slice_type === 'logos'">
-        <logos-slice :slice="slice" />
+      <template v-if="slice.slice_type === 'partners_logos'">
+        <partners-logos-slice :slice="slice" />
       </template>
     </section>
   </div>
@@ -71,7 +71,7 @@ import PopInCampaigns from '@/components/slices/PopInCampaigns'
 import PageSection from '@/components/slices/PageSection'
 import WebSnippet from '@/components/slices/WebSnippet'
 import FeaturesSlice from '@/components/slices/Features'
-import LogosSlice from '@/components/slices/Logos'
+import PartnersLogosSlice from '@/components/slices/PartnersLogos'
 
 export default {
   name: 'SliceZone',
@@ -86,7 +86,7 @@ export default {
     WebSnippet,
     FeaturesSlice,
     ProcessSlice,
-    LogosSlice,
+    PartnersLogosSlice,
   },
   props: {
     slices: {

--- a/components/slices/Logos.vue
+++ b/components/slices/Logos.vue
@@ -6,7 +6,7 @@
       :field="title"
     />
     <prismic-rich-text v-else class="sr-only" :field="title" />
-    <div class="wrapper">
+    <div class="logos__wrapper">
       <div
         v-for="(item, itemIndex) in items"
         :key="`item-${itemIndex}`"
@@ -49,28 +49,67 @@ export default {
 
 <style lang="scss">
 .logos {
+  margin: 0 16px;
+
   &__title h2 {
     font-family: $font-open-sans;
-    font-size: 2rem;
     font-weight: $font-normal;
-    height: 49px;
-    letter-spacing: 0.009rem;
-    line-height: 49px;
+    color: $blue-5;
+    letter-spacing: 0.00938rem;
     text-align: center;
+    font-size: 1.75rem;
+    height: 40px;
+    line-height: 40px;
     margin-top: 24px;
+    margin-bottom: 24px;
   }
-}
 
-.wrapper {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  padding: 64px 98px;
+  &__wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 32px;
+  }
 
-  &__item img {
-    max-height: 66px;
-    margin: 0 30px 24px;
+  .wrapper__item {
+    img {
+      margin: 0 5px;
+    }
+  }
+
+  @include device-is('tablet') {
+    margin: 0 32px;
+
+    .wrapper {
+      margin-bottom: 44px;
+    }
+  }
+
+  @include device-is('desktop') {
+    &__title h2 {
+      margin-bottom: 48px;
+    }
+
+    &__wrapper {
+      margin-bottom: 60px;
+    }
+
+    .wrapper__item {
+      img {
+        margin: 0 8px;
+      }
+    }
+  }
+
+  @include device-is('large-screen') {
+    max-width: 1920px;
+
+    &__title h2 {
+      font-size: 2.125rem;
+      height: 49px;
+      line-height: 49px;
+    }
   }
 }
 </style>

--- a/components/slices/Logos.vue
+++ b/components/slices/Logos.vue
@@ -10,7 +10,7 @@
       <div
         v-for="(item, itemIndex) in items"
         :key="`item-${itemIndex}`"
-        class="wrapper__item"
+        class="logos-wrapper__item"
       >
         <pix-image :field="item.logos_image" />
       </div>
@@ -72,7 +72,7 @@ export default {
     margin-bottom: 32px;
   }
 
-  .wrapper__item {
+  .logos-wrapper__item {
     img {
       margin: 0 5px;
     }
@@ -80,10 +80,6 @@ export default {
 
   @include device-is('tablet') {
     margin: 0 32px;
-
-    .wrapper {
-      margin-bottom: 44px;
-    }
   }
 
   @include device-is('desktop') {
@@ -95,7 +91,7 @@ export default {
       margin-bottom: 60px;
     }
 
-    .wrapper__item {
+    .logos-wrapper__item {
       img {
         margin: 0 8px;
       }

--- a/components/slices/Logos.vue
+++ b/components/slices/Logos.vue
@@ -1,0 +1,76 @@
+<template>
+  <section class="logos">
+    <prismic-rich-text
+      v-if="hasTitle && shouldDisplayTitle"
+      class="logos__title"
+      :field="title"
+    />
+    <prismic-rich-text v-else class="sr-only" :field="title" />
+    <div class="wrapper">
+      <div
+        v-for="(item, itemIndex) in items"
+        :key="`item-${itemIndex}`"
+        class="wrapper__item"
+      >
+        <pix-image :field="item.logos_image" />
+      </div>
+    </div>
+  </section>
+</template>
+
+<script>
+export default {
+  name: 'LogosSlice',
+  props: {
+    slice: {
+      type: Object,
+      default: null,
+    },
+  },
+  computed: {
+    items() {
+      return this.slice.items
+    },
+    shouldDisplayTitle() {
+      return this.slice.primary.logos_should_display_title
+    },
+    hasTitle() {
+      return (
+        this.slice.primary.logos_title.length &&
+        this.slice.primary.logos_title[0].text.length
+      )
+    },
+    title() {
+      return this.slice.primary.logos_title
+    },
+  },
+}
+</script>
+
+<style lang="scss">
+.logos {
+  &__title h2 {
+    font-family: $font-open-sans;
+    font-size: 2rem;
+    font-weight: $font-normal;
+    height: 49px;
+    letter-spacing: 0.009rem;
+    line-height: 49px;
+    text-align: center;
+    margin-top: 24px;
+  }
+}
+
+.wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 98px;
+
+  &__item img {
+    max-height: 66px;
+    margin: 0 30px 24px;
+  }
+}
+</style>

--- a/components/slices/PartnersLogos.vue
+++ b/components/slices/PartnersLogos.vue
@@ -1,16 +1,16 @@
 <template>
-  <section class="logos">
+  <section class="partners-logos">
     <prismic-rich-text
       v-if="hasTitle && shouldDisplayTitle"
-      class="logos__title"
+      class="partners-logos__title"
       :field="title"
     />
     <prismic-rich-text v-else class="sr-only" :field="title" />
-    <div class="logos__wrapper">
+    <div class="partners-logos__wrapper">
       <div
         v-for="(item, itemIndex) in items"
         :key="`item-${itemIndex}`"
-        class="logos-wrapper__item"
+        class="partners-logos-wrapper__item"
       >
         <pix-image :field="item.logos_image" />
       </div>
@@ -48,7 +48,7 @@ export default {
 </script>
 
 <style lang="scss">
-.logos {
+.partners-logos {
   margin: 0 16px;
 
   &__title h2 {
@@ -73,7 +73,7 @@ export default {
   }
 }
 
-.logos-wrapper {
+.partners-logos-wrapper {
   &__item {
     img {
       margin: 0 5px;
@@ -82,13 +82,13 @@ export default {
 }
 
 @include device-is('tablet') {
-  .logos {
+  .partners-logos {
     margin: 0 32px;
   }
 }
 
 @include device-is('desktop') {
-  .logos {
+  .partners-logos {
     &__title h2 {
       margin-bottom: 48px;
     }
@@ -98,7 +98,7 @@ export default {
     }
   }
 
-  .logos-wrapper {
+  .partners-logos-wrapper {
     &__item {
       img {
         margin: 0 8px;
@@ -108,7 +108,7 @@ export default {
 }
 
 @include device-is('large-screen') {
-  .logos {
+  .partners-logos {
     max-width: 1920px;
 
     &__title h2 {

--- a/components/slices/PartnersLogos.vue
+++ b/components/slices/PartnersLogos.vue
@@ -71,18 +71,24 @@ export default {
     justify-content: center;
     margin-bottom: 32px;
   }
+}
 
-  .logos-wrapper__item {
+.logos-wrapper {
+  &__item {
     img {
       margin: 0 5px;
     }
   }
+}
 
-  @include device-is('tablet') {
+@include device-is('tablet') {
+  .logos {
     margin: 0 32px;
   }
+}
 
-  @include device-is('desktop') {
+@include device-is('desktop') {
+  .logos {
     &__title h2 {
       margin-bottom: 48px;
     }
@@ -90,15 +96,19 @@ export default {
     &__wrapper {
       margin-bottom: 60px;
     }
+  }
 
-    .logos-wrapper__item {
+  .logos-wrapper {
+    &__item {
       img {
         margin: 0 8px;
       }
     }
   }
+}
 
-  @include device-is('large-screen') {
+@include device-is('large-screen') {
+  .logos {
     max-width: 1920px;
 
     &__title h2 {

--- a/components/slices/PartnersLogos.vue
+++ b/components/slices/PartnersLogos.vue
@@ -20,7 +20,7 @@
 
 <script>
 export default {
-  name: 'LogosSlice',
+  name: 'PartnersLogosSlice',
   props: {
     slice: {
       type: Object,

--- a/components/slices/Process.vue
+++ b/components/slices/Process.vue
@@ -161,191 +161,191 @@ export default {
   &__wrapper {
     padding: 48px 32px;
   }
-}
-
-.wrapper {
-  &__row {
-    display: flex;
-    align-items: center;
-    flex-direction: column;
-    margin-bottom: 24px;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-
-  &__item {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-bottom: 24px;
-    width: 293px;
-    padding: 24px;
-    box-shadow: 0 24px 32px 0 rgba($black, 0.03),
-      0 8px 32px 0 rgba($black, 0.06);
-    border-radius: 20px;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-
-    img {
-      height: 51px;
-      width: 51px;
-    }
-
-    p {
-      margin: 0;
-    }
-  }
-}
-
-.item {
-  &__title h1 {
-    width: 175px;
-    color: $grey-1;
-    font-size: 1.25rem;
-    letter-spacing: 0;
-    line-height: 30px;
-    font-weight: $font-semi-bold;
-    margin: 0 8px 16px 24px;
-  }
-
-  &__description {
-    width: 175px;
-    color: $grey-6;
-    font-size: 0.875rem;
-    letter-spacing: 0.009rem;
-    line-height: 22px;
-    margin-left: 24px;
-  }
-}
-
-@include device-is('tablet') {
-  .process {
-    &__title h1 {
-      margin-top: 60px;
-    }
-
-    &__subtitle h3 {
-      top: 0;
-      margin-bottom: 48px;
-    }
-
-    &__wrapper {
-      flex-direction: row;
-      padding: 80px 0;
-    }
-  }
-
-  .wrapper__item {
-    margin-bottom: 40px;
-
-    div:first-of-type {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-    }
-
-    img {
-      margin-bottom: 24px;
-    }
-  }
-}
-
-@include device-is('desktop') {
-  .process {
-    &__title h1 {
-      margin-top: 60px;
-    }
-
-    &__wrapper {
-      padding: 80px 0 84px;
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: space-around;
-    }
-  }
 
   .wrapper {
     &__row {
-      flex-direction: row;
+      display: flex;
+      align-items: center;
+      flex-direction: column;
+      margin-bottom: 24px;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+
+    &__item {
+      display: flex;
+      align-items: center;
       justify-content: center;
-      align-items: baseline;
-    }
+      margin-bottom: 24px;
+      width: 293px;
+      padding: 24px;
+      box-shadow: 0 24px 32px 0 rgba($black, 0.03),
+        0 8px 32px 0 rgba($black, 0.06);
+      border-radius: 20px;
 
-    &__item {
-      &:first-of-type {
-        margin-left: 56px;
+      &:last-child {
+        margin-bottom: 0;
       }
-
-      padding: 32px 24px 56px 24px;
-      height: 273px;
-
-      display: block;
-      margin-right: 56px;
-      margin-bottom: 0;
-      text-align: center;
-      height: 100%;
-
-      img {
-        margin-right: 0;
-      }
-    }
-  }
-
-  .item {
-    &__title h1 {
-      width: 245px;
-      font-size: 1.25rem;
-      margin-left: 0;
-    }
-
-    &__description {
-      margin-top: 8px;
-      width: 245px;
-      margin-left: 0;
-    }
-  }
-}
-
-@include device-is('large-screen') {
-  .process__wrapper {
-    padding: 0 98px 60px 98px;
-    width: 100%;
-    display: flex;
-    align-items: stretch;
-    flex-wrap: wrap;
-    justify-content: space-around;
-  }
-
-  .wrapper {
-    &__item {
-      &:first-of-type {
-        margin-left: 0;
-      }
-
-      max-width: 293px;
-      padding: 32px 24px 50px 24px;
-      text-align: center;
-      height: 100%;
 
       img {
         height: 51px;
         width: 51px;
       }
 
-      &:last-of-type {
-        margin-right: 0;
+      p {
+        margin: 0;
       }
     }
   }
 
   .item {
+    &__title h1 {
+      width: 175px;
+      color: $grey-1;
+      font-size: 1.25rem;
+      letter-spacing: 0;
+      line-height: 30px;
+      font-weight: $font-semi-bold;
+      margin: 0 8px 16px 24px;
+    }
+
     &__description {
-      margin-top: 8px;
-      width: 245px;
+      width: 175px;
+      color: $grey-6;
+      font-size: 0.875rem;
+      letter-spacing: 0.009rem;
+      line-height: 22px;
+      margin-left: 24px;
+    }
+  }
+
+  @include device-is('tablet') {
+    .process {
+      &__title h1 {
+        margin-top: 60px;
+      }
+
+      &__subtitle h3 {
+        top: 0;
+        margin-bottom: 48px;
+      }
+
+      &__wrapper {
+        flex-direction: row;
+        padding: 80px 0;
+      }
+    }
+
+    .wrapper__item {
+      margin-bottom: 40px;
+
+      div:first-of-type {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+
+      img {
+        margin-bottom: 24px;
+      }
+    }
+  }
+
+  @include device-is('desktop') {
+    .process {
+      &__title h1 {
+        margin-top: 60px;
+      }
+
+      &__wrapper {
+        padding: 80px 0 84px;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-around;
+      }
+    }
+
+    .wrapper {
+      &__row {
+        flex-direction: row;
+        justify-content: center;
+        align-items: baseline;
+      }
+
+      &__item {
+        &:first-of-type {
+          margin-left: 56px;
+        }
+
+        padding: 32px 24px 56px 24px;
+        height: 273px;
+
+        display: block;
+        margin-right: 56px;
+        margin-bottom: 0;
+        text-align: center;
+        height: 100%;
+
+        img {
+          margin-right: 0;
+        }
+      }
+    }
+
+    .item {
+      &__title h1 {
+        width: 245px;
+        font-size: 1.25rem;
+        margin-left: 0;
+      }
+
+      &__description {
+        margin-top: 8px;
+        width: 245px;
+        margin-left: 0;
+      }
+    }
+  }
+
+  @include device-is('large-screen') {
+    .process__wrapper {
+      padding: 0 98px 60px 98px;
+      width: 100%;
+      display: flex;
+      align-items: stretch;
+      flex-wrap: wrap;
+      justify-content: space-around;
+    }
+
+    .wrapper {
+      &__item {
+        &:first-of-type {
+          margin-left: 0;
+        }
+
+        max-width: 293px;
+        padding: 32px 24px 50px 24px;
+        text-align: center;
+        height: 100%;
+
+        img {
+          height: 51px;
+          width: 51px;
+        }
+
+        &:last-of-type {
+          margin-right: 0;
+        }
+      }
+    }
+
+    .item {
+      &__description {
+        margin-top: 8px;
+        width: 245px;
+      }
     }
   }
 }

--- a/components/slices/Process.vue
+++ b/components/slices/Process.vue
@@ -15,18 +15,21 @@
       <div
         v-for="(itemsByRow, rowIndex) in rows"
         :key="`row-${rowIndex}`"
-        class="wrapper__row"
+        class="process-wrapper__row"
       >
         <div
           v-for="(item, itemIndex) in itemsByRow"
           :key="`item-${itemIndex}`"
-          class="wrapper__item"
+          class="process-wrapper__item"
         >
           <pix-image v-if="hasImage(item)" :field="item.item_image" />
           <div>
-            <prismic-rich-text class="item__title" :field="item.item_title" />
             <prismic-rich-text
-              class="item__description"
+              class="process-wrapper-item__title"
+              :field="item.item_title"
+            />
+            <prismic-rich-text
+              class="process-wrapper-item__description"
               :field="item.item_description"
             />
           </div>
@@ -162,7 +165,7 @@ export default {
     padding: 48px 32px;
   }
 
-  .wrapper {
+  .process-wrapper {
     &__row {
       display: flex;
       align-items: center;
@@ -200,7 +203,7 @@ export default {
     }
   }
 
-  .item {
+  .process-wrapper-item {
     &__title h1 {
       width: 175px;
       color: $grey-1;
@@ -238,7 +241,7 @@ export default {
       }
     }
 
-    .wrapper__item {
+    .process-wrapper__item {
       margin-bottom: 40px;
 
       div:first-of-type {
@@ -267,7 +270,7 @@ export default {
       }
     }
 
-    .wrapper {
+    .process-wrapper {
       &__row {
         flex-direction: row;
         justify-content: center;
@@ -294,7 +297,7 @@ export default {
       }
     }
 
-    .item {
+    .process-wrapper-item {
       &__title h1 {
         width: 245px;
         font-size: 1.25rem;
@@ -319,7 +322,7 @@ export default {
       justify-content: space-around;
     }
 
-    .wrapper {
+    .process-wrapper {
       &__item {
         &:first-of-type {
           margin-left: 0;
@@ -341,7 +344,7 @@ export default {
       }
     }
 
-    .item {
+    .process-wrapper-item {
       &__description {
         margin-top: 8px;
         width: 245px;

--- a/components/slices/Process.vue
+++ b/components/slices/Process.vue
@@ -164,191 +164,188 @@ export default {
   &__wrapper {
     padding: 48px 32px;
   }
+}
+
+.process-wrapper {
+  &__row {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    margin-bottom: 24px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &__item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 24px;
+    width: 293px;
+    padding: 24px;
+    box-shadow: 0 24px 32px 0 rgba($black, 0.03),
+      0 8px 32px 0 rgba($black, 0.06);
+    border-radius: 20px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    img {
+      height: 51px;
+      width: 51px;
+    }
+
+    p {
+      margin: 0;
+    }
+  }
+}
+
+.process-wrapper-item {
+  &__title h1 {
+    width: 175px;
+    color: $grey-1;
+    font-size: 1.25rem;
+    letter-spacing: 0;
+    line-height: 30px;
+    font-weight: $font-semi-bold;
+    margin: 0 8px 16px 24px;
+  }
+
+  &__description {
+    width: 175px;
+    color: $grey-6;
+    font-size: 0.875rem;
+    letter-spacing: 0.009rem;
+    line-height: 22px;
+    margin-left: 24px;
+  }
+}
+
+@include device-is('tablet') {
+  .process {
+    &__title h1 {
+      margin-top: 60px;
+    }
+
+    &__subtitle h3 {
+      top: 0;
+      margin-bottom: 48px;
+    }
+
+    &__wrapper {
+      flex-direction: row;
+      padding: 80px 0;
+    }
+  }
+
+  .process-wrapper__item {
+    margin-bottom: 40px;
+
+    div:first-of-type {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    img {
+      margin-bottom: 24px;
+    }
+  }
+}
+
+@include device-is('desktop') {
+  .process {
+    &__title h1 {
+      margin-top: 60px;
+    }
+
+    &__wrapper {
+      padding: 80px 0 84px;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-around;
+    }
+  }
 
   .process-wrapper {
     &__row {
-      display: flex;
-      align-items: center;
-      flex-direction: column;
-      margin-bottom: 24px;
-
-      &:last-child {
-        margin-bottom: 0;
-      }
+      flex-direction: row;
+      justify-content: center;
+      align-items: baseline;
     }
 
     &__item {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      margin-bottom: 24px;
-      width: 293px;
-      padding: 24px;
-      box-shadow: 0 24px 32px 0 rgba($black, 0.03),
-        0 8px 32px 0 rgba($black, 0.06);
-      border-radius: 20px;
-
-      &:last-child {
-        margin-bottom: 0;
+      &:first-of-type {
+        margin-left: 56px;
       }
+      padding: 32px 24px 56px 24px;
+      display: block;
+      margin-right: 56px;
+      margin-bottom: 0;
+      text-align: center;
+      height: 100%;
 
       img {
-        height: 51px;
-        width: 51px;
-      }
-
-      p {
-        margin: 0;
+        margin-right: 0;
       }
     }
   }
 
   .process-wrapper-item {
     &__title h1 {
-      width: 175px;
-      color: $grey-1;
+      width: 245px;
       font-size: 1.25rem;
-      letter-spacing: 0;
-      line-height: 30px;
-      font-weight: $font-semi-bold;
-      margin: 0 8px 16px 24px;
+      margin-left: 0;
     }
 
     &__description {
-      width: 175px;
-      color: $grey-6;
-      font-size: 0.875rem;
-      letter-spacing: 0.009rem;
-      line-height: 22px;
-      margin-left: 24px;
+      margin-top: 8px;
+      width: 245px;
+      margin-left: 0;
     }
   }
+}
 
-  @include device-is('tablet') {
-    .process {
-      &__title h1 {
-        margin-top: 60px;
+@include device-is('large-screen') {
+  .process__wrapper {
+    padding: 0 98px 60px 98px;
+    width: 100%;
+    display: flex;
+    align-items: stretch;
+    flex-wrap: wrap;
+    justify-content: space-around;
+  }
+
+  .process-wrapper {
+    &__item {
+      &:first-of-type {
+        margin-left: 0;
       }
 
-      &__subtitle h3 {
-        top: 0;
-        margin-bottom: 48px;
-      }
-
-      &__wrapper {
-        flex-direction: row;
-        padding: 80px 0;
-      }
-    }
-
-    .process-wrapper__item {
-      margin-bottom: 40px;
-
-      div:first-of-type {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-      }
+      max-width: 293px;
+      padding: 32px 24px 50px 24px;
+      text-align: center;
+      height: 100%;
 
       img {
-        margin-bottom: 24px;
+        height: 51px;
+        width: 51px;
+      }
+
+      &:last-of-type {
+        margin-right: 0;
       }
     }
   }
 
-  @include device-is('desktop') {
-    .process {
-      &__title h1 {
-        margin-top: 60px;
-      }
-
-      &__wrapper {
-        padding: 80px 0 84px;
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-around;
-      }
-    }
-
-    .process-wrapper {
-      &__row {
-        flex-direction: row;
-        justify-content: center;
-        align-items: baseline;
-      }
-
-      &__item {
-        &:first-of-type {
-          margin-left: 56px;
-        }
-
-        padding: 32px 24px 56px 24px;
-        height: 273px;
-
-        display: block;
-        margin-right: 56px;
-        margin-bottom: 0;
-        text-align: center;
-        height: 100%;
-
-        img {
-          margin-right: 0;
-        }
-      }
-    }
-
-    .process-wrapper-item {
-      &__title h1 {
-        width: 245px;
-        font-size: 1.25rem;
-        margin-left: 0;
-      }
-
-      &__description {
-        margin-top: 8px;
-        width: 245px;
-        margin-left: 0;
-      }
-    }
-  }
-
-  @include device-is('large-screen') {
-    .process__wrapper {
-      padding: 0 98px 60px 98px;
-      width: 100%;
-      display: flex;
-      align-items: stretch;
-      flex-wrap: wrap;
-      justify-content: space-around;
-    }
-
-    .process-wrapper {
-      &__item {
-        &:first-of-type {
-          margin-left: 0;
-        }
-
-        max-width: 293px;
-        padding: 32px 24px 50px 24px;
-        text-align: center;
-        height: 100%;
-
-        img {
-          height: 51px;
-          width: 51px;
-        }
-
-        &:last-of-type {
-          margin-right: 0;
-        }
-      }
-    }
-
-    .process-wrapper-item {
-      &__description {
-        margin-top: 8px;
-        width: 245px;
-      }
+  .process-wrapper-item {
+    &__description {
+      margin-top: 8px;
+      width: 245px;
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la refonte du site vitrine, on souhaiterait avoir des blocs réutilisables.

## :robot: Solution
Créer la nouvelle slice Logos

## :rainbow: Remarques
Dans la nouvelle navigation: on a un composant qui s'appelle `LogosZone`.
Dans une page, on peut ajouter un composant `Logos`.

Qu'est-ce que vous pensez du nommage?
Pour clarifier on peut renommer:
- soit le premier en `NavigationLogosZone` (du coup préfixer tous les noms des composants de la navigation par `Navigation`)
- soit le 2e en `PartnerLogos` mais est-ce que cette slice sera toujours utilisée pour y mettre des logos partner?

## :sparkles: Review App
- Maquettes Abstract: https://share.goabstract.com/adc30f0b-8179-400b-973b-775118e3227d
- Côté Prismic, récupérer le cookie du document "index"

https://site-pr186.review.pix.fr/
https://pro-pr186.review.pix.fr/