### PR TITLE
[BUGFIX] Pouvoir cliquer sur l'icon du bouton dropdown de la navigation

### DIFF
--- a/components/slices/NavigationZone.vue
+++ b/components/slices/NavigationZone.vue
@@ -13,6 +13,7 @@
           :dropdown-index="`${index}`"
           class="dropdown-toggle navigation-zone__item links-group"
           @click="toggleDropdown(`${index}`)"
+          @click.stop.prevent
         >
           {{ menuItem.name }}
           <fa v-if="showDropdown(`${index}`)" icon="angle-up" />


### PR DESCRIPTION
## :unicorn: Problème
Pour ouvrir le menu déroulant "Enseignement", cliquer sur la flèche vers le bas ne fonctionne pas.
cf. issue: https://github.com/1024pix/pix/issues/1972

## :robot: Solution
Lorsque l'on clique sur l'icon, l'action est appelé deux fois: une fois trigger par le parent et une autre fois trigger par l'icon lui-même. Ce qui fait que l'on a l'impression que la dropdown ne s'ouvre pas.

La solution est de mettre un event.stopPropagation.

## :sparkles: Review App
https://site-pr187.review.pix.fr/
https://pro-pr187.review.pix.fr/
