### PR TITLE
[FEATURE] Suppression de l'execution des test au moment du preversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "release": "npm run release:minor",
     "release:patch": "npm version patch -m \"Release v%s\"",
     "release:minor": "npm version minor -m \"Release v%s\"",
-    "release:major": "npm version major -m \"Release v%s\"",
-    "preversion": "git checkout dev && git pull --rebase && NODE_ENV=test npm test"
+    "release:major": "npm version major -m \"Release v%s\""
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "1.2.30",


### PR DESCRIPTION
## :unicorn: Problème

Les tests s'exécutent dans pix-bot au moment du deploiement, ce qui entraine un dépassement mémoire dans pix-bot.

## :robot: Solution

Il n'est pas nécessaire d'exécuter les tests au déploiement dans pix-bot. On supprime cette commande dans le `preversion`

## :rainbow: Remarques

N/A


