### PR TITLE
[FEATURE] Avoir une navigation principale pour Pix Pro (PIX-1368).

### DIFF
--- a/components/BurgerMenuNav.vue
+++ b/components/BurgerMenuNav.vue
@@ -9,7 +9,7 @@
         </li>
       </ul>
     </div>
-    <div v-if="isPixPro" class="nav-middle">
+    <div v-if="isPixPro && showProItems" class="nav-middle">
       <hr class="nav-middle__bar" />
       <p>Pix Pro</p>
       <ul>
@@ -34,6 +34,10 @@ export default {
     proItems: {
       type: Array,
       default: null,
+    },
+    showProItems: {
+      type: Boolean,
+      default: true,
     },
   },
   computed: {

--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -5,6 +5,7 @@
         <burger-menu-nav
           :items="burgerMenuLinks"
           :pro-items="organizationNavItems"
+          :show-pro-items="showSubNav"
         />
       </push-menu>
     </client-only>
@@ -36,7 +37,7 @@
           </section>
         </div>
       </div>
-      <pix-pro-sub-nav v-if="isPixPro" :nav-items="organizationNavItems" />
+      <pix-pro-sub-nav v-if="showSubNav" :nav-items="organizationNavItems" />
     </div>
   </div>
 </template>
@@ -65,6 +66,14 @@ export default {
     isPixPro() {
       return process.env.isPixPro
     },
+
+    showSubNav() {
+      return (
+        this.isPixPro &&
+        this.usedMainNavigation.data.navigation_for === 'pix-site'
+      )
+    },
+
     ...mapState(['mainNavigation', 'organizationNavItems']),
 
     usedMainNavigation() {

--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -14,7 +14,7 @@
         <div class="navigation-slice-zone__content">
           <div class="navigation-slice-zone-content__left-side">
             <section
-              v-for="(slice, index) in mainNavigation.data.body"
+              v-for="(slice, index) in usedMainNavigation.data.body"
               :key="`navigation-slice-left-${index}`"
             >
               <template v-if="slice.slice_type === 'logos_zone'">
@@ -26,7 +26,7 @@
             </section>
           </div>
           <section
-            v-for="(slice, index) in mainNavigation.data.body"
+            v-for="(slice, index) in usedMainNavigation.data.body"
             :key="`navigation-slice-right-${index}`"
             class="navigation-slice-zone-wrapper__right-side"
           >
@@ -65,11 +65,15 @@ export default {
       return process.env.isPixPro
     },
     ...mapState(['mainNavigation', 'organizationNavItems']),
+
+    usedMainNavigation() {
+      return { ...this.mainNavigation[0] }
+    },
     burgerMenuLinks() {
-      const navigationZone = this.mainNavigation.data.body.find(
+      const navigationZone = this.usedMainNavigation.data.body.find(
         (slice) => slice.slice_type === 'navigation_zone'
       )
-      const actionsZone = this.mainNavigation.data.body.find(
+      const actionsZone = this.usedMainNavigation.data.body.find(
         (slice) => slice.slice_type === 'actions_zone'
       )
       return [...navigationZone.items, ...actionsZone.items]

--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -74,10 +74,10 @@ export default {
       )
     },
 
-    ...mapState(['mainNavigation', 'organizationNavItems']),
+    ...mapState(['mainNavigations', 'organizationNavItems']),
 
     usedMainNavigation() {
-      const groupBySite = groupBy(this.mainNavigation, 'data.navigation_for')
+      const groupBySite = groupBy(this.mainNavigations, 'data.navigation_for')
       if (this.isPixPro && groupBySite['pix-pro']) {
         return groupBySite['pix-pro'][0]
       }

--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -43,6 +43,7 @@
 
 <script>
 import { mapState } from 'vuex'
+import { groupBy } from 'lodash'
 import LogosZone from '@/components/slices/LogosZone'
 import NavigationZone from '@/components/slices/NavigationZone'
 import ActionsZone from '@/components/slices/ActionsZone'
@@ -67,8 +68,13 @@ export default {
     ...mapState(['mainNavigation', 'organizationNavItems']),
 
     usedMainNavigation() {
-      return { ...this.mainNavigation[0] }
+      const groupBySite = groupBy(this.mainNavigation, 'data.navigation_for')
+      if (this.isPixPro && groupBySite['pix-pro']) {
+        return groupBySite['pix-pro'][0]
+      }
+      return groupBySite['pix-site'][0]
     },
+
     burgerMenuLinks() {
       const navigationZone = this.usedMainNavigation.data.body.find(
         (slice) => slice.slice_type === 'navigation_zone'

--- a/package-lock.json
+++ b/package-lock.json
@@ -10744,9 +10744,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@nuxtjs/dotenv": "^1.4.1",
     "@nuxtjs/prismic": "^1.2.3",
     "chart.js": "2.9.3",
+    "lodash": "^4.17.20",
     "nuxt": "^2.13.3",
     "nuxt-fontawesome": "0.4.0",
     "nuxt-i18n": "6.13.1",

--- a/plugins/i18n.js
+++ b/plugins/i18n.js
@@ -1,6 +1,6 @@
 export default function ({ app: { $prismic, i18n, store } }) {
   i18n.onLanguageSwitched = () => {
     store.dispatch('updateNavigation', { prismic: $prismic, i18n })
-    store.dispatch('updateMainNavigation', { prismic: $prismic, i18n })
+    store.dispatch('updateMainNavigations', { prismic: $prismic, i18n })
   }
 }

--- a/services/document-fetcher.js
+++ b/services/document-fetcher.js
@@ -25,6 +25,13 @@ export function documentFetcher(
   const lang = i18n.locale || i18n.defaultLocale
   return {
     get: getSingle,
+    findByType: async (type) => {
+      const documents = await prismic.api.query(
+        prismic.predicates.at('document.type', type),
+        { lang }
+      )
+      return documents.results
+    },
     getEmployers: async () => {
       const document = await prismic.api.getSingle('employers', {
         lang,

--- a/store/index.js
+++ b/store/index.js
@@ -51,7 +51,7 @@ export const mutations = {
     state.aboutNavItems = navItems(navigations, 'about-nav')
   },
   updateMainNavigation(state, navigations) {
-    state.mainNavigation = { ...navigations }
+    state.mainNavigation = navigations
   },
   updateHotNews(state, hotNews) {
     state.hotNews = hotNews && hotNews.data ? hotNews.data.description : null
@@ -63,7 +63,7 @@ function getNavigation(prismic, i18n) {
 }
 
 function getMainNavigation(prismic, i18n) {
-  return documentFetcher(prismic, i18n).get(documents.mainNavigation)
+  return documentFetcher(prismic, i18n).findByType(documents.mainNavigation)
 }
 
 function getHotNews(prismic, i18n) {

--- a/store/index.js
+++ b/store/index.js
@@ -6,14 +6,14 @@ export const state = () => ({
   aboutNavItems: [],
   hotNews: null,
   host: null,
-  mainNavigation: [],
+  mainNavigations: [],
 })
 export const actions = {
   async nuxtServerInit({ commit }, { app, req }) {
     commit('updateNavigation', await getNavigation(app.$prismic, app.i18n))
     commit(
-      'updateMainNavigation',
-      await getMainNavigation(app.$prismic, app.i18n)
+      'updateMainNavigations',
+      await getMainNavigations(app.$prismic, app.i18n)
     )
     commit('updateHotNews', await getHotNews(app.$prismic, app.i18n))
     commit('updateHost', req)
@@ -21,8 +21,8 @@ export const actions = {
   async updateNavigation({ commit }, { i18n, prismic }) {
     commit('updateNavigation', await getNavigation(prismic, i18n))
   },
-  async updateMainNavigation({ commit }, { i18n, prismic }) {
-    commit('updateMainNavigation', await getMainNavigation(prismic, i18n))
+  async updateMainNavigations({ commit }, { i18n, prismic }) {
+    commit('updateMainNavigations', await getMainNavigations(prismic, i18n))
   },
 }
 export const mutations = {
@@ -50,8 +50,8 @@ export const mutations = {
     state.resourcesNavItems = navItems(navigations, 'ressources-nav')
     state.aboutNavItems = navItems(navigations, 'about-nav')
   },
-  updateMainNavigation(state, navigations) {
-    state.mainNavigation = navigations
+  updateMainNavigations(state, navigations) {
+    state.mainNavigations = [...navigations]
   },
   updateHotNews(state, hotNews) {
     state.hotNews = hotNews && hotNews.data ? hotNews.data.description : null
@@ -62,7 +62,7 @@ function getNavigation(prismic, i18n) {
   return documentFetcher(prismic, i18n).get(documents.navigation)
 }
 
-function getMainNavigation(prismic, i18n) {
+function getMainNavigations(prismic, i18n) {
   return documentFetcher(prismic, i18n).findByType(documents.mainNavigation)
 }
 

--- a/tests/components/slices/NavigationSliceZone.test.js
+++ b/tests/components/slices/NavigationSliceZone.test.js
@@ -70,7 +70,7 @@ describe('NavigationSliceZone', () => {
         beforeEach(() => {
           store = {
             state: {
-              mainNavigation: [expectedSiteNavigation, expectedProNavigation],
+              mainNavigations: [expectedSiteNavigation, expectedProNavigation],
             },
           }
         })
@@ -99,7 +99,7 @@ describe('NavigationSliceZone', () => {
           }
           store = {
             state: {
-              mainNavigation: [expectedSiteNavigation, expectedProNavigation],
+              mainNavigations: [expectedSiteNavigation, expectedProNavigation],
             },
           }
         })
@@ -128,7 +128,7 @@ describe('NavigationSliceZone', () => {
           }
           store = {
             state: {
-              mainNavigation: [expectedSiteNavigation],
+              mainNavigations: [expectedSiteNavigation],
             },
           }
         })
@@ -160,7 +160,7 @@ describe('NavigationSliceZone', () => {
 
           store = {
             state: {
-              mainNavigation: [expectedSiteNavigation, expectedProNavigation],
+              mainNavigations: [expectedSiteNavigation, expectedProNavigation],
             },
           }
         })
@@ -190,7 +190,7 @@ describe('NavigationSliceZone', () => {
 
           store = {
             state: {
-              mainNavigation: [expectedSiteNavigation],
+              mainNavigations: [expectedSiteNavigation],
             },
           }
         })

--- a/tests/components/slices/NavigationSliceZone.test.js
+++ b/tests/components/slices/NavigationSliceZone.test.js
@@ -1,0 +1,181 @@
+import { shallowMount } from '@vue/test-utils'
+import NavigationSliceZone from '~/components/NavigationSliceZone'
+
+jest.mock('~/services/document-fetcher')
+
+describe('NavigationSliceZone slice', () => {
+  let component
+  let store
+
+  const expectedSiteNavigation = {
+    data: {
+      navigation_for: 'pix-site',
+      body: [
+        {
+          slice_type: 'logos_zone',
+          slice_label: null,
+          items: [],
+          primary: {},
+        },
+        {
+          slice_type: 'navigation_zone',
+          items: [],
+          primary: {},
+        },
+        {
+          slice_type: 'actions_zone',
+          slice_label: null,
+          items: [],
+          primary: {},
+        },
+      ],
+    },
+  }
+
+  const expectedProNavigation = {
+    data: {
+      navigation_for: 'pix-pro',
+      body: [
+        {
+          slice_type: 'logos_zone',
+          slice_label: null,
+          items: [],
+          primary: {},
+        },
+        {
+          slice_type: 'navigation_zone',
+          items: [],
+          primary: {},
+        },
+        {
+          slice_type: 'actions_zone',
+          slice_label: null,
+          items: [],
+          primary: {},
+        },
+      ],
+    },
+  }
+
+  describe('Slice: NavigationSliceZone', () => {
+    afterEach(() => {
+      process.env = {
+        isPixPro: false,
+      }
+    })
+
+    describe('When we are in pix-site and we have two navigation', () => {
+      beforeEach(() => {
+        store = {
+          state: {
+            mainNavigation: [expectedSiteNavigation, expectedProNavigation],
+          },
+        }
+      })
+
+      it('should return the site navigation', () => {
+        // given
+        component = shallowMount(NavigationSliceZone, {
+          mocks: {
+            $store: store,
+          },
+          stubs: {
+            'client-only': true,
+            'push-menu': true,
+            'burger-menu-nav': true,
+            'organization-nav': true,
+            'logos-zone': true,
+            'navigation-zone': true,
+            'actions-zone': true,
+            'pix-pro-sub-nav': true,
+            fa: true,
+          },
+        })
+
+        // when
+        const result = component.vm.usedMainNavigation
+
+        // then
+        expect(result).toEqual(expectedSiteNavigation)
+      })
+    })
+
+    describe('When we are in pix-pro and we have two navigation', () => {
+      beforeEach(() => {
+        process.env = {
+          isPixPro: true,
+        }
+        store = {
+          state: {
+            mainNavigation: [expectedSiteNavigation, expectedProNavigation],
+          },
+        }
+      })
+
+      it('should return the pro navigation', () => {
+        // given
+        component = shallowMount(NavigationSliceZone, {
+          mocks: {
+            $store: store,
+          },
+          stubs: {
+            'client-only': true,
+            'push-menu': true,
+            'burger-menu-nav': true,
+            'organization-nav': true,
+            'logos-zone': true,
+            'navigation-zone': true,
+            'actions-zone': true,
+            'pix-pro-sub-nav': true,
+            fa: true,
+          },
+        })
+
+        // when
+        const result = component.vm.usedMainNavigation
+
+        // then
+        expect(result).toEqual(expectedProNavigation)
+      })
+    })
+
+    describe('When we are in pix-pro and we have only the site navigation', () => {
+      beforeEach(() => {
+        process.env = {
+          isPixPro: true,
+        }
+        store = {
+          state: {
+            mainNavigation: [expectedSiteNavigation],
+          },
+        }
+      })
+
+      it('should return the site navigation', () => {
+        // given
+        component = shallowMount(NavigationSliceZone, {
+          mocks: {
+            $store: store,
+          },
+          stubs: {
+            'client-only': true,
+            'push-menu': true,
+            'burger-menu-nav': true,
+            'organization-nav': true,
+            'logos-zone': true,
+            'navigation-zone': true,
+            'actions-zone': true,
+            'pix-pro-sub-nav': true,
+            fa: true,
+          },
+        })
+
+        // when
+        const result = component.vm.usedMainNavigation
+
+        // then
+        expect(result).toEqual(expectedSiteNavigation)
+      })
+    })
+  })
+})

--- a/tests/components/slices/NavigationSliceZone.test.js
+++ b/tests/components/slices/NavigationSliceZone.test.js
@@ -3,9 +3,20 @@ import NavigationSliceZone from '~/components/NavigationSliceZone'
 
 jest.mock('~/services/document-fetcher')
 
-describe('NavigationSliceZone slice', () => {
+describe('NavigationSliceZone', () => {
   let component
   let store
+  const stubs = {
+    'client-only': true,
+    'push-menu': true,
+    'burger-menu-nav': true,
+    'organization-nav': true,
+    'logos-zone': true,
+    'navigation-zone': true,
+    'actions-zone': true,
+    'pix-pro-sub-nav': true,
+    fa: true,
+  }
 
   const expectedSiteNavigation = {
     data: {
@@ -13,20 +24,15 @@ describe('NavigationSliceZone slice', () => {
       body: [
         {
           slice_type: 'logos_zone',
-          slice_label: null,
           items: [],
-          primary: {},
         },
         {
           slice_type: 'navigation_zone',
           items: [],
-          primary: {},
         },
         {
           slice_type: 'actions_zone',
-          slice_label: null,
           items: [],
-          primary: {},
         },
       ],
     },
@@ -38,20 +44,15 @@ describe('NavigationSliceZone slice', () => {
       body: [
         {
           slice_type: 'logos_zone',
-          slice_label: null,
           items: [],
-          primary: {},
         },
         {
           slice_type: 'navigation_zone',
           items: [],
-          primary: {},
         },
         {
           slice_type: 'actions_zone',
-          slice_label: null,
           items: [],
-          primary: {},
         },
       ],
     },
@@ -64,117 +65,151 @@ describe('NavigationSliceZone slice', () => {
       }
     })
 
-    describe('When we are in pix-site and we have two navigation', () => {
-      beforeEach(() => {
-        store = {
-          state: {
-            mainNavigation: [expectedSiteNavigation, expectedProNavigation],
-          },
-        }
-      })
-
-      it('should return the site navigation', () => {
-        // given
-        component = shallowMount(NavigationSliceZone, {
-          mocks: {
-            $store: store,
-          },
-          stubs: {
-            'client-only': true,
-            'push-menu': true,
-            'burger-menu-nav': true,
-            'organization-nav': true,
-            'logos-zone': true,
-            'navigation-zone': true,
-            'actions-zone': true,
-            'pix-pro-sub-nav': true,
-            fa: true,
-          },
+    describe('#usedMainNavigation', () => {
+      describe('When we are in pix-site and we have the site navigation', () => {
+        beforeEach(() => {
+          store = {
+            state: {
+              mainNavigation: [expectedSiteNavigation, expectedProNavigation],
+            },
+          }
         })
 
-        // when
-        const result = component.vm.usedMainNavigation
+        it('should return the site navigation', () => {
+          // given
+          component = shallowMount(NavigationSliceZone, {
+            mocks: {
+              $store: store,
+            },
+            stubs,
+          })
 
-        // then
-        expect(result).toEqual(expectedSiteNavigation)
+          // when
+          const result = component.vm.usedMainNavigation
+
+          // then
+          expect(result).toEqual(expectedSiteNavigation)
+        })
+      })
+
+      describe('When we are in pix-pro and we have the pro navigation', () => {
+        beforeEach(() => {
+          process.env = {
+            isPixPro: true,
+          }
+          store = {
+            state: {
+              mainNavigation: [expectedSiteNavigation, expectedProNavigation],
+            },
+          }
+        })
+
+        it('should return the pro navigation', () => {
+          // given
+          component = shallowMount(NavigationSliceZone, {
+            mocks: {
+              $store: store,
+            },
+            stubs,
+          })
+
+          // when
+          const result = component.vm.usedMainNavigation
+
+          // then
+          expect(result).toEqual(expectedProNavigation)
+        })
+      })
+
+      describe('When we are in pix-pro and we have only the site navigation', () => {
+        beforeEach(() => {
+          process.env = {
+            isPixPro: true,
+          }
+          store = {
+            state: {
+              mainNavigation: [expectedSiteNavigation],
+            },
+          }
+        })
+
+        it('should return the site navigation', () => {
+          // given
+          component = shallowMount(NavigationSliceZone, {
+            mocks: {
+              $store: store,
+            },
+            stubs,
+          })
+
+          // when
+          const result = component.vm.usedMainNavigation
+
+          // then
+          expect(result).toEqual(expectedSiteNavigation)
+        })
       })
     })
 
-    describe('When we are in pix-pro and we have two navigation', () => {
-      beforeEach(() => {
-        process.env = {
-          isPixPro: true,
-        }
-        store = {
-          state: {
-            mainNavigation: [expectedSiteNavigation, expectedProNavigation],
-          },
-        }
-      })
+    describe('#showSubNav', () => {
+      describe('When we are in pix-pro and we have the pro navigation', () => {
+        beforeEach(() => {
+          process.env = {
+            isPixPro: true,
+          }
 
-      it('should return the pro navigation', () => {
-        // given
-        component = shallowMount(NavigationSliceZone, {
-          mocks: {
-            $store: store,
-          },
-          stubs: {
-            'client-only': true,
-            'push-menu': true,
-            'burger-menu-nav': true,
-            'organization-nav': true,
-            'logos-zone': true,
-            'navigation-zone': true,
-            'actions-zone': true,
-            'pix-pro-sub-nav': true,
-            fa: true,
-          },
+          store = {
+            state: {
+              mainNavigation: [expectedSiteNavigation, expectedProNavigation],
+            },
+          }
         })
 
-        // when
-        const result = component.vm.usedMainNavigation
+        it('should not show the subNav', () => {
+          // given
+          component = shallowMount(NavigationSliceZone, {
+            mocks: {
+              $store: store,
+            },
+            stubs,
+          })
 
-        // then
-        expect(result).toEqual(expectedProNavigation)
-      })
-    })
+          // when
+          const result = component.vm.showSubNav
 
-    describe('When we are in pix-pro and we have only the site navigation', () => {
-      beforeEach(() => {
-        process.env = {
-          isPixPro: true,
-        }
-        store = {
-          state: {
-            mainNavigation: [expectedSiteNavigation],
-          },
-        }
+          // then
+          expect(result).toEqual(false)
+        })
       })
 
-      it('should return the site navigation', () => {
-        // given
-        component = shallowMount(NavigationSliceZone, {
-          mocks: {
-            $store: store,
-          },
-          stubs: {
-            'client-only': true,
-            'push-menu': true,
-            'burger-menu-nav': true,
-            'organization-nav': true,
-            'logos-zone': true,
-            'navigation-zone': true,
-            'actions-zone': true,
-            'pix-pro-sub-nav': true,
-            fa: true,
-          },
+      describe('When we are in pix-pro and we have only the site navigation', () => {
+        beforeEach(() => {
+          process.env = {
+            isPixPro: true,
+          }
+
+          store = {
+            state: {
+              mainNavigation: [expectedSiteNavigation],
+            },
+          }
         })
 
-        // when
-        const result = component.vm.usedMainNavigation
+        it('should show the subNav', () => {
+          // given
+          component = shallowMount(NavigationSliceZone, {
+            mocks: {
+              $store: store,
+            },
+            stubs,
+          })
 
-        // then
-        expect(result).toEqual(expectedSiteNavigation)
+          // when
+          const result = component.vm.showSubNav
+
+          // then
+          expect(result).toEqual(true)
+        })
       })
     })
   })

--- a/tests/services/document-fetcher.test.js
+++ b/tests/services/document-fetcher.test.js
@@ -109,4 +109,34 @@ describe('DocumentFetcher', () => {
     expect(prismicPredicates.at).toBeCalledWith('my.slices_page.uid', uid)
     expect(response).toEqual(expectedValue)
   })
+
+  test('#findByType', async () => {
+    // Given
+    const type = 'main_navigation'
+    const expectedValue = [
+      { type: 'main_navigation', navigation_for: 'pix-site' },
+      { type: 'main_navigation', navigation_for: 'pix-pro' },
+    ]
+    const expectedPredicatesAtValue = Symbol('AT')
+    const findMock = () => ({ results: expectedValue })
+    const prismicApi = {
+      query: jest.fn().mockImplementationOnce(findMock),
+    }
+    prismic.api = prismicApi
+
+    const prismicPredicates = {
+      at: jest.fn(() => expectedPredicatesAtValue),
+    }
+    prismic.predicates = prismicPredicates
+
+    // When
+    const response = await documentFetcher(prismic).findByType(type)
+
+    // Then
+    expect(prismicApi.query).toBeCalledWith(expectedPredicatesAtValue, {
+      lang: 'fr-fr',
+    })
+    expect(prismicPredicates.at).toBeCalledWith('document.type', type)
+    expect(response).toEqual(expectedValue)
+  })
 })


### PR DESCRIPTION
## :unicorn: Problème
Le site pro.pix va avoir sa propre navigation principale et n'utilisera plus les sub-nav.

## :robot: Solution
- Coté Prismic : ajout d'un attribut `navigation_for` avec comme valeur pix-site/pix-pro sur le type `Main Navigation`
- Rendre le type `Main Navigation` répétable
- Ajouter une méthode pour récupérer tous les documents d'un même type
- Dans `NavigationSliceZone`, regrouper (par Lodash qui a été ajouté) les navigations par site utilisé, et prendre la première navigation proposé pour le site actuel
- Si pro.pix n'a pas de navigation (comme actuellement sur la prod), prendre celle de pix-site
- Si pro.pix a une navigation, retirer la sub-nav qui devient inutile (aussi dans le burger).

## :rainbow: Remarques
- Ajout de Lodash
- Ajout de tests 😸 

## :sparkles: Review App
https://site-pr190.review.pix.fr/
https://pro-pr190.review.pix.fr/
