### PR TITLE
[CLEANUP] Retirer la balise H1 déjà prise en compte par prismic-rich-text.

### DIFF
--- a/components/SimplePage.vue
+++ b/components/SimplePage.vue
@@ -2,9 +2,7 @@
   <div class="page">
     <header class="page-header">
       <div class="container md padding-container">
-        <h1 class="page-header__title">
-          <prismic-rich-text :field="content.title" />
-        </h1>
+        <prismic-rich-text :field="content.title" class="page-header__title" />
       </div>
     </header>
 


### PR DESCRIPTION
## :unicorn: Problème
Dans les `simple-page`, comme la page /accessibilite, il y avait 2 balises H1.
Vu que dans Prismic, on précise déjà que le titre est en H1, la balise `prismic-rich-text` ajoutait déjà une balise H1. Donc la notre faisait doublon.

## :robot: Solution
Retirer la balise H1 que nous avions

## :rainbow: Pour tester : 
- Aller sur la page pix.fr/accessibilite et voir les titres (avec Wave). Observer qu'on a deux H1 l'un sur l'autre
- Aller sur la PR https://site-pr192.review.pix.fr/accessibilite , regarder les titres et ne voir qu'un seul H1

## :sparkles: Review App
https://site-pr192.review.pix.fr/
https://pro-pr192.review.pix.fr/
