### PR TITLE
[FEATURE] Création du bloc Statistiques et refacto (PIX-1200).

### DIFF
--- a/assets/scss/components/slices/features.scss
+++ b/assets/scss/components/slices/features.scss
@@ -1,5 +1,6 @@
 .features {
   &__title h2 {
+    color: $grey-90;
     font-size: 2.125rem;
     font-weight: normal;
     height: 49px;
@@ -52,7 +53,7 @@
 .features-wrapper-item {
     &__title h1 {
       width: 217px;
-      color: $grey-1;
+      color: $grey-45;
       font-size: 1rem;
       letter-spacing: 0;
       line-height: 30px;
@@ -62,7 +63,7 @@
 
     &__description {
       width: 217px;
-      color: $grey-10;
+      color: $grey-45;
       font-size: 0.875rem;
       letter-spacing: 0.15px;
       line-height: 24px;

--- a/assets/scss/components/slices/features.scss
+++ b/assets/scss/components/slices/features.scss
@@ -26,7 +26,9 @@
       margin-bottom: 0;
     }
   }
+}
 
+.features-wrapper-row {
   &__item {
     display: flex;
     align-items: center;
@@ -43,22 +45,19 @@
       height: 62px;
       width: 55px;
     }
-
-    p {
-      margin: 0;
-    }
   }
 }
 
-.features-wrapper-item {
-    &__title h1 {
+.features-wrapper-row-item {
+
+    &__title h3 {
       width: 217px;
       color: $grey-45;
       font-size: 1rem;
       letter-spacing: 0;
       line-height: 30px;
       font-weight: 600;
-      margin-top: 0;
+      margin-top: 16px;
     }
 
     &__description {
@@ -80,7 +79,7 @@
     }
   }
 
-  .features-wrapper {
+  .features-wrapper-row {
     &__item {
       margin-bottom: 40px;
 
@@ -92,8 +91,9 @@
     }
   }
 
-  .features-wrapper-item {
-    &__title h1 {
+  .features-wrapper-row-item {
+
+    &__title h3 {
       width: 518px;
       font-size: 1.25rem;
     }
@@ -121,7 +121,9 @@
       justify-content: center;
       align-items: baseline;
     }
+  }
 
+  .features-wrapper-row {
     &__item {
       display: block;
       margin-right: 98px;
@@ -133,8 +135,9 @@
     }
   }
 
-  .features-wrapper-item {
-    &__title h1 {
+  .features-wrapper-row-item {
+
+    &__title h3 {
       width: 200px;
       font-size: 1.25rem;
     }
@@ -156,7 +159,7 @@
     }
   }
 
-  .features-wrapper {
+  .features-wrapper-row {
     &__item {
       margin-right: 76px;
       text-align: center;
@@ -168,8 +171,9 @@
     }
   }
 
-  .features-wrapper-item {
-    &__title h1 {
+  .features-wrapper-row-item {
+
+    &__title h3 {
       width: 294px;
     }
 

--- a/assets/scss/components/slices/features.scss
+++ b/assets/scss/components/slices/features.scss
@@ -1,0 +1,179 @@
+.features {
+  &__title h2 {
+    font-size: 2.125rem;
+    font-weight: normal;
+    height: 49px;
+    letter-spacing: 0.15px;
+    line-height: 49px;
+    text-align: center;
+    margin-top: 64px;
+  }
+
+  &__wrapper {
+    padding: 64px 0;
+  }
+}
+
+.features-wrapper {
+  &__row {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    margin-bottom: 24px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &__item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 24px;
+
+    &:last-child {
+      margin-right: 0;
+      margin-bottom: 0;
+    }
+
+    img {
+      margin-right: 25px;
+      height: 62px;
+      width: 55px;
+    }
+
+    p {
+      margin: 0;
+    }
+  }
+}
+
+.features-wrapper-item {
+    &__title h1 {
+      width: 217px;
+      color: $grey-1;
+      font-size: 1rem;
+      letter-spacing: 0;
+      line-height: 30px;
+      font-weight: 600;
+      margin-top: 0;
+    }
+
+    &__description {
+      width: 217px;
+      color: $grey-10;
+      font-size: 0.875rem;
+      letter-spacing: 0.15px;
+      line-height: 24px;
+    }
+}
+
+@include device-is('tablet') {
+  .features {
+    &__title h2 {
+      margin-top: 80px;
+    }
+    &__wrapper {
+      padding: 80px 0;
+    }
+  }
+
+  .features-wrapper {
+    &__item {
+      margin-bottom: 40px;
+
+      img {
+        margin-right: 32px;
+        height: 73px;
+        width: 65px;
+      }
+    }
+  }
+
+  .features-wrapper-item {
+    &__title h1 {
+      width: 518px;
+      font-size: 1.25rem;
+    }
+
+    &__description {
+      width: 518px;
+    }
+  }
+}
+
+@include device-is('desktop') {
+  .features {
+    &__title h2 {
+      margin-top: 80px;
+    }
+
+    &__wrapper {
+      padding: 80px 0 84px;
+    }
+  }
+
+  .features-wrapper {
+    &__row {
+      flex-direction: row;
+      justify-content: center;
+      align-items: baseline;
+    }
+
+    &__item {
+      display: block;
+      margin-right: 98px;
+      text-align: center;
+
+      img {
+        margin-right: 0;
+      }
+    }
+  }
+
+  .features-wrapper-item {
+    &__title h1 {
+      width: 200px;
+      font-size: 1.25rem;
+    }
+
+    &__description {
+      margin-top: 8px;
+      width: 200px;
+    }
+  }
+}
+
+@include device-is('large-screen') {
+  .features {
+    &__title h2 {
+      margin-top: 120px;
+    }
+    &__wrapper {
+      padding: 60px 0;
+    }
+  }
+
+  .features-wrapper {
+    &__item {
+      margin-right: 76px;
+      text-align: center;
+
+      img {
+        height: 73px;
+        width: 65px;
+      }
+    }
+  }
+
+  .features-wrapper-item {
+    &__title h1 {
+      width: 294px;
+    }
+
+    &__description {
+      width: 294px;
+    }
+  }
+}

--- a/assets/scss/components/slices/process.scss
+++ b/assets/scss/components/slices/process.scss
@@ -1,5 +1,6 @@
 .process {
   &__title h2 {
+    color: $grey-90;
     font-size: 2rem;
     font-weight: $font-normal;
     height: 49px;
@@ -45,8 +46,8 @@
     margin-bottom: 24px;
     width: 293px;
     padding: 24px;
-    box-shadow: 0 24px 32px 0 rgba($black, 0.03),
-    0 8px 32px 0 rgba($black, 0.06);
+    box-shadow: 0 24px 32px 0 rgba($grey-200, 0.03),
+    0 8px 32px 0 rgba($grey-200, 0.06);
     border-radius: 20px;
 
     &:last-child {
@@ -67,7 +68,7 @@
 .process-wrapper-item {
   &__title h3 {
     width: 175px;
-    color: $grey-1;
+    color: $grey-45;
     font-size: 1.25rem;
     letter-spacing: 0;
     line-height: 30px;
@@ -77,7 +78,7 @@
 
   &__description {
     width: 175px;
-    color: $grey-6;
+    color: $grey-45;
     font-size: 0.875rem;
     letter-spacing: 0.009rem;
     line-height: 22px;

--- a/assets/scss/components/slices/process.scss
+++ b/assets/scss/components/slices/process.scss
@@ -38,7 +38,9 @@
       margin-bottom: 0;
     }
   }
+}
 
+.process-wrapper-row {
   &__item {
     display: flex;
     align-items: center;
@@ -58,14 +60,11 @@
       height: 51px;
       width: 51px;
     }
-
-    p {
-      margin: 0;
-    }
   }
 }
 
-.process-wrapper-item {
+.process-wrapper-row-item {
+
   &__title h3 {
     width: 175px;
     color: $grey-45;
@@ -73,7 +72,7 @@
     letter-spacing: 0;
     line-height: 30px;
     font-weight: $font-semi-bold;
-    margin: 0 8px 16px 24px;
+    margin: 0 8px 0 24px;
   }
 
   &__description {
@@ -83,6 +82,10 @@
     letter-spacing: 0.009rem;
     line-height: 22px;
     margin-left: 24px;
+
+    p {
+      margin: 0;
+    }
   }
 }
 
@@ -103,17 +106,25 @@
     }
   }
 
-  .process-wrapper__item {
-    margin-bottom: 40px;
+  .process-wrapper-row {
+    &__item {
+      margin-bottom: 40px;
 
-    div:first-of-type {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
+      div:first-of-type {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+
+      img {
+        margin-bottom: 24px;
+      }
     }
+  }
 
-    img {
-      margin-bottom: 24px;
+  .process-wrapper-row-item {
+    &__title h3 {
+      margin-bottom: 8px;
     }
   }
 }
@@ -138,7 +149,9 @@
       justify-content: center;
       align-items: baseline;
     }
+  }
 
+  .process-wrapper-row {
     &__item {
       &:first-of-type {
         margin-left: 56px;
@@ -156,7 +169,8 @@
     }
   }
 
-  .process-wrapper-item {
+  .process-wrapper-row-item {
+
     &__title h3 {
       width: 245px;
       font-size: 1.25rem;
@@ -172,16 +186,18 @@
 }
 
 @include device-is('large-screen') {
-  .process__wrapper {
-    padding: 0 98px 60px 98px;
-    width: 100%;
-    display: flex;
-    align-items: stretch;
-    flex-wrap: wrap;
-    justify-content: space-around;
+  .process {
+    &__wrapper {
+      padding: 0 98px 60px 98px;
+      width: 100%;
+      display: flex;
+      align-items: stretch;
+      flex-wrap: wrap;
+      justify-content: space-around;
+    }
   }
 
-  .process-wrapper {
+  .process-wrapper-row {
     &__item {
       &:first-of-type {
         margin-left: 0;
@@ -192,18 +208,19 @@
       text-align: center;
       height: 100%;
 
+      &:last-of-type {
+        margin-right: 0;
+      }
+
       img {
         height: 51px;
         width: 51px;
       }
-
-      &:last-of-type {
-        margin-right: 0;
-      }
     }
   }
 
-  .process-wrapper-item {
+  .process-wrapper-row-item {
+
     &__description {
       margin-top: 8px;
       width: 245px;

--- a/assets/scss/components/slices/process.scss
+++ b/assets/scss/components/slices/process.scss
@@ -1,0 +1,211 @@
+.process {
+  &__title h2 {
+    font-size: 2rem;
+    font-weight: $font-normal;
+    height: 49px;
+    letter-spacing: 0.009rem;
+    line-height: 49px;
+    text-align: center;
+    margin-top: 24px;
+    margin-bottom: 32px;
+  }
+
+  &__subtitle h3 {
+    position: relative;
+    top: 8px;
+    font-size: 1rem;
+    font-weight: $font-light;
+    height: 49px;
+    letter-spacing: 0.009rem;
+    line-height: 49px;
+    text-align: center;
+  }
+
+  &__wrapper {
+    padding: 48px 32px;
+  }
+}
+
+.process-wrapper {
+  &__row {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    margin-bottom: 24px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &__item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 24px;
+    width: 293px;
+    padding: 24px;
+    box-shadow: 0 24px 32px 0 rgba($black, 0.03),
+    0 8px 32px 0 rgba($black, 0.06);
+    border-radius: 20px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    img {
+      height: 51px;
+      width: 51px;
+    }
+
+    p {
+      margin: 0;
+    }
+  }
+}
+
+.process-wrapper-item {
+  &__title h3 {
+    width: 175px;
+    color: $grey-1;
+    font-size: 1.25rem;
+    letter-spacing: 0;
+    line-height: 30px;
+    font-weight: $font-semi-bold;
+    margin: 0 8px 16px 24px;
+  }
+
+  &__description {
+    width: 175px;
+    color: $grey-6;
+    font-size: 0.875rem;
+    letter-spacing: 0.009rem;
+    line-height: 22px;
+    margin-left: 24px;
+  }
+}
+
+@include device-is('tablet') {
+  .process {
+    &__title h2 {
+      margin-top: 60px;
+    }
+
+    &__subtitle h3 {
+      top: 0;
+      margin-bottom: 48px;
+    }
+
+    &__wrapper {
+      flex-direction: row;
+      padding: 80px 0;
+    }
+  }
+
+  .process-wrapper__item {
+    margin-bottom: 40px;
+
+    div:first-of-type {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    img {
+      margin-bottom: 24px;
+    }
+  }
+}
+
+@include device-is('desktop') {
+  .process {
+    &__title h2 {
+      margin-top: 60px;
+    }
+
+    &__wrapper {
+      padding: 80px 0 84px;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-around;
+    }
+  }
+
+  .process-wrapper {
+    &__row {
+      flex-direction: row;
+      justify-content: center;
+      align-items: baseline;
+    }
+
+    &__item {
+      &:first-of-type {
+        margin-left: 56px;
+      }
+      padding: 32px 24px 56px 24px;
+      display: block;
+      margin-right: 56px;
+      margin-bottom: 0;
+      text-align: center;
+      height: 100%;
+
+      img {
+        margin-right: 0;
+      }
+    }
+  }
+
+  .process-wrapper-item {
+    &__title h3 {
+      width: 245px;
+      font-size: 1.25rem;
+      margin-left: 0;
+    }
+
+    &__description {
+      margin-top: 8px;
+      width: 245px;
+      margin-left: 0;
+    }
+  }
+}
+
+@include device-is('large-screen') {
+  .process__wrapper {
+    padding: 0 98px 60px 98px;
+    width: 100%;
+    display: flex;
+    align-items: stretch;
+    flex-wrap: wrap;
+    justify-content: space-around;
+  }
+
+  .process-wrapper {
+    &__item {
+      &:first-of-type {
+        margin-left: 0;
+      }
+
+      max-width: 293px;
+      padding: 32px 24px 50px 24px;
+      text-align: center;
+      height: 100%;
+
+      img {
+        height: 51px;
+        width: 51px;
+      }
+
+      &:last-of-type {
+        margin-right: 0;
+      }
+    }
+  }
+
+  .process-wrapper-item {
+    &__description {
+      margin-top: 8px;
+      width: 245px;
+    }
+  }
+}

--- a/assets/scss/components/slices/statistics.scss
+++ b/assets/scss/components/slices/statistics.scss
@@ -1,6 +1,6 @@
 .statistics {
   &__title h2 {
-    color: $grey-11;
+    color: $grey-90;
     font-size: 1.75rem;
     font-weight: normal;
     height: 80px;
@@ -59,7 +59,7 @@
 .statistics-wrapper-item {
   &__title h3 {
     width: 293px;
-    color: $blue-5;
+    color: $grey-90;
     text-align: center;
     font-size: 2rem;
     letter-spacing: 0;
@@ -71,7 +71,7 @@
   &__description {
     text-align: center;
     width: 293px;
-    color: $grey-10;
+    color: $grey-45;
     font-size: 1.25rem;
     letter-spacing: 0;
     line-height: 32px;

--- a/assets/scss/components/slices/statistics.scss
+++ b/assets/scss/components/slices/statistics.scss
@@ -1,0 +1,107 @@
+.statistics {
+  &__title h2 {
+    color: $grey-11;
+    font-size: 1.75rem;
+    font-weight: normal;
+    height: 80px;
+    letter-spacing: 0.15px;
+    line-height: 40px;
+    text-align: center;
+    margin-top: 48px;
+  }
+
+  &__subtitle h3 {
+    position: relative;
+    top: 24px;
+    font-size: 1rem;
+    font-weight: $font-light;
+    height: 49px;
+    letter-spacing: 0.009rem;
+    line-height: 49px;
+    text-align: center;
+  }
+
+  &__wrapper {
+    padding: 0 34px;
+  }
+}
+
+.statistics-wrapper {
+  &__row {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 24px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &__item {
+    height: 196px;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-bottom: 32px;
+
+    &:last-child {
+      margin-right: 0;
+      margin-bottom: 32px;
+    }
+
+    p {
+      margin: 0;
+    }
+  }
+}
+
+.statistics-wrapper-item {
+  &__title h3 {
+    width: 293px;
+    color: $blue-5;
+    text-align: center;
+    font-size: 2rem;
+    letter-spacing: 0;
+    line-height: 43px;
+    font-weight: 600;
+    margin-top: 17px;
+  }
+
+  &__description {
+    text-align: center;
+    width: 293px;
+    color: $grey-10;
+    font-size: 1.25rem;
+    letter-spacing: 0;
+    line-height: 32px;
+    margin-top: 5px;
+  }
+}
+
+@include device-is('tablet') {
+  .statistics {
+    &__title h2 {
+      font-size: 2rem;
+    }
+  }
+  .statistics-wrapper {
+    &__row {
+      flex-direction: row;
+    }
+  }
+}
+
+@include device-is('large-screen') {
+  .statistics {
+    &__wrapper {
+      padding: 0 98px;
+    }
+  }
+
+  .statistics-wrapper {
+    &__item {
+      margin-bottom: 61px;
+    }
+  }
+}

--- a/assets/scss/components/slices/statistics.scss
+++ b/assets/scss/components/slices/statistics.scss
@@ -3,11 +3,10 @@
     color: $grey-90;
     font-size: 1.75rem;
     font-weight: normal;
-    height: 80px;
     letter-spacing: 0.15px;
     line-height: 40px;
     text-align: center;
-    margin-top: 48px;
+    margin: 60px 0 64px 0;
   }
 
   &__subtitle h3 {
@@ -22,7 +21,7 @@
   }
 
   &__wrapper {
-    padding: 0 34px;
+    padding: 0 34px 61px 34px;
   }
 }
 
@@ -36,7 +35,9 @@
       margin-bottom: 0;
     }
   }
+}
 
+.statistics-wrapper-row {
   &__item {
     height: 196px;
     width: 100%;
@@ -49,14 +50,11 @@
       margin-right: 0;
       margin-bottom: 32px;
     }
-
-    p {
-      margin: 0;
-    }
   }
 }
 
-.statistics-wrapper-item {
+.statistics-wrapper-row-item {
+
   &__title h3 {
     width: 293px;
     color: $grey-90;
@@ -76,6 +74,10 @@
     letter-spacing: 0;
     line-height: 32px;
     margin-top: 5px;
+
+    p {
+      margin: 0;
+    }
   }
 }
 
@@ -99,7 +101,7 @@
     }
   }
 
-  .statistics-wrapper {
+  .statistics-wrapper-row {
     &__item {
       margin-bottom: 61px;
     }

--- a/components/SliceZone.vue
+++ b/components/SliceZone.vue
@@ -53,6 +53,9 @@
       <template v-if="slice.slice_type === 'process'">
         <process-slice :slice="slice" />
       </template>
+      <template v-if="slice.slice_type === 'multiple_block'">
+        <multiple-block-slice :slice="slice" />
+      </template>
       <template v-if="slice.slice_type === 'partners_logos'">
         <partners-logos-slice :slice="slice" />
       </template>
@@ -71,11 +74,13 @@ import PopInCampaigns from '@/components/slices/PopInCampaigns'
 import PageSection from '@/components/slices/PageSection'
 import WebSnippet from '@/components/slices/WebSnippet'
 import FeaturesSlice from '@/components/slices/Features'
+import MultipleBlockSlice from '@/components/slices/MultipleBlock'
 import PartnersLogosSlice from '@/components/slices/PartnersLogos'
 
 export default {
   name: 'SliceZone',
   components: {
+    MultipleBlockSlice,
     PageBanner,
     ArticleSlice,
     HeroBanner,

--- a/components/slices/MultipleBlock.vue
+++ b/components/slices/MultipleBlock.vue
@@ -1,35 +1,35 @@
 <template>
-  <section class="block" :style="[background]">
+  <section :class="blockClass" :style="[background]">
     <prismic-rich-text
       v-if="hasTitle && shouldDisplayTitle"
-      class="block__title"
+      :class="`${blockClass}__title`"
       :field="title"
     />
     <prismic-rich-text v-else class="sr-only" :field="title" />
     <prismic-rich-text
       v-if="shouldUseSubtitle && hasSubtitle"
-      class="block__subtitle"
+      :class="`${blockClass}__subtitle`"
       :field="subtitle"
     />
-    <div class="block__wrapper">
+    <div :class="`${blockClass}__wrapper`">
       <div
         v-for="(itemsByRow, rowIndex) in rows"
         :key="`row-${rowIndex}`"
-        class="block-wrapper__row"
+        :class="`${blockClass}-wrapper__row`"
       >
         <div
           v-for="(item, itemIndex) in itemsByRow"
           :key="`item-${itemIndex}`"
-          class="block-wrapper__item"
+          :class="`${blockClass}-wrapper__item`"
         >
           <pix-image v-if="hasImage(item)" :field="item.item_image" />
           <div>
             <prismic-rich-text
-              class="block-wrapper-item__title"
+              :class="`${blockClass}-wrapper-item__title`"
               :field="item.item_title"
             />
             <prismic-rich-text
-              class="block-wrapper-item__description"
+              :class="`${blockClass}-wrapper-item__description`"
               :field="item.item_description"
             />
           </div>
@@ -63,6 +63,9 @@ export default {
       return {
         backgroundColor: `${this.slice.primary.block_background_color}`,
       }
+    },
+    blockClass() {
+      return this.slice.primary.block_style
     },
     items() {
       return this.slice.items
@@ -136,3 +139,9 @@ export default {
   },
 }
 </script>
+
+<style lang="scss">
+@import '../../assets/scss/components/slices/features.scss';
+@import '../../assets/scss/components/slices/process.scss';
+@import '../../assets/scss/components/slices/statistics.scss';
+</style>

--- a/components/slices/MultipleBlock.vue
+++ b/components/slices/MultipleBlock.vue
@@ -108,7 +108,7 @@ export default {
       const isObjectConstructor = item.item_image.constructor === Object
       return isLengthDifferentThanZero && isObjectConstructor
     },
-    findNbItemsInRow() {
+    numberItemsPerRowForScreenWidth() {
       if (process.client) {
         const isLargeScreen = document.body.clientWidth >= DESKTOP_MIN_WIDTH
         const isExtraLargeScreen =
@@ -130,9 +130,17 @@ export default {
     },
     splitItemsIntoRows() {
       const rows = []
-      const chunkSize = this.findNbItemsInRow()
-      for (let i = 0; i < this.items.length; i += chunkSize) {
-        rows.push(this.items.slice(i, i + chunkSize))
+      const numberOfItemsPerRow = this.numberItemsPerRowForScreenWidth()
+      for (
+        let item = 0;
+        item < this.items.length;
+        item += numberOfItemsPerRow
+      ) {
+        const screenSizedItems = this.items.slice(
+          item,
+          item + numberOfItemsPerRow
+        )
+        rows.push(screenSizedItems)
       }
       return rows
     },

--- a/components/slices/MultipleBlock.vue
+++ b/components/slices/MultipleBlock.vue
@@ -20,16 +20,16 @@
         <div
           v-for="(item, itemIndex) in itemsByRow"
           :key="`item-${itemIndex}`"
-          :class="`${blockClass}-wrapper__item`"
+          :class="`${blockClass}-wrapper-row__item`"
         >
           <pix-image v-if="hasImage(item)" :field="item.item_image" />
           <div>
             <prismic-rich-text
-              :class="`${blockClass}-wrapper-item__title`"
+              :class="`${blockClass}-wrapper-row-item__title`"
               :field="item.item_title"
             />
             <prismic-rich-text
-              :class="`${blockClass}-wrapper-item__description`"
+              :class="`${blockClass}-wrapper-row-item__description`"
               :field="item.item_description"
             />
           </div>

--- a/components/slices/MultipleBlock.vue
+++ b/components/slices/MultipleBlock.vue
@@ -1,0 +1,138 @@
+<template>
+  <section class="block" :style="[background]">
+    <prismic-rich-text
+      v-if="hasTitle && shouldDisplayTitle"
+      class="block__title"
+      :field="title"
+    />
+    <prismic-rich-text v-else class="sr-only" :field="title" />
+    <prismic-rich-text
+      v-if="shouldUseSubtitle && hasSubtitle"
+      class="block__subtitle"
+      :field="subtitle"
+    />
+    <div class="block__wrapper">
+      <div
+        v-for="(itemsByRow, rowIndex) in rows"
+        :key="`row-${rowIndex}`"
+        class="block-wrapper__row"
+      >
+        <div
+          v-for="(item, itemIndex) in itemsByRow"
+          :key="`item-${itemIndex}`"
+          class="block-wrapper__item"
+        >
+          <pix-image v-if="hasImage(item)" :field="item.item_image" />
+          <div>
+            <prismic-rich-text
+              class="block-wrapper-item__title"
+              :field="item.item_title"
+            />
+            <prismic-rich-text
+              class="block-wrapper-item__description"
+              :field="item.item_description"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script>
+import {
+  EXTRA_LARGE_SCREEN_MIN_WIDTH,
+  DESKTOP_MIN_WIDTH,
+} from '~/config/breakpoints'
+
+export default {
+  name: 'MultipleBlock',
+  props: {
+    slice: {
+      type: Object,
+      default: null,
+    },
+  },
+  data() {
+    return {
+      rows: [],
+    }
+  },
+  computed: {
+    background() {
+      return {
+        backgroundColor: `${this.slice.primary.block_background_color}`,
+      }
+    },
+    items() {
+      return this.slice.items
+    },
+    shouldDisplayTitle() {
+      return this.slice.primary.block_should_display_title
+    },
+    shouldUseSubtitle() {
+      return this.slice.primary.block_should_use_subtitle
+    },
+    hasTitle() {
+      return (
+        this.slice.primary.block_title &&
+        this.slice.primary.block_title.length &&
+        this.slice.primary.block_title[0].text &&
+        this.slice.primary.block_title[0].text.length
+      )
+    },
+    hasSubtitle() {
+      return (
+        this.slice.primary.block_subtitle &&
+        this.slice.primary.block_subtitle.length &&
+        this.slice.primary.block_subtitle[0].text &&
+        this.slice.primary.block_subtitle[0].text.length
+      )
+    },
+    title() {
+      return this.slice.primary.block_title
+    },
+    subtitle() {
+      return this.slice.primary.block_subtitle
+    },
+  },
+  mounted() {
+    this.rows = this.splitItemsIntoRows()
+  },
+  methods: {
+    hasImage(item) {
+      const isLengthDifferentThanZero = Object.keys(item.item_image).length
+      const isObjectConstructor = item.item_image.constructor === Object
+      return isLengthDifferentThanZero && isObjectConstructor
+    },
+    findNbItemsInRow() {
+      if (process.client) {
+        const isLargeScreen = document.body.clientWidth >= DESKTOP_MIN_WIDTH
+        const isExtraLargeScreen =
+          document.body.clientWidth >= EXTRA_LARGE_SCREEN_MIN_WIDTH
+
+        if (this.items.length === 3 && isLargeScreen) {
+          return 3
+        }
+        if (this.items.length === 4) {
+          if (isExtraLargeScreen) {
+            return 4
+          }
+          if (isLargeScreen) {
+            return 3
+          }
+        }
+        return 2
+      }
+    },
+    splitItemsIntoRows() {
+      const rows = []
+      const chunkSize = this.findNbItemsInRow()
+      for (let i = 0; i < this.items.length; i += chunkSize) {
+        rows.push(this.items.slice(i, i + chunkSize))
+      }
+      return rows
+    },
+  },
+}
+</script>


### PR DESCRIPTION
## :unicorn: Problème

Il manque un bloc statistique contribuable par la team Contenu sur Prismic.

## :robot: Solution

Ce nouveau bloc présentant les mêmes caractéristiques au niveau du `template` et du `script` que les blocs **Feature** et **Process**, nous avons opté pour une refacto de ces trois composants avec des appels à des fichiers SCSS externes et propres à chacun des blocs en fonction du type de ces derniers à créer sur Prismic. 

- Création d'un composant `MultipleBlock` (Prismic et code) reprenant le template et la logique des composants Process, Features et Stats
- Création d'un dossier slices dans `assets/scss` afin de copier l'architecture du dossier de composants Vue (components/slices) avec ajout des styles des différents composants faisant appel à MultipleBlock
- Update 14/10/2020 : Modification des couleurs utilisées dans les fichiers CSS afin de suivre le design system suite à la PR #200 

## :rainbow: Remarques

Je me demande si `MultipleBlock` est un nom pertinent pour ce composant. 🧐
Je n'ai pas réussi à trouver quelque chose de succinct pour exprimer la réutilisation possible de ce composant par différents blocs dans Prismic.

## :sparkles: Review App
https://site-pr193.review.pix.fr/
https://pro-pr193.review.pix.fr/
