### PR TITLE
[BUGFIX] Gestion des liens sur Pix-pro.

### DIFF
--- a/components/PixLink.vue
+++ b/components/PixLink.vue
@@ -55,7 +55,12 @@ function getRelativeLinkPrefix(url) {
   if (!url) {
     return ''
   }
-  const defaultPrefixes = 'https://pix.org,https://pix.fr'
+  let defaultPrefixes
+  if (process.env.isPixPro) {
+    defaultPrefixes = 'https://pro.pix.fr'
+  } else {
+    defaultPrefixes = 'https://pix.org,https://pix.fr'
+  }
   const relativeLinkPrefixes = (
     process.env.RELATIVE_LINK_PREFIXES || defaultPrefixes
   ).split(',')

--- a/components/slices/PageSection.vue
+++ b/components/slices/PageSection.vue
@@ -16,9 +16,9 @@
           <prismic-rich-text :field="item.paragraph" />
         </div>
       </div>
-      <a v-if="hasButton" :href="buttonLink" :class="buttonClass">
+      <pix-link v-if="hasButton" :href="buttonLink" :class="buttonClass">
         {{ $prismic.asText(buttonText) }}
-      </a>
+      </pix-link>
     </div>
   </section>
 </template>

--- a/components/slices/PageSection.vue
+++ b/components/slices/PageSection.vue
@@ -16,7 +16,7 @@
           <prismic-rich-text :field="item.paragraph" />
         </div>
       </div>
-      <pix-link v-if="hasButton" :href="buttonLink" :class="buttonClass">
+      <pix-link v-if="hasButton" :field="buttonLink" :class="buttonClass">
         {{ $prismic.asText(buttonText) }}
       </pix-link>
     </div>
@@ -70,7 +70,7 @@ export default {
       return this.slice.primary.description
     },
     buttonLink() {
-      return this.slice.primary.button_link.url
+      return this.slice.primary.button_link
     },
     buttonText() {
       return this.slice.primary.button_title


### PR DESCRIPTION
## :unicorn: Problème
Le site Pix-site utilise le composant `pix-link` pour gérer spécifiquement les liens vers les documents, les liens vers pix.fr et les liens externes.
Le site Pro.pix.fr n'utilisait pas ces liens partout, et n'était pas considéré dans ce composant.

## :robot: Solution
- Ajout du `pix-link` à la place d'un `a` dans la Page Section
- Changement des sites relatives pour considérés `pro.pix.fr`

## :rainbow: Remarques
Bug remontés actuellement sur la prod quand on clique sur "Contactez-nous" sur la page Employers

## :sparkles: Review App
https://site-pr194.review.pix.fr/
https://pro-pr194.review.pix.fr/
