### PR TITLE
[BUGFIX] Fix appel à /undefined (PIX-1402).

### DIFF
--- a/components/slices/Article.vue
+++ b/components/slices/Article.vue
@@ -88,7 +88,7 @@ export default {
     },
     background() {
       let style = {}
-      if (this.isOnlyTextLayout) {
+      if (this.isOnlyTextLayout && this.hasBackgroundImage) {
         style = {
           background: `no-repeat url(${this.content.article_background.url})`,
           backgroundSize: '100%',
@@ -102,6 +102,11 @@ export default {
       return (
         this.content.article_video &&
         this.content.article_video.link_type !== 'Any'
+      )
+    },
+    hasBackgroundImage() {
+      return (
+        this.content.article_background && this.content.article_background.url
       )
     },
     isOnlyTextLayout() {


### PR DESCRIPTION
## :unicorn: Problème
Des appels vers ${host}/undefined se font sur la page index.

## :robot: Solution
Des background-image à `undefined` sont définis sur les éléments HTML.
Il faut vérifier si l'image est présente côté Prismic avant de l'attribuer côté app.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :sparkles: Review App
Vérifier que l'on a plus d'appels à ${host}/undefined dans la console du navigateur sur la page index.
https://site-pr195.review.pix.fr/
https://pro-pr195.review.pix.fr/
