### PR TITLE
Mise en place du nouveau Matomo

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -83,7 +83,7 @@ export default {
     '@nuxtjs/style-resources',
     ['nuxt-i18n', { detectBrowserLanguage: false }],
     '@nuxtjs/moment',
-    ['nuxt-matomo', { matomoUrl: 'https://stats.pix.fr/', siteId: 1 }],
+    ['nuxt-matomo', { matomoUrl: 'https://analytics.pix.fr/', siteId: 1 }],
     [
       'nuxt-fontawesome',
       {


### PR DESCRIPTION
## :unicorn: Contexte

Matomo a été migré depuis OVH (https://stats.pix.fr) vers Scalingo (https://analytics.pix.fr). 

## :robot: Changement

L'objet de cette PR est de mettre à jour la configuration Matomo de Nuxt pour pointer vers le nouveau serveur.

## :rainbow: Remarques

Depuis la fusion des 2 sites Pix.fr et Pix Pro, tous deux pointent vers le même Matomo. 

Il faudra faire le nécessaire pour dissocier les 2 sites dans le futur.

## :sparkles: Review App
https://site-pr000.review.pix.fr/
https://pro-pr000.review.pix.fr/
