### PR TITLE
[FEATURE] Préciser le domaine Pix ou Pix pro dans les titres (PIX-1233).

### DIFF
--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -44,7 +44,6 @@ export default {
   'page-titles': {
     about: 'Who are we ? | Pix',
     'contact-digital-mediation': 'Request for information | Pix',
-    'higher-education': 'Higher education | Pix',
     'higher-education-establishment-registration':
       'Slot inquiry | Pix Orga sup',
     index: 'Accueil | Pix',

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -42,7 +42,6 @@ export default {
   'page-titles': {
     about: 'Qui sommes-nous ? | Pix',
     'contact-digital-mediation': "Demande d'information | Pix",
-    'higher-education': 'Enseignement supérieur | Pix',
     'higher-education-establishment-registration':
       "Demande d'espace | Pix Orga sup",
     index: 'Accueil | Pix',

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -42,7 +42,6 @@ export default {
   'page-titles': {
     about: 'Qui sommes-nous ? | Pix',
     'contact-digital-mediation': "Demande d'information | Pix",
-    'higher-education': 'Enseignement supérieur | Pix',
     'higher-education-establishment-registration':
       "Demande d'espace | Pix Orga sup",
     index: 'Accueil | Pix',

--- a/pages/pix-pro/_custom-page.vue
+++ b/pages/pix-pro/_custom-page.vue
@@ -53,7 +53,7 @@ export default {
 
     return {
       meta,
-      title: this.title,
+      title: `${this.title} | Pix Pro`,
     }
   },
 }

--- a/pages/pix-site/_custom-page.vue
+++ b/pages/pix-site/_custom-page.vue
@@ -53,7 +53,7 @@ export default {
 
     return {
       meta,
-      title: this.title,
+      title: `${this.title} | Pix`,
     }
   },
 }

--- a/pages/pix-site/news/_slug.vue
+++ b/pages/pix-site/news/_slug.vue
@@ -47,6 +47,7 @@ export default {
     )
     return {
       meta,
+      title: `${this.newsItem.data.title[0].text} | Pix`,
     }
   },
 }

--- a/pages/pix-site/news/_slug.vue
+++ b/pages/pix-site/news/_slug.vue
@@ -16,6 +16,7 @@ import NewsItemPost from '@/components/NewsItemPost'
 export default {
   nuxtI18n: {
     paths: {
+      fr: '/actualites/:slug',
       'fr-fr': '/actualites/:slug',
       'en-gb': '/news/:slug',
     },


### PR DESCRIPTION
## :unicorn: Problème
Actuellement : 
- Les titres des pages créées dans le code sont dans les traductions
- Les titres des pages Slices ou Simple sont uniquement les titres préciser dans Prismic

## :robot: Solution
- Sur les pages contribuables, on ajoute '| Pix' ou '| Pix pro' au titre

## :rainbow: Remarques
- BSR : suppression du titre de la page Ens. Sup. qui a été supprimé
- BSR : Il n'y avait pas de précisions d'url pour les actualités en FR

## :100: Pour tester
- Vérifier les site .pro, .org et .fr
- La page Accessibilité est une Simple Page : Voir qu'il y a | Pix quand on l'appel sur pix.fr et | Pix Pro quand on l'appel sur pix pro