### PR TITLE
[BUGFIX] Correction des tailles d'images et de titres du MultipleBlock-Features (PIX-1530).

### DIFF
--- a/assets/scss/components/slices/features.scss
+++ b/assets/scss/components/slices/features.scss
@@ -1,7 +1,7 @@
 .features {
   &__title h2 {
-    color: $grey-90;
-    font-size: 2.125rem;
+    color: $grey-80;
+    font-size: 1.75rem;
     font-weight: normal;
     height: 49px;
     letter-spacing: 0.15px;
@@ -42,7 +42,7 @@
 
     img {
       margin-right: 25px;
-      max-width: 55px;
+      max-height: 74px;
     }
   }
 }
@@ -51,7 +51,7 @@
 
     &__title h3 {
       width: 217px;
-      color: $grey-45;
+      color: $grey-90;
       font-size: 1rem;
       letter-spacing: 0;
       line-height: 30px;
@@ -72,6 +72,7 @@
   .features {
     &__title h2 {
       margin-top: 80px;
+      font-size: 2.125rem;
     }
     &__wrapper {
       padding: 80px 0;
@@ -84,8 +85,6 @@
 
       img {
         margin-right: 32px;
-        height: 73px;
-        width: 65px;
       }
     }
   }
@@ -162,11 +161,6 @@
     &__item {
       margin-right: 76px;
       text-align: center;
-
-      img {
-        height: 73px;
-        width: 65px;
-      }
     }
   }
 

--- a/assets/scss/components/slices/features.scss
+++ b/assets/scss/components/slices/features.scss
@@ -42,8 +42,7 @@
 
     img {
       margin-right: 25px;
-      height: 62px;
-      width: 55px;
+      max-width: 55px;
     }
   }
 }

--- a/assets/scss/components/slices/statistics.scss
+++ b/assets/scss/components/slices/statistics.scss
@@ -50,6 +50,10 @@
       margin-right: 0;
       margin-bottom: 32px;
     }
+
+    img {
+      max-height: 65px;
+    }
   }
 }
 

--- a/assets/scss/components/slices/statistics.scss
+++ b/assets/scss/components/slices/statistics.scss
@@ -66,7 +66,7 @@
     font-size: 2rem;
     letter-spacing: 0;
     line-height: 43px;
-    font-weight: 600;
+    font-weight: $font-semi-bold;
     margin-top: 17px;
   }
 


### PR DESCRIPTION
## :unicorn: Problème

Les images des blocs Process, Stats et Features qu'il est possible de réaliser n'ont pas la même taille.
Or le block était défini sur Prismic avec une taille d'image de 51px X 51px  pour les trois types de blocs, causant des rognages sur certains blocs lorsque les images étaient trop grandes/larges.

## :robot: Solution

- Modification du Custom Type sur Prismic avec une taille auto correspondant à la taille originelle de l'image importée.
- Ajout de CSS pour fixer la taille des images dans les blocs où cela est nécessaire.

## :100: Pour tester

Aller sur la [RA](https://site-pr206.review.pix.fr/enseignement-scolaire2) et remarquer d'éventuelles différences entre le bloc features de test et celui du dessus.

A noter que la taille de la police des titres des items a changé afin de mieux coller aux [maquettes](https://app.abstract.com/projects/c43b8749-ba3a-474e-a6c5-dbf76bade2ee/branches/0f98f94c-8f44-4d4f-a988-72be104570aa/collections/186f2f0a-48b6-4835-a08d-fe2f159c7ab9).
