### PR TITLE
[CLEANUP] Supprimer les titres H1 sur les cartes des news

### DIFF
--- a/components/NewsItemCard.vue
+++ b/components/NewsItemCard.vue
@@ -23,7 +23,7 @@
           </span>
         </p>
 
-        <prismic-rich-text :field="slice.title" class="news-item-card__title" />
+        <h3 class="news-item-card__title">{{ slice.title[0].text }}</h3>
 
         <prismic-rich-text
           :field="slice.excerpt"
@@ -204,7 +204,7 @@ export default {
     font-weight: 300;
   }
 
-  &__title h1 {
+  &__title {
     font-size: 1.4rem;
     line-height: 1.8rem;
     color: #222222;


### PR DESCRIPTION
## :unicorn: Problème
Les news ont un niveau H1 pour les titres, ce qu'on 

## :robot: Solution
Forcer un H3 sur les titres des cartes news

## :rainbow: Remarques
Une réflexion a11y sur les titres sera a mené une fois l'audit réalisé

## :100: Pour tester
Voir la home
