### PR TITLE
[CLEANUP] Renommage de la route Legal Notice

### DIFF
--- a/pages/pix-site/legal-notices.vue
+++ b/pages/pix-site/legal-notices.vue
@@ -36,7 +36,7 @@ export default {
     paths: {
       fr: '/mentions-legales',
       'fr-fr': '/mentions-legales',
-      'en-gb': '/en-gb/legal-notices',
+      'en-gb': '/legal-notice',
     },
   },
   components: { PageSection },


### PR DESCRIPTION
## :unicorn: Problème
La page mention légales est en cours de traduction, mais l'url /en-gb/legal-notice ne fonctionne pas, car elle a été mal créé dans le code

## :robot: Solution
Renommer correctement le Path de cette page

## :rainbow: Remarques
Cette page est vouée à être supprimée et remplacée par une Simple Page, mais cela devra attendre la fin de l'audit car elle fait partie des pages à ne pas modifier

## :100: Pour tester
Aller sur https://site-pr212.review.pix.org/en-gb/legal-notice
