### PR TITLE
[BUGFIX] Pages en Erreur 404 sur les sites .fr et .org (PIX-1611)

### DIFF
--- a/components/PixLink.vue
+++ b/components/PixLink.vue
@@ -25,15 +25,17 @@ export default {
       const relativeLinkPrefix = getRelativeLinkPrefix(url)
 
       if (this.field.link_type === 'Document') {
+        const localeURL = getLocaleUrl(url, this.localePath)
         template = `
-          <router-link to="${this.localePath(url)}" exact>
+          <router-link to="${localeURL}" exact>
             <slot/>
           </router-link>
         `
       } else if (relativeLinkPrefix) {
         const relativeUrl = url.replace(relativeLinkPrefix, '/')
+        const localeURL = getLocaleUrl(relativeUrl, this.localePath)
         template = `
-          <router-link to="${this.localePath(relativeUrl)}" exact>
+          <router-link to="${localeURL}" exact>
             <slot/>
           </router-link>
         `
@@ -51,6 +53,18 @@ export default {
     },
   },
 }
+
+function getLocaleUrl(url, localePath) {
+  if (
+    url.startsWith('/fr') ||
+    url.startsWith('/en-gb') ||
+    url.startsWith('/fr-fr')
+  ) {
+    return url
+  }
+  return localePath(url)
+}
+
 function getRelativeLinkPrefix(url) {
   if (!url) {
     return ''

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -60,6 +60,7 @@ export default {
     '~/plugins/meta.js',
     { src: '~plugins/slide-menu', ssr: false },
     '~plugins/vue-js-modal',
+    { src: '~/plugins/prismicLinks', ssr: false },
   ],
 
   /*

--- a/plugins/html-serializer.js
+++ b/plugins/html-serializer.js
@@ -11,7 +11,7 @@ export default function (type, element, content, children) {
     const url = prismicDOM.Link.url(element.data, linkResolver)
 
     if (element.data.link_type === 'Document') {
-      result = `<nuxt-link to="${url}">${content}</nuxt-link>`
+      result = `<a href="${url}" data-nuxt-link>${content}</a>`
     } else {
       const target = element.data.target
         ? `target="'${element.data.target}'" rel="noopener"`

--- a/plugins/link-resolver.js
+++ b/plugins/link-resolver.js
@@ -8,9 +8,11 @@ export default function (doc) {
     'cgu_page',
     'statistiques',
     'legal-notices',
+    'simple_page',
   ]
   if (staticRoute.includes(doc.type)) {
-    return `/${doc.uid}`
+    const locale = doc.lang !== 'fr-fr' ? `/${doc.lang}` : ''
+    return `${locale}/${doc.uid}`
   }
   if (doc.type === 'news_item') {
     return `/actualites/${doc.uid}`

--- a/plugins/prismicLinks.js
+++ b/plugins/prismicLinks.js
@@ -1,0 +1,16 @@
+export default ({ redirect }) => {
+  window.addEventListener(
+    'click',
+    (event) => {
+      // If the clicked element doesn't have the right selector, bail
+      if (!event.target.matches('a[data-nuxt-link]')) return
+
+      // Don't follow the link
+      event.preventDefault()
+
+      // Push link destination to router
+      redirect(event.target.pathname)
+    },
+    false
+  )
+}


### PR DESCRIPTION
## :unicorn: Problème

Certaines pages en ligne sur Prismic qui sont en Erreur 404 sur les sites .fr et .org : les pages Protection des données à caractère personnel et la Liste des sous-traitants.

Elles ne sont pas référencées dans la nav ou le footer, mais par un lien dans les CGU vers la Politique de protection, et un lien dans la Politique de protection vers la Liste des sous-traitants.

## :robot: Solution

Ces 2 liens (Protection des données à caractère personnel et la Liste des sous-traitants) sont actuellement des liens de type "Web" vers pix.fr dans des éléments RichText de Prismic. Par conséquence, à la génération statique, ces liens ne sont pas parcouru et donc `nuxt` ne génère pas ces pages.

Nous avons déjà un mécanisme mis en place afin de transformer les liens de type `Document` des RichText Prismic. Mais ce mécanisme a un bug pour les liens de type document car ils sont transformés en `nuxt-link` qui ne sont pas interprété.

Pour corriger ce bug, nous avons mis en place cette solution (utilisé dans le [projet d'exemple nuxt de prismic](https://github.com/prismicio/nuxtjs-blog)):
https://github.com/nuxt-community/prismic-module/issues/60

Les liens sont transformés en lien marqué `nuxt-link` (`<a data-nuxt-link>`) puis ces liens sont gérés par le plugin `prismicLink`.

## :rainbow: Remarques

Les liens "Protection des données à caractère personnel" et la "Liste des sous-traitants" ont déjà été changé de type `Web` en type `Document`.

## :100: Pour tester

1. Aller sur la page des CGU (lien dans le footer)
2. Cliquer sur le lien "Politique de protection des données à caractère personnel" (Chapitre 12)
3. Cliquer sur le lien "Lien vers la liste des sous-traitants" (Chapitre "Sous-traitants du GIP Pix")

