### PR TITLE
[BUGFIX] Pouvoir voir tout le texte en mode mobile (PIX-1714).

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -51,6 +51,10 @@ h6 {
   font-family: 'Nunito', Arial, sans-serif;
 }
 
+p,
+div {
+  word-wrap: break-word;
+}
 .app-viewport {
   .app-brand {
     height: 66px;


### PR DESCRIPTION
## :unicorn: Problème
Problème remonté lors de l'audit : 
> Sur la page /accessibilite, les adresses liées au défenseur des droits sont coupées lorsque la page est réduite à une largeur de 320px.

## :robot: Solution
Ajouter `word-wrap: break-word` dans les `div` et `p` du site 

## :rainbow: Remarques
La propriété word-break est utilisée pour définir la façon dont la césure s'applique pour les endroits où le texte dépasserait de sa boîte de contenu.

## :100: Pour tester
- Visiter les pages en mode mobile, et notamment la page a11y avec les liens en bas.
