### PR TITLE
[CLEANUP] Utiliser une SlicePage pour l'index du site vitrine (PIX-1444).

### DIFF
--- a/pages/pix-site/index.vue
+++ b/pages/pix-site/index.vue
@@ -6,53 +6,65 @@
 
 <script>
 import SliceZone from '@/components/SliceZone'
-import { documents, documentFetcher } from '~/services/document-fetcher'
+import { documentFetcher } from '~/services/document-fetcher'
 
 export default {
+  name: 'Index',
+  nuxtI18n: {
+    paths: {
+      fr: '/',
+      'fr-fr': '/',
+      'en-gb': '/',
+    },
+  },
   components: {
     SliceZone,
   },
-  async asyncData({ app, error, req, currentPagePath }) {
+  async asyncData({ params, app, req, error, currentPagePath }) {
     try {
-      const document = await documentFetcher(app.$prismic, app.i18n, req).get(
-        documents.index
-      )
+      const document = await documentFetcher(
+        app.$prismic,
+        app.i18n,
+        req
+      ).getPageByUid('index-pix-site')
+
+      const meta = document.data.meta
 
       const latestNewsItems = await documentFetcher(
         app.$prismic,
         app.i18n,
         req
       ).findNewsItems({ page: 1, pageSize: 3 })
-
-      return {
-        currentPagePath,
-        meta: document.data.meta,
-        document: document.data.body,
-        latestNewsItems,
-      }
+      return { currentPagePath, meta, document, latestNewsItems }
     } catch (e) {
-      // eslint-disable-next-line no-console
-      console.error({ e })
       error({ statusCode: 404, message: 'Page not found' })
     }
   },
-  head() {
-    const meta = this.$getMeta(this.meta, this.currentPagePath, this.$prismic)
-    const pageTitle = this.$t('page-titles.index')
-    return {
-      title: pageTitle,
-      meta,
-    }
-  },
+
   computed: {
     slices() {
-      return this.document.map((slice, index) => {
+      const rawDocumentSlices = this.document.data.body
+      return rawDocumentSlices.map((slice, index) => {
         if (slice.slice_type === 'latest_news') {
           slice.primary.latest_news_items = this.latestNewsItems
         }
         return slice
       })
     },
+    type() {
+      return this.document.type
+    },
+    title() {
+      return this.document.data.title[0].text
+    },
+  },
+  head() {
+    const meta = this.$getMeta(this.meta, this.currentPagePath, this.$prismic)
+
+    return {
+      meta,
+      title: `${this.title} | Pix`,
+    }
   },
 }
 </script>

--- a/tests/pages/pix-site/index.test.js
+++ b/tests/pages/pix-site/index.test.js
@@ -8,11 +8,12 @@ describe('Index Page', () => {
 
   beforeEach(async () => {
     documentFetcher.mockReturnValue({
-      get: () =>
+      getPageByUid: () =>
         Promise.resolve({
           data: {
             id: '',
             meta: '',
+            type: 'slice_page',
             body: [{}, {}, {}, {}, {}, {}, {}, {}],
           },
         }),


### PR DESCRIPTION
## :unicorn: Problème
La page Index du site Vitrine utilise encore un document spécial de Prismic (index). On voudrait utiliser une slice page comme toutes les autres pages.

## :robot: Solution
- Changer la façon dont le document est récupéré

## :100: Pour tester
Voir la page sur : 
