### PR TITLE
[TECH] Désactiver la prévisualisation de Prismic quand le mode SSR n'est pas activé.

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -159,6 +159,7 @@ export default {
     endpoint: process.env.PRISMIC_API_ENDPOINT,
     linkResolver: '@/plugins/link-resolver',
     htmlSerializer: '@/plugins/html-serializer',
+    preview: process.env.SSR_ENABLED === 'true',
   },
   router: {
     middleware: 'current-page-path',


### PR DESCRIPTION
## :unicorn: Problème
Bien que l'on ait passé le site en mode statique, le plugin Prismic continue de faire un appel à `api.prismic.io`. Cela est du au fait que le plugin essaie de récupérer une preview si elle existe.

## :robot: Solution
Désactiver la prévisualisation de Prismic en suivant la documentation : [https://prismic.nuxtjs.org/previews#disabling-previews](https://prismic.nuxtjs.org/previews#disabling-previews).

## :rainbow: Remarques
On garde la prévisualisation activée pour le mode SSR, utilisée par preview.pix.fr.

## :100: Pour tester
Se rendre sur la Review App.
Vérifier qu'aucun appel vers `api.prismic.io` ne soit réalisé.

