### PR TITLE
[BUGFIX] Pouvoir avoir le footer pix-pro.

### DIFF
--- a/components/FooterSliceZone.vue
+++ b/components/FooterSliceZone.vue
@@ -57,6 +57,9 @@ export default {
     }
   },
   computed: {
+    isPixPro() {
+      return process.env.isPixPro
+    },
     ...mapState(['mainFooters']),
     usedMainFooter() {
       const groupBySite = groupBy(this.mainFooters, 'data.footer_for')


### PR DESCRIPTION
## :unicorn: Problème
- Le MainFooter pour Pix-Pro est présent dans Prismic, mais ne s'affiche pas.
- Cause : la vérification `this.isPixPro` renvoyait undefined car il n'y avait pas la computed associé

## :robot: Solution
- Remettre la computed associé

## :rainbow: Remarques

## :100: Pour tester
Aller sur le site pro, et ne pas voir le logo de la marianne en footer
