### PR TITLE
[BUGFIX] Afficher le titre de la page en title (PIX-2028).

### DIFF
--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -24,23 +24,11 @@ export default {
   },
   'news-page-title': 'News',
   'news-page-no-news': 'No news available for the moment.',
-  alt: {
-    footer: {
-      'back-to-homepage': 'Back to Pix homepage',
-      'backed-by-unesco': 'Backed by Unesco',
-      'backed-by-education-ministry':
-        'Backed by the French Ministry of Education',
-      'pix-homepage': 'Back to Pix homepage',
-    },
-    'header-nav': {
-      'pix-homepage': 'Pix homepage',
-      'public-service': 'Public State Service',
-    },
-  },
   announcement: 'Announcement',
   engineering: 'Engineering',
   event: 'Event',
   feature: 'Feature',
+  society: 'Society',
   form: {
     'not-supported':
       'Your browser does not support iframes. The contact form cannot be displayed. Please use another contact method (phone, fax etc)',
@@ -49,8 +37,7 @@ export default {
     'contact-digital-mediation': 'Request for information | Pix',
     'higher-education-establishment-registration':
       'Slot inquiry | Pix Orga sup',
-    index: 'Accueil | Pix',
-    news: 'Actualités | Pix',
+    news: 'News | Pix',
     'pix-certification-application':
       'Application for accreditation as a certification center | Pix',
     'pix-orga-higher-school-registration':
@@ -58,13 +45,6 @@ export default {
     'pix-orga-registration': 'Request for information | Pix pro',
   },
   'preview-page-load': 'Preview page loading...',
-  society: 'Society',
-  'resources-title': 'Resources',
-  'social-networks-title': 'Follow us',
-  'stats-legend-label-accounts': 'Comptes Pix créés',
-  'stats-legend-label-campaigns': 'Campagnes d’évaluation',
-  'stats-legend-label-certifications': 'Certifications Pix délivrées',
-  'stats-legend-label-organizations': 'Organisations partenaires',
   'error-content':
     '<p>Oups ! Un problème est survenu, mais pas de panix !</p>' +
     '<p>Vous pouvez revenir sur la ' +
@@ -72,8 +52,4 @@ export default {
     '<br/>Si vous avez besoin d’aide, vous pouvez consulter le ' +
     '<a href="https://support.pix.fr/">support</a>.' +
     '</p>',
-  layout: {
-    'main-nav': 'Main navigation',
-    'footer-nav': 'Secondary navigation',
-  },
 }

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -24,21 +24,11 @@ export default {
   },
   'news-page-title': 'Actualités',
   'news-page-no-news': "Il n’y a pas encore d'actualités",
-  alt: {
-    footer: {
-      'pix-homepage': "Retour à l'accueil Pix",
-      'backed-by-unesco': "Soutenu par l'Unesco",
-      'backed-by-education-ministry': "Soutenu par le ministère de l'éducation",
-    },
-    'header-nav': {
-      'pix-homepage': 'Accueil du site pix.fr',
-      'public-service': "Service public d'État",
-    },
-  },
   announcement: 'Annonce',
   engineering: 'Ingénierie',
   event: 'Événement',
   feature: 'Nouveauté',
+  society: 'Société',
   form: {
     'not-supported':
       "Votre navigateur ne supporte pas les iframes. Le formulaire de contact ne peut pas être affiché. Merci d'utiliser une autre méthode de contact (téléphone, fax, etc.)",
@@ -47,7 +37,6 @@ export default {
     'contact-digital-mediation': "Demande d'information | Pix",
     'higher-education-establishment-registration':
       "Demande d'espace | Pix Orga sup",
-    index: 'Accueil | Pix',
     news: 'Actualités | Pix',
     'pix-certification-application':
       "Demande d'agrément comme centre de certification | Pix",
@@ -56,13 +45,6 @@ export default {
     'pix-orga-registration': "Demande d'information | Pix pro",
   },
   'preview-page-load': 'Chargement de la page de prévisualisation...',
-  society: 'Société',
-  'resources-title': 'Ressources',
-  'social-networks-title': 'Nous suivre',
-  'stats-legend-label-accounts': 'Comptes Pix créés',
-  'stats-legend-label-campaigns': 'Campagnes d’évaluation',
-  'stats-legend-label-certifications': 'Certifications Pix délivrées',
-  'stats-legend-label-organizations': 'Organisations partenaires',
   'error-content':
     '<p>Oups ! Un problème est survenu, mais pas de panix !</p>' +
     '<p>Vous pouvez revenir sur la ' +
@@ -70,8 +52,4 @@ export default {
     '<br/>Si vous avez besoin d’aide, vous pouvez consulter le ' +
     '<a href="https://support.pix.fr/">support</a>.' +
     '</p>',
-  layout: {
-    'main-nav': 'Navigation principale',
-    'footer-nav': 'Navigation secondaire de pied de page',
-  },
 }

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -24,26 +24,15 @@ export default {
   },
   'news-page-title': 'Actualités',
   'news-page-no-news': "Il n’y a pas encore d'actualités",
-  alt: {
-    footer: {
-      'pix-homepage': "Retour à l'accueil Pix",
-      'backed-by-unesco': "Soutenu par l'Unesco",
-      'backed-by-education-ministry': "Soutenu par le ministère de l'éducation",
-    },
-    'header-nav': {
-      'pix-homepage': 'Accueil du site pix.fr',
-      'public-service': "Service public d'État",
-    },
-  },
   announcement: 'Annonce',
   engineering: 'Ingénierie',
   event: 'Événement',
   feature: 'Nouveauté',
+  society: 'Société',
   'page-titles': {
     'contact-digital-mediation': "Demande d'information | Pix",
     'higher-education-establishment-registration':
       "Demande d'espace | Pix Orga sup",
-    index: 'Accueil | Pix',
     news: 'Actualités | Pix',
     'pix-certification-application':
       "Demande d'agrément comme centre de certification | Pix",
@@ -56,13 +45,6 @@ export default {
       "Votre navigateur ne supporte pas les iframes. Le formulaire de contact ne peut pas être affiché. Merci d'utiliser une autre méthode de contact (téléphone, fax, etc.)",
   },
   'preview-page-load': 'Chargement de la page de prévisualisation...',
-  society: 'Société',
-  'resources-title': 'Ressources',
-  'social-networks-title': 'Nous suivre',
-  'stats-legend-label-accounts': 'Comptes Pix créés',
-  'stats-legend-label-campaigns': 'Campagnes d’évaluation',
-  'stats-legend-label-certifications': 'Certifications Pix délivrées',
-  'stats-legend-label-organizations': 'Organisations partenaires',
   'error-content':
     '<p>Oups ! Un problème est survenu, mais pas de panix !</p>' +
     '<p>Vous pouvez revenir sur la ' +
@@ -70,8 +52,4 @@ export default {
     '<br/>Si vous avez besoin d’aide, vous pouvez consulter le ' +
     '<a href="https://support.pix.fr/">support</a>.' +
     '</p>',
-  layout: {
-    'main-nav': 'Navigation principale',
-    'footer-nav': 'Navigation secondaire de pied de page',
-  },
 }

--- a/pages/pix-site/index.vue
+++ b/pages/pix-site/index.vue
@@ -38,6 +38,7 @@ export default {
         currentPagePath,
         meta: document.data.meta,
         document: document.data.body,
+        title: document.data.title[0].text,
         latestNewsItems,
       }
     } catch (e) {
@@ -48,9 +49,8 @@ export default {
   },
   head() {
     const meta = this.$getMeta(this.meta, this.currentPagePath, this.$prismic)
-    const pageTitle = this.$t('page-titles.index')
     return {
-      title: pageTitle,
+      title: `${this.title} | Pix`,
       meta,
     }
   },

--- a/tests/pages/pix-site/index.test.js
+++ b/tests/pages/pix-site/index.test.js
@@ -15,6 +15,7 @@ describe('Index Page', () => {
             meta: '',
             type: 'slice_page',
             body: [{}, {}, {}, {}, {}, {}, {}, {}],
+            title: [{}],
           },
         }),
       findNewsItems: () =>


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix-site, le titre était récupéré via les fichiers de traduction au lieu de récupérer le titre coté Prismic (comme sur Pix-pro)
Conséquence : le titre sur pix.org/en-gb était "Accueil"

## :robot: Solution
Utiliser le titre venant de prismic

## :rainbow: Remarques
En supprimant la traduction du titre dans les fichiers de trad, il y a eu aussi un nettoyage de traduction non utilisées.

## :100: Pour tester
Aller sur le site .org en anglais et vérifier que le site est bien "Home | Pix"
