### PR TITLE
[BUGFIX] Rendre visible le burger menu en cas de message (PIX-1960).

### DIFF
--- a/components/BurgerMenuNav.vue
+++ b/components/BurgerMenuNav.vue
@@ -97,4 +97,12 @@ export default {
     height: 24px !important;
   }
 }
+.hot-news + .navigation-slice-zone {
+  .bm-burger-button {
+    margin-top: 70px;
+    @include device-is('large-screen') {
+      display: none;
+    }
+  }
+}
 </style>

--- a/components/HotNewsBanner.vue
+++ b/components/HotNewsBanner.vue
@@ -38,22 +38,12 @@ export default {
   display: flex;
   flex-direction: row;
 
-  @media (min-width: 769px) {
-    padding: 5px;
-    height: 60px;
-  }
-
   div {
     text-align: center;
     line-height: 1rem;
     font-size: 0.875rem;
     margin: 0 auto;
     align-self: center;
-
-    @media (min-width: 769px) {
-      width: 700px;
-      line-height: 1.375rem;
-    }
   }
 
   a {


### PR DESCRIPTION
## :unicorn: Problème
Quand il y a une `hot news` sur le site, le burger menu passe par dessus et n'est plus visible

## :robot: Solution
Modifier sa position dans le cas où une hot news est présente

## :rainbow: Remarques
Le module de burger menu a déjà ses propres CSS qui ne sont pas modifiables, ce qui est pas pratique

## :100: Pour tester
- Aller sur le site en FR pour voir le bandeau, et voir le burger menu dans la zone blanche
- Aller sur le site en EN pour voir le site sans le bandeau, et voir le burger menu à la même place que d'habitude
