### PR TITLE
[FEATURE] Récupérer les meta descriptions depuis prismic.

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -30,7 +30,8 @@ export default {
       {
         hid: 'description',
         name: 'description',
-        content: process.env.npm_package_description || '',
+        content:
+          'Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques tout au long de la vie.',
       },
     ],
     link: [

--- a/services/document-fetcher.js
+++ b/services/document-fetcher.js
@@ -60,6 +60,7 @@ export function documentFetcher(
     getPageByUid: async (uid) => {
       const simplePage = await getSimplePageByUid(uid)
       const slicePage = await getSlicesPageByUid(uid)
+
       const formPage = await getFormPageByUid(uid)
       return simplePage || slicePage || formPage
     },

--- a/services/meta-builder.js
+++ b/services/meta-builder.js
@@ -2,7 +2,7 @@ export default function getMeta(meta, currentPagePath, prismic) {
   function getTwitterCard() {
     const twitterMeta = meta.find((meta) => meta.slice_type === 'twitter_card')
     if (!twitterMeta) {
-      return {}
+      return []
     }
     return [
       { hid: 'twitter:card', name: 'twitter:card', content: 'summary' },
@@ -24,10 +24,11 @@ export default function getMeta(meta, currentPagePath, prismic) {
       },
     ]
   }
+
   function getOgCard() {
     const ogMeta = meta.find((meta) => meta.slice_type === 'general_card')
     if (!ogMeta) {
-      return {}
+      return []
     }
     return [
       {
@@ -61,8 +62,5 @@ export default function getMeta(meta, currentPagePath, prismic) {
   const twitterCard = getTwitterCard()
   const ogCard = getOgCard()
 
-  if (twitterCard.length && ogCard.length) {
-    return [...twitterCard, ...ogCard]
-  }
-  return []
+  return [...twitterCard, ...ogCard]
 }

--- a/services/meta-builder.js
+++ b/services/meta-builder.js
@@ -56,11 +56,26 @@ export default function getMeta(meta, currentPagePath, prismic) {
     ]
   }
 
+  function getGeneralMeta() {
+    const generalCard = meta.find((meta) => meta.slice_type === 'general_card')
+    if (!generalCard) {
+      return []
+    }
+    return [
+      {
+        hid: 'description',
+        name: 'description',
+        content: prismic.asText(generalCard.primary.description),
+      },
+    ]
+  }
+
   if (!meta) {
     return []
   }
   const twitterCard = getTwitterCard()
   const ogCard = getOgCard()
+  const generalMeta = getGeneralMeta()
 
-  return [...twitterCard, ...ogCard]
+  return [...twitterCard, ...ogCard, ...generalMeta]
 }

--- a/services/meta-builder.js
+++ b/services/meta-builder.js
@@ -1,3 +1,6 @@
+export const fallbackDescription =
+  'Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques tout au long de la vie.'
+
 export default function getMeta(meta, currentPagePath, prismic) {
   function getTwitterCard() {
     const twitterMeta = meta.find((meta) => meta.slice_type === 'twitter_card')
@@ -39,7 +42,8 @@ export default function getMeta(meta, currentPagePath, prismic) {
       {
         hid: 'og:description',
         property: 'og:description',
-        content: prismic.asText(ogMeta.primary.description),
+        content:
+          prismic.asText(ogMeta.primary.description) || fallbackDescription,
       },
       { hid: 'og:type', property: 'og:type', content: 'article' },
       {
@@ -65,7 +69,9 @@ export default function getMeta(meta, currentPagePath, prismic) {
       {
         hid: 'description',
         name: 'description',
-        content: prismic.asText(generalCard.primary.description),
+        content:
+          prismic.asText(generalCard.primary.description) ||
+          fallbackDescription,
       },
     ]
   }

--- a/tests/pages/pix-site/__snapshots__/index.test.js.snap
+++ b/tests/pages/pix-site/__snapshots__/index.test.js.snap
@@ -1,13 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Index Page get the corrects meta 1`] = `
-VueWrapper {
-  "_emitted": Object {},
-  "_emittedByOrder": Array [],
-  "isFunctionalComponent": undefined,
-}
-`;
-
 exports[`Index Page renders properly 1`] = `
 "<div class=\\"index\\">
   <slice-zone-stub slices=\\"[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]\\"></slice-zone-stub>

--- a/tests/pages/pix-site/__snapshots__/index.test.js.snap
+++ b/tests/pages/pix-site/__snapshots__/index.test.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Index Page get the corrects meta 1`] = `
+VueWrapper {
+  "_emitted": Object {},
+  "_emittedByOrder": Array [],
+  "isFunctionalComponent": undefined,
+}
+`;
+
 exports[`Index Page renders properly 1`] = `
 "<div class=\\"index\\">
   <slice-zone-stub slices=\\"[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]\\"></slice-zone-stub>

--- a/tests/pages/pix-site/index.test.js
+++ b/tests/pages/pix-site/index.test.js
@@ -1,7 +1,7 @@
 import VueMeta from 'vue-meta'
 import { getInitialised, createLocalVue } from './utils'
 import { documentFetcher } from '~/services/document-fetcher'
-import getMeta from '~/services/meta-builder'
+import getMeta, { fallbackDescription } from '~/services/meta-builder'
 
 const localVue = createLocalVue()
 localVue.prototype.$getMeta = getMeta
@@ -63,14 +63,28 @@ describe('Index Page', () => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  test('get correct title info', () => {
+  test('gets the correct title', () => {
     expect(wrapper.vm.$metaInfo.title).toBe(`${PRISMIC_TITLE} | Pix`)
     expect(wrapper.vm.$data.title).toBe(PRISMIC_TITLE)
   })
 
-  test('get the corrects meta', () => {
+  test('gets the correct meta description from Prismic', () => {
     expect(findMetaContent('og:description')).toBe(PRISMIC_META)
     expect(findMetaContent('description')).toBe(PRISMIC_META)
+  })
+
+  test('uses the fallback meta description when not filled in Prismic', async () => {
+    wrapper = await getInitialised('index', {
+      localVue,
+      computed: {
+        $prismic() {
+          return { asText: () => '' }
+        },
+      },
+    })
+
+    expect(findMetaContent('og:description')).toBe(fallbackDescription)
+    expect(findMetaContent('description')).toBe(fallbackDescription)
   })
 
   function findMetaContent(hid) {

--- a/tests/pages/pix-site/index.test.js
+++ b/tests/pages/pix-site/index.test.js
@@ -1,10 +1,19 @@
-import { getInitialised } from './utils'
+import VueMeta from 'vue-meta'
+import { getInitialised, createLocalVue } from './utils'
 import { documentFetcher } from '~/services/document-fetcher'
+import getMeta from '~/services/meta-builder'
+
+const localVue = createLocalVue()
+localVue.prototype.$getMeta = getMeta
+
+localVue.use(VueMeta, { keyName: 'head' })
 
 jest.mock('~/services/document-fetcher')
 
 describe('Index Page', () => {
   let wrapper
+  const PRISMIC_META = 'meta info'
+  const PRISMIC_TITLE = 'title'
 
   beforeEach(async () => {
     documentFetcher.mockReturnValue({
@@ -12,10 +21,15 @@ describe('Index Page', () => {
         Promise.resolve({
           data: {
             id: '',
-            meta: '',
+            meta: [
+              {
+                slice_type: 'general_card',
+                primary: { description: '', image: {} },
+              },
+            ],
             type: 'slice_page',
             body: [{}, {}, {}, {}, {}, {}, {}, {}],
-            title: [{}],
+            title: [{ text: PRISMIC_TITLE }],
           },
         }),
       findNewsItems: () =>
@@ -27,8 +41,20 @@ describe('Index Page', () => {
           },
         }),
     })
-    wrapper = await getInitialised('index')
+    wrapper = await getInitialised('index', {
+      localVue,
+      computed: {
+        $prismic() {
+          return { asText: () => PRISMIC_META }
+        },
+      },
+    })
   })
+
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
   test('mounts properly', () => {
     expect(wrapper.vm).toBeTruthy()
   })
@@ -36,4 +62,20 @@ describe('Index Page', () => {
   test('renders properly', () => {
     expect(wrapper.html()).toMatchSnapshot()
   })
+
+  test('get correct title info', () => {
+    expect(wrapper.vm.$metaInfo.title).toBe(`${PRISMIC_TITLE} | Pix`)
+    expect(wrapper.vm.$data.title).toBe(PRISMIC_TITLE)
+  })
+
+  test('get the corrects meta', () => {
+    expect(findMetaContent('og:description')).toBe(PRISMIC_META)
+    expect(findMetaContent('description')).toBe(PRISMIC_META)
+  })
+
+  function findMetaContent(hid) {
+    const meta = wrapper.vm.$metaInfo.meta.find((m) => m.hid === hid)
+    expect(meta).toBeTruthy()
+    return wrapper.vm.$metaInfo.meta.find((m) => m.hid === hid).content
+  }
 })

--- a/tests/pages/pix-site/utils.js
+++ b/tests/pages/pix-site/utils.js
@@ -1,4 +1,7 @@
-import { shallowMount } from '@vue/test-utils'
+import {
+  shallowMount,
+  createLocalVue as createLocalVueTest,
+} from '@vue/test-utils'
 
 /**
  * This is needed to manage the asyncData() from vuepages
@@ -38,4 +41,8 @@ export function emptyPrismicDocument() {
     primary: { title: '' },
     items: [{}],
   }
+}
+
+export function createLocalVue() {
+  return createLocalVueTest()
 }


### PR DESCRIPTION
## :unicorn: Problème
Les meta descriptions proviennent du `package.json` et il n'est pas possible de les changer pour chaque page. 

## :robot: Solution
On récupère la meta description depuis prismic. Si elle n'est pas renseignée, on utilise une description générique.

## :100: Pour tester
- Lancer en local avec la commande `SSR_ENABLED=true npm run dev:site`
- Lancer la preview depuis prismic

Remplir une description dans l'onglet `Social Cards` et voir qu'elle s'applique bien au tag `<meta name="description" content="Ma description">`

Si rien n'est rempli, on doit y voir la phrase par défaut.


