### PR TITLE
[FIX] Désactiver l'extraction des images pour qu'elles s'affichent sur les site .org

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -69,18 +69,6 @@ export default {
   buildModules: [
     // Doc: https://github.com/nuxt-community/eslint-module
     ['@nuxtjs/eslint-module', { fix: true }],
-    [
-      '~/modules/assets-extractor',
-      {
-        hostnames: [
-          'images.prismic.io',
-          'prismic-io.s3.amazonaws.com',
-          'storage.gra.cloud.ovh.net',
-          'pix-site.cdn.prismic.io',
-        ],
-        extensions: ['jpg', 'jpeg', 'gif', 'png', 'webp', 'svg', 'mp4', 'pdf'],
-      },
-    ],
   ],
   /*
    ** Nuxt.js modules


### PR DESCRIPTION
## :unicorn: Problème

le site d’integ .org ne récupère aucune image

C'est à cause de l'URL des images qui sont réécrites en ajoutant la locale, du coup il ne trouve plus les images.
```
https://site.integration.pix.org/fr/_assets/pix-site/3d7f707f-fcc2-49a6-9cfa-9b5dcd18b226-coffee-mug-heart.svg
```
Or les images sont dans `/_assets` et il recherche dans `/fr/_assets`

## :robot: Solution

Désactiver le `build_module` d'extraction des assets dans le `nuxt-config.js` afin de prendre le temps pour trouver une solution 

## :100: Pour tester

Aller sur les site .org et voir si on récupère les images correctement.
