### PR TITLE
[FEATURE] Générer les pages "orphelines" (PIX-2246).

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,6 +1,8 @@
 import { transports } from 'winston'
+import routes from './services/get-routes-to-generate'
 
 export default {
+  generate: { routes },
   target: process.env.SSR_ENABLED === 'true' ? 'server' : 'static',
   publicRuntimeConfig: {
     languageSwitchEnabled: process.env.LANGUAGE_SWITCH_ENABLED || false,

--- a/services/get-routes-to-generate.js
+++ b/services/get-routes-to-generate.js
@@ -1,0 +1,22 @@
+import prismic from 'prismic-javascript'
+import _ from 'lodash'
+
+export default async function () {
+  const api = await prismic.getApi(process.env.PRISMIC_API_ENDPOINT)
+  const { routes, totalPages } = await getRoutesInPage(api, 1)
+  for (let page = 2; page <= totalPages; page++) {
+    const { routes: nextPageRoutes } = await getRoutesInPage(api, page)
+    routes.push(...nextPageRoutes)
+  }
+  return routes
+}
+
+async function getRoutesInPage(api, page) {
+  const { results, total_pages: totalPages } = await api.query('', {
+    pageSize: 100,
+    page,
+  })
+  const uids = _.map(results, 'uid')
+  const routes = _.reject(uids, _.isEmpty)
+  return { totalPages, routes }
+}

--- a/tests/services/get-routes-to-generate.test.js
+++ b/tests/services/get-routes-to-generate.test.js
@@ -1,0 +1,74 @@
+import getRoutesToGenerate from '@/services/get-routes-to-generate'
+import prismic from 'prismic-javascript'
+jest.mock('prismic-javascript')
+
+describe('#getRoutesToGenerate', () => {
+  test('it should fetch routes to generate', async () => {
+    // Given
+    const expected = ['route-to-generate']
+    const prismicApi = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce({ results: [{ uid: 'route-to-generate' }] }),
+    }
+    prismic.getApi = () => prismicApi
+
+    // When
+    const result = await getRoutesToGenerate(prismic)
+
+    // Then
+    expect(prismicApi.query).toBeCalledWith('', { pageSize: 100, page: 1 })
+    expect(result).toEqual(expected)
+  })
+
+  test('it should not return null routes', async () => {
+    // Given
+    const expected = ['route-to-generate']
+    const prismicApi = {
+      query: jest.fn().mockReturnValueOnce({
+        results: [{ uid: 'route-to-generate' }, {}, { uid: null }],
+      }),
+    }
+    prismic.getApi = () => prismicApi
+
+    // When
+    const result = await getRoutesToGenerate(prismic)
+
+    // Then
+    expect(prismicApi.query).toBeCalledWith('', { pageSize: 100, page: 1 })
+    expect(result).toEqual(expected)
+  })
+
+  test('it should handle pagination', async () => {
+    // Given
+    const expected = [
+      'route-to-generate-from-first-page',
+      'route-to-generate-from-second-page',
+    ]
+
+    const firstPage = {
+      total_pages: 2,
+      results: [{ uid: 'route-to-generate-from-first-page' }],
+    }
+    const secondPage = {
+      total_pages: 2,
+      results: [{ uid: 'route-to-generate-from-second-page' }],
+    }
+
+    const prismicApi = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce(firstPage)
+        .mockResolvedValueOnce(secondPage),
+    }
+    prismic.getApi = () => prismicApi
+
+    // When
+    const result = await getRoutesToGenerate(prismic)
+
+    // Then
+    expect(prismicApi.query).toBeCalledWith('', { pageSize: 100, page: 1 })
+    expect(prismicApi.query).toBeCalledWith('', { pageSize: 100, page: 2 })
+    expect(result).toEqual(expected)
+  })
+})


### PR DESCRIPTION
## :unicorn: Problème
Depuis que le site est en mode statique, les pages orphelines (i.e. qui n'ont pas de lien vers elles) ne sont plus générées.
En effet, seules les pages repérées par le crawler de nuxt sont identifiées et incluses dans le build.

## :robot: Solution
Nuxt offre une [option de configuration](https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-generate#routes) permettant de spécifier les routes à générer.
On utilise l'api de prismic pour récupérer les `uid` des documents qui correspondent aux routes à générer.

## :rainbow: Remarques
On s'est rendu compte qu'une page `mediation-numerique2` est générée.
Celle-ci est générée car le footer contient un lien vers `https://pix.fr/mediation-numerique2`
Il n'existe pourtant aucune page `mediation-numerique2` mais une page `mediation-numerique`.
Après de longues recherches, nous avons compris qu'il s'agissait de l'ancien `uri`.
Prismic conserve un historique des `uri` de chaque document et permet ainsi de ne pas casser de liens.
Plus d'information dans la [documentation de Prismic](https://user-guides.prismic.io/en/articles/764589-how-to-prepare-your-content-for-seo).

## :100: Pour tester
Se rendre sur les pages orphelines et vérifier qu'elles sont bien affichées.
Par exemple : /dp-formulaire-demande-agrement