### PR TITLE
[FEATURE] Ne plus bouger les icone quand on ouvre le burger menu (PIX-2242).

### DIFF
--- a/components/LanguageSwitcher.vue
+++ b/components/LanguageSwitcher.vue
@@ -30,7 +30,7 @@
         </span>
       </li>
     </ul>
-    <span class="separator"></span>
+    <span class="separator" />
   </div>
   <div v-else-if="showLanguageDropdown && type === 'only-text'">
     <ul>

--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="navigation-slice-zone">
     <client-only>
-      <push-menu width="230" class="burger-menu">
+      <slide-menu width="230" class="burger-menu">
         <burger-menu-nav :items="burgerMenuLinks" />
-      </push-menu>
+      </slide-menu>
     </client-only>
     <div id="page-wrap">
       <div class="navigation-slice-zone__wrapper">

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -8,7 +8,7 @@
       />
     </nuxt-link>
     <!-- eslint-disable-next-line vue/no-v-html -->
-    <div v-html="$t('error-content')"></div>
+    <div v-html="$t('error-content')" />
   </div>
 </template>
 <script>

--- a/tests/components/slices/NavigationSliceZone.test.js
+++ b/tests/components/slices/NavigationSliceZone.test.js
@@ -8,7 +8,7 @@ describe('NavigationSliceZone', () => {
   let store
   const stubs = {
     'client-only': true,
-    'push-menu': true,
+    'slide-menu': true,
     'burger-menu-nav': true,
     'organization-nav': true,
     'logos-zone': true,


### PR DESCRIPTION
## :unicorn: Problème
Quand on ouvrait le burger menu, tout se décallait.

## :robot: Solution
Utiliser un Slide menu plutôt qu'un Push menu

## :rainbow: Remarques
Voir https://vue-burger-menu.netlify.app/

## :100: Pour tester
Aller sur le site, diminuer la taille pouvoir avoir le burger menu. L'ouvrir et toujours voir les icones Pix.
