### PR TITLE
[DESIGN] Ajouter un arrondi sur les bannières de pages (PIX-2245).

### DIFF
--- a/components/slices/PageBanner.vue
+++ b/components/slices/PageBanner.vue
@@ -72,6 +72,7 @@ export default {
           background: `no-repeat url(${this.slice.primary.banner_background.url})`,
           backgroundSize: 'cover',
           backgroundPosition: 'top right',
+          'clip-path': 'ellipse(110% 50% at 50% 40%)',
         }
       }
       style.backgroundColor = this.slice.primary.banner_background_color


### PR DESCRIPTION
## :unicorn: Problème
Besoin d'ajout d'un arrondi sur la bannière des pages

## :robot: Solution
Ajout du clip-path quand on ajoute le background image

## :rainbow: Remarques
Changement léger du clip-path par rapport au ticket Jira pour mieux gérer le mobile

## :100: Pour tester
Voir l'accueil de pix-site ou pix-pro
