### PR TITLE
[FEATURE] Redesign du menu burger (PIX-2257).

### DIFF
--- a/components/BurgerMenuNav.vue
+++ b/components/BurgerMenuNav.vue
@@ -26,7 +26,7 @@ export default {
 </script>
 
 <style lang="scss">
-.navigation-slice-zone {
+.burger-menu {
   .bm-menu {
     background: $white;
 

--- a/components/BurgerMenuNav.vue
+++ b/components/BurgerMenuNav.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="nav-top">
+  <div class="burger-navigation">
     <ul>
       <li
         v-for="item in items.navigationZone"
         :key="item.id"
-        class="nav-top__link"
+        class="burger-navigation__link"
       >
         <pix-link :field="item.link">
           {{ $prismic.asText(item.name) }}
@@ -15,7 +15,7 @@
       <li
         v-for="item in items.actionsZone"
         :key="item.id"
-        class="nav-top__link"
+        class="burger-navigation__link"
         :class="item === signUpButton ? 'button' : 'login'"
       >
         <pix-link :field="item.link">
@@ -76,7 +76,7 @@ export default {
       }
     }
 
-    .nav-top {
+    .burger-navigation {
       &__link {
         font-weight: 600;
         color: $white;
@@ -91,56 +91,40 @@ export default {
           line-height: 1.5rem;
           color: $grey-60;
 
+          &[href*='pro.pix'] {
+            width: 256px;
+            padding-top: 12px;
+            border-top: 1px solid $grey-70;
+          }
+
           &:hover {
             text-decoration: underline;
           }
         }
+      }
 
-        &--login {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          max-width: 225px;
-          height: 44px;
-          background-color: $blue;
-          border-radius: 4px;
+      .login > a {
+        color: blue;
+      }
 
-          a {
-            color: $white;
-            font-size: 0.875rem;
-            font-weight: 600;
-          }
+      .button {
+        width: 225px;
+        margin-left: 0;
+
+        a {
+          color: $white;
         }
       }
     }
+  }
 
-    .button {
-      width: 225px;
-      margin-left: 0;
+  .bm-item-list {
+    height: 100%;
 
-      a {
-        color: $white;
-      }
-    }
-
-    a[href*='pro.pix'] {
-      width: 256px;
-      padding-top: 12px;
-      border-top: 1px solid $grey-70;
-    }
-
-    .login > a {
-      color: blue;
-    }
-
-    .bm-item-list {
+    & > * {
+      padding: 0;
+      flex-direction: column;
       height: 100%;
-
-      & > * {
-        padding: 0;
-        flex-direction: column;
-        height: 100%;
-      }
     }
   }
 

--- a/components/BurgerMenuNav.vue
+++ b/components/BurgerMenuNav.vue
@@ -1,14 +1,18 @@
 <template>
-  <div>
-    <div class="nav-top">
-      <ul>
-        <li v-for="item in items" :key="item.id" class="nav-top__link">
-          <pix-link :field="item.link">
-            {{ $prismic.asText(item.name) }}
-          </pix-link>
-        </li>
-      </ul>
-    </div>
+  <div class="nav-top">
+    <ul>
+      <li
+        v-for="item in items"
+        :key="item.id"
+        :class="
+          item.style === 'button' ? 'nav-top__link--login' : 'nav-top__link'
+        "
+      >
+        <pix-link :field="item.link">
+          {{ $prismic.asText(item.name) }}
+        </pix-link>
+      </li>
+    </ul>
     <language-switcher type="only-text" />
   </div>
 </template>
@@ -33,7 +37,7 @@ export default {
 <style lang="scss">
 .navigation-slice-zone {
   .bm-menu {
-    background: $blue-gradient;
+    background: $white;
 
     @include device-is('large-screen') {
       display: none;
@@ -57,7 +61,7 @@ export default {
         font-weight: 600;
         color: $white;
         text-align: left;
-        margin-bottom: 12px;
+        margin-bottom: 24px;
 
         a {
           text-decoration: none;
@@ -65,10 +69,30 @@ export default {
           transition: 0.3s;
           font-size: 1rem;
           line-height: 1.5rem;
-          color: $white;
+          color: $grey-60;
 
           &:hover {
             text-decoration: underline;
+          }
+        }
+
+        a[href*='app.pix'] {
+          color: blue;
+        }
+
+        &--login {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          max-width: 225px;
+          height: 44px;
+          background-color: $blue;
+          border-radius: 4px;
+
+          a {
+            color: $white;
+            font-size: 0.875rem;
+            font-weight: 600;
           }
         }
       }
@@ -76,7 +100,7 @@ export default {
 
     .bm-item-list {
       height: 100%;
-      padding: 0 25px;
+      //padding: 0 25px;
 
       & > * {
         padding: 0;

--- a/components/BurgerMenuNav.vue
+++ b/components/BurgerMenuNav.vue
@@ -1,49 +1,25 @@
 <template>
-  <div class="burger-navigation">
-    <ul>
-      <li
-        v-for="item in items.navigationZone"
-        :key="item.id"
-        class="burger-navigation__link"
-      >
-        <pix-link :field="item.link">
-          {{ $prismic.asText(item.name) }}
-        </pix-link>
-      </li>
-    </ul>
-    <ul>
-      <li
-        v-for="item in items.actionsZone"
-        :key="item.id"
-        class="burger-navigation__link"
-        :class="item === signUpButton ? 'button' : 'login'"
-      >
-        <pix-link :field="item.link">
-          {{ $prismic.asText(item.name) }}
-        </pix-link>
-      </li>
-    </ul>
+  <div class="burger-menu-nav">
+    <burger-menu-nav-items :items="items.navigationZone" />
+    <burger-menu-nav-items :items="items.actionsZone" :is-action="true" />
     <language-switcher type="only-text" />
   </div>
 </template>
 
 <script>
 import LanguageSwitcher from '@/components/LanguageSwitcher'
+import BurgerMenuNavItems from '@/components/BurgerMenuNavItems'
 
 export default {
   name: 'BurgerMenuNav',
   components: {
     LanguageSwitcher,
+    BurgerMenuNavItems,
   },
   props: {
     items: {
       type: Object,
       default: null,
-    },
-  },
-  computed: {
-    signUpButton() {
-      return this.items.actionsZone[this.items.actionsZone.length - 1]
     },
   },
 }
@@ -56,65 +32,6 @@ export default {
 
     @include device-is('large-screen') {
       display: none;
-    }
-
-    ul {
-      margin: 24px 0 0 0;
-      padding: 0;
-      list-style: none;
-
-      &:last-child {
-        margin: 0;
-      }
-
-      & > li {
-        padding-left: 0;
-
-        &::before {
-          display: none;
-        }
-      }
-    }
-
-    .burger-navigation {
-      &__link {
-        font-weight: 600;
-        color: $white;
-        text-align: left;
-        margin-bottom: 24px;
-
-        a {
-          text-decoration: none;
-          display: block;
-          transition: 0.3s;
-          font-size: 1rem;
-          line-height: 1.5rem;
-          color: $grey-60;
-
-          &[href*='pro.pix'] {
-            width: 256px;
-            padding-top: 12px;
-            border-top: 1px solid $grey-70;
-          }
-
-          &:hover {
-            text-decoration: underline;
-          }
-        }
-      }
-
-      .login > a {
-        color: blue;
-      }
-
-      .button {
-        width: 225px;
-        margin-left: 0;
-
-        a {
-          color: $white;
-        }
-      }
     }
   }
 

--- a/components/BurgerMenuNav.vue
+++ b/components/BurgerMenuNav.vue
@@ -2,11 +2,21 @@
   <div class="nav-top">
     <ul>
       <li
-        v-for="item in items"
+        v-for="item in items.navigationZone"
         :key="item.id"
-        :class="
-          item.style === 'button' ? 'nav-top__link--login' : 'nav-top__link'
-        "
+        class="nav-top__link"
+      >
+        <pix-link :field="item.link">
+          {{ $prismic.asText(item.name) }}
+        </pix-link>
+      </li>
+    </ul>
+    <ul>
+      <li
+        v-for="item in items.actionsZone"
+        :key="item.id"
+        class="nav-top__link"
+        :class="item === signUpButton ? 'button' : 'login'"
       >
         <pix-link :field="item.link">
           {{ $prismic.asText(item.name) }}
@@ -27,8 +37,13 @@ export default {
   },
   props: {
     items: {
-      type: Array,
+      type: Object,
       default: null,
+    },
+  },
+  computed: {
+    signUpButton() {
+      return this.items.actionsZone[this.items.actionsZone.length - 1]
     },
   },
 }
@@ -44,8 +59,13 @@ export default {
     }
 
     ul {
-      padding-left: 0;
+      margin: 24px 0 0 0;
+      padding: 0;
       list-style: none;
+
+      &:last-child {
+        margin: 0;
+      }
 
       & > li {
         padding-left: 0;
@@ -76,10 +96,6 @@ export default {
           }
         }
 
-        a[href*='app.pix'] {
-          color: blue;
-        }
-
         &--login {
           display: flex;
           align-items: center;
@@ -98,9 +114,27 @@ export default {
       }
     }
 
+    .button {
+      width: 225px;
+      margin-left: 0;
+
+      a {
+        color: $white;
+      }
+    }
+
+    a[href*='pro.pix'] {
+      width: 256px;
+      padding-top: 12px;
+      border-top: 1px solid $grey-70;
+    }
+
+    .login > a {
+      color: blue;
+    }
+
     .bm-item-list {
       height: 100%;
-      //padding: 0 25px;
 
       & > * {
         padding: 0;

--- a/components/BurgerMenuNavItems.vue
+++ b/components/BurgerMenuNavItems.vue
@@ -40,7 +40,7 @@ export default {
   list-style: none;
 
   &:last-child {
-    margin-top: 8px;
+    margin: 8px 0 0 0;
   }
 
   &__link {
@@ -102,10 +102,6 @@ export default {
         }
       }
     }
-  }
-
-  &:last-child {
-    margin: 0;
   }
 }
 </style>

--- a/components/BurgerMenuNavItems.vue
+++ b/components/BurgerMenuNavItems.vue
@@ -1,0 +1,115 @@
+<template>
+  <ul class="burger-menu-nav__items">
+    <li
+      v-for="item in items"
+      :key="item.id"
+      class="burger-menu-nav-items__link"
+      :class="
+        isAction
+          ? 'burger-menu-nav-items__link--action'
+          : 'burger-menu-nav-items__link--link'
+      "
+    >
+      <pix-link :field="item.link">
+        {{ $prismic.asText(item.name) }}
+      </pix-link>
+    </li>
+  </ul>
+</template>
+
+<script>
+export default {
+  name: 'BurgerMenuNavItems',
+  props: {
+    items: {
+      type: Array,
+      default: null,
+    },
+    isAction: {
+      type: Boolean,
+      default: false,
+    },
+  },
+}
+</script>
+
+<style lang="scss">
+.burger-menu-nav {
+  &__items {
+    margin: 24px 0 0 0;
+    padding: 0;
+    list-style: none;
+
+    &:last-child {
+      margin-top: 8px;
+    }
+  }
+}
+
+.burger-menu-nav-items {
+  &__link {
+    padding-left: 0;
+    font-weight: 600;
+    color: $white;
+    text-align: left;
+    margin-bottom: 24px;
+
+    &::before {
+      display: none;
+    }
+
+    a {
+      display: block;
+      transition: 0.3s;
+      font-size: 1rem;
+      line-height: 1.5rem;
+      color: $grey-60;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+
+    &--link {
+      &:last-child {
+        & > a {
+          width: 256px;
+          padding-top: 12px;
+          border-top: 1px solid $grey-20;
+        }
+      }
+    }
+
+    &--action {
+      & > a {
+        color: $blue;
+      }
+
+      &:last-child {
+        transition: all 0.5s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 225px;
+        height: 44px;
+        background: $blue;
+        border-radius: 4px;
+        color: $white;
+
+        & > a {
+          color: $white;
+        }
+
+        &:hover {
+          transition: all 0.5s ease;
+          transform: scale(1.03);
+        }
+      }
+    }
+  }
+
+  &:last-child {
+    margin: 0;
+  }
+}
+</style>

--- a/components/BurgerMenuNavItems.vue
+++ b/components/BurgerMenuNavItems.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul class="burger-menu-nav__items">
+  <ul class="burger-menu-nav-items">
     <li
       v-for="item in items"
       :key="item.id"
@@ -7,7 +7,7 @@
       :class="
         isAction
           ? 'burger-menu-nav-items__link--action'
-          : 'burger-menu-nav-items__link--link'
+          : 'burger-menu-nav-items__link--regular-link'
       "
     >
       <pix-link :field="item.link">
@@ -34,19 +34,15 @@ export default {
 </script>
 
 <style lang="scss">
-.burger-menu-nav {
-  &__items {
-    margin: 24px 0 0 0;
-    padding: 0;
-    list-style: none;
-
-    &:last-child {
-      margin-top: 8px;
-    }
-  }
-}
-
 .burger-menu-nav-items {
+  margin: 24px 0 0 0;
+  padding: 0;
+  list-style: none;
+
+  &:last-child {
+    margin-top: 8px;
+  }
+
   &__link {
     padding-left: 0;
     font-weight: 600;
@@ -70,7 +66,7 @@ export default {
       }
     }
 
-    &--link {
+    &--regular-link {
       &:last-child {
         & > a {
           width: 256px;

--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -6,31 +6,29 @@
       </slide-menu>
     </client-only>
     <div id="page-wrap">
-      <div class="navigation-slice-zone__wrapper">
-        <div class="navigation-slice-zone__content">
-          <div class="navigation-slice-zone-content__left-side">
-            <section
-              v-for="(slice, index) in usedMainNavigation.data.body"
-              :key="`navigation-slice-left-${index}`"
-            >
-              <template v-if="slice.slice_type === 'logos_zone'">
-                <logos-zone :slice="slice" />
-              </template>
-              <template v-if="slice.slice_type === 'navigation_zone'">
-                <navigation-zone :slice="slice" />
-              </template>
-            </section>
-          </div>
+      <div class="navigation-slice-zone__content">
+        <div class="navigation-slice-zone-content__left-side">
           <section
             v-for="(slice, index) in usedMainNavigation.data.body"
-            :key="`navigation-slice-right-${index}`"
-            class="navigation-slice-zone-wrapper__right-side"
+            :key="`navigation-slice-left-${index}`"
           >
-            <template v-if="slice.slice_type === 'actions_zone'">
-              <actions-zone :slice="slice" />
+            <template v-if="slice.slice_type === 'logos_zone'">
+              <logos-zone :slice="slice" />
+            </template>
+            <template v-if="slice.slice_type === 'navigation_zone'">
+              <navigation-zone :slice="slice" />
             </template>
           </section>
         </div>
+        <section
+          v-for="(slice, index) in usedMainNavigation.data.body"
+          :key="`navigation-slice-right-${index}`"
+          class="navigation-slice-zone-wrapper__right-side"
+        >
+          <template v-if="slice.slice_type === 'actions_zone'">
+            <actions-zone :slice="slice" />
+          </template>
+        </section>
       </div>
     </div>
   </div>
@@ -87,17 +85,11 @@ export default {
     display: block;
   }
 
-  .navigation-slice-zone__wrapper {
-    display: grid;
-    grid-template-columns: 1.2fr repeat(12, 1fr) 1.2fr;
-    grid-template-rows: auto;
-  }
-
   .navigation-slice-zone__content {
     display: flex;
-    justify-content: flex-end;
+    justify-content: space-between;
+    margin-left: 100px;
     height: 80px;
-    grid-column: 2 / span 12;
   }
 
   @include device-is('large-screen') {

--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -71,7 +71,10 @@ export default {
       const actionsZone = this.usedMainNavigation.data.body.find(
         (slice) => slice.slice_type === 'actions_zone'
       )
-      return [...navigationZone.items, ...actionsZone.items]
+      return {
+        navigationZone: navigationZone.items,
+        actionsZone: actionsZone.items,
+      }
     },
   },
 }

--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -5,31 +5,29 @@
         <burger-menu-nav :items="burgerMenuLinks" />
       </slide-menu>
     </client-only>
-    <div id="page-wrap">
-      <div class="navigation-slice-zone__content">
-        <div class="navigation-slice-zone-content__left-side">
-          <section
-            v-for="(slice, index) in usedMainNavigation.data.body"
-            :key="`navigation-slice-left-${index}`"
-          >
-            <template v-if="slice.slice_type === 'logos_zone'">
-              <logos-zone :slice="slice" />
-            </template>
-            <template v-if="slice.slice_type === 'navigation_zone'">
-              <navigation-zone :slice="slice" />
-            </template>
-          </section>
-        </div>
+    <div class="navigation-slice-zone__content">
+      <div class="navigation-slice-zone-content__left-side">
         <section
           v-for="(slice, index) in usedMainNavigation.data.body"
-          :key="`navigation-slice-right-${index}`"
-          class="navigation-slice-zone-wrapper__right-side"
+          :key="`navigation-slice-left-${index}`"
         >
-          <template v-if="slice.slice_type === 'actions_zone'">
-            <actions-zone :slice="slice" />
+          <template v-if="slice.slice_type === 'logos_zone'">
+            <logos-zone :slice="slice" />
+          </template>
+          <template v-if="slice.slice_type === 'navigation_zone'">
+            <navigation-zone :slice="slice" />
           </template>
         </section>
       </div>
+      <section
+        v-for="(slice, index) in usedMainNavigation.data.body"
+        :key="`navigation-slice-right-${index}`"
+        class="navigation-slice-zone-content__right-side"
+      >
+        <template v-if="slice.slice_type === 'actions_zone'">
+          <actions-zone :slice="slice" />
+        </template>
+      </section>
     </div>
   </div>
 </template>

--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="navigation-slice-zone">
     <client-only>
-      <slide-menu width="230" class="burger-menu">
+      <slide-menu width="320" class="burger-menu">
         <burger-menu-nav :items="burgerMenuLinks" />
       </slide-menu>
     </client-only>

--- a/components/slices/ActionsZone.vue
+++ b/components/slices/ActionsZone.vue
@@ -36,35 +36,36 @@ export default {
 
 <style scoped lang="scss">
 .actions-zone {
-  display: none;
+  display: flex;
+  align-items: center;
+  height: 100%;
   margin-left: 22px;
 
-  @include device-is('large-screen') {
-    display: flex;
-    align-items: center;
-    height: 100%;
+  & > div {
+    margin-right: 16px;
+  }
 
-    & > div {
-      margin-right: 16px;
+  &__item {
+    font-size: 0.875rem;
+    color: $grey-50;
+    font-family: $font-roboto;
+    font-weight: $font-medium;
+    letter-spacing: 0.13px;
+    line-height: 22px;
 
-      &:last-of-type {
-        margin-right: 0;
-      }
+    &.link:hover {
+      color: $blue;
     }
 
+    &.button {
+      display: none;
+    }
+  }
+
+  @include device-is('large-screen') {
     &__item {
-      font-size: 0.875rem;
-      color: $grey-50;
-      font-family: $font-roboto;
-      font-weight: $font-medium;
-      letter-spacing: 0.13px;
-      line-height: 22px;
-
-      &.link:hover {
-        color: $blue;
-      }
-
       &.button {
+        display: flex;
         color: $white;
         height: 36px;
       }

--- a/components/slices/ActionsZone.vue
+++ b/components/slices/ActionsZone.vue
@@ -50,8 +50,8 @@ export default {
     color: $grey-50;
     font-family: $font-roboto;
     font-weight: $font-medium;
-    letter-spacing: 0.13px;
-    line-height: 22px;
+    letter-spacing: 0.008rem;
+    line-height: 1.375rem;
 
     &.link:hover {
       color: $blue;


### PR DESCRIPTION
## :unicorn: Problème

Le menu de navigation burger n'a pas été soumis au même traitement que le reste de Pix-Site et Pix-Pro.

## :robot: Solution

Nouvelle intégration du menu pour mieux correspondre à ce qu'il est possible de retrouver sur les [maquettes correspondantes](https://app.abstract.com/projects/c43b8749-ba3a-474e-a6c5-dbf76bade2ee/branches/bebfc077-344c-493f-b5d9-5af739007f4c/collections/4ba0a963-0c56-4a4d-a624-50ab00fb671a).

## :rainbow: Remarques

Plusieurs points sont à noter : 

- Nous avons choisi, et contrairement à ce qu'il est possible de retrouver sur les maquettes, de ne pas intégrer les logos de Pix et République Française car depuis la PR #247 , les icônes ne se déplacent plus lorsque l'on ouvre le menu, les laissant ainsi apparaitre une fois le menu ouvert, les rendant redondants. A cela s'ajoute une intégration non aisée liée à l'utilisation de la librairie `vue-burger-menu`.

- Nous avons modifié l'organisation des données passées en `props` au composant `BurgerMenuNav` afin de les rendre plus facilement utilisables et de mieux accentuer la séparation entre ce est `lien` et `action` (ex: Enseignement Scolaire VS S'inscrire). 
Cela nous incite toutefois à une répétition de la création de la liste `<ul>` dans le composant de par la pluralité nouvellement créée des données passée à la liste.
Nous optons donc pour la création d'un nouveau composant `BurgerMenuNavItemsList` contenant la liste `<ul>` en question et réutilisée deux fois dans le composant `BurgerMenuNav` afin de réduire la duplication de code.

## :100: Pour tester

Aller sur Pix-site (.fr et .org) et Pix-Pro, et vérifier que l'intégration correspond aux maquettes proposées.

