### PR TITLE
Activer l'asset-extractor et corriger l'affichage d'image sur pix.org

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -71,6 +71,18 @@ export default {
   buildModules: [
     // Doc: https://github.com/nuxt-community/eslint-module
     ['@nuxtjs/eslint-module', { fix: true }],
+    [
+      '~/modules/assets-extractor',
+      {
+        hostnames: [
+          'images.prismic.io',
+          'prismic-io.s3.amazonaws.com',
+          'storage.gra.cloud.ovh.net',
+          'pix-site.cdn.prismic.io',
+        ],
+        extensions: ['jpg', 'jpeg', 'gif', 'png', 'webp', 'svg', 'mp4', 'pdf'],
+      },
+    ],
   ],
   /*
    ** Nuxt.js modules

--- a/scripts/signal_deploy_to_pr.sh
+++ b/scripts/signal_deploy_to_pr.sh
@@ -24,7 +24,6 @@ PR_NUMBER=$(echo $APP | grep -Po '(?<=-pr)\d+')
 RA_SITE_URL_FR="https://site-pr$PR_NUMBER.review.pix.fr"
 RA_SITE_URL_ORG="https://site-pr$PR_NUMBER.review.pix.org"
 RA_PRO_URL_FR="https://pro-pr$PR_NUMBER.review.pix.fr"
-RA_PRO_URL_ORG="https://pro-pr$PR_NUMBER.review.pix.org"
 
 MESSAGE_PREFIX="I'm deploying this PR to these urls:"
 
@@ -36,5 +35,5 @@ if [[ $existing_comments == *"${MESSAGE_PREFIX}"* ]]; then
 else
 	curl -Ssf -u $GITHUB_USER:$GITHUB_USER_TOKEN \
 		-X POST "https://api.github.com/repos/1024pix/pix-site/issues/${PR_NUMBER}/comments" \
-    --data "{\"body\":\"$MESSAGE_PREFIX\n\n- Pix Site (fr): $RA_SITE_URL_FR\n- Pix Site (org): $RA_SITE_URL_ORG\n- Pix Pro (fr): $RA_PRO_URL_FR\n- Pix Pro (org): $RA_PRO_URL_ORG\n\n Please check it out!\"}"
+    --data "{\"body\":\"$MESSAGE_PREFIX\n\n- Pix Site (fr): $RA_SITE_URL_FR\n- Pix Site (org): $RA_SITE_URL_ORG\n- Pix Pro (fr): $RA_PRO_URL_FR\n\n Please check it out!\"}"
 fi

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -32,11 +32,11 @@ server {
   rewrite ^/employeurs$ https://pro.pix.fr permanent;
 
   if ($host ~ \.org) {
-    rewrite ^/(?!fr)(?!en-gb)(?!_nuxt)(?!images) $scheme://$host/fr$request_uri permanent;
+    rewrite ^/(?!fr)(?!en-gb)(?!_nuxt)(?!images)(?!_assets) $scheme://$host/fr$request_uri permanent;
   }
 
   if ($http_x_forwarded_host ~ \.org) {
-    rewrite ^/(?!fr)(?!en-gb)(?!_nuxt)(?!images) $scheme://$http_x_forwarded_host/fr$request_uri permanent;
+    rewrite ^/(?!fr)(?!en-gb)(?!_nuxt)(?!images)(?!_assets) $scheme://$http_x_forwarded_host/fr$request_uri permanent;
   }
 }
 

--- a/tests.sh
+++ b/tests.sh
@@ -32,3 +32,5 @@ checkRedirect pix.fr /help "" 301 https://support.pix.fr/
 checkRedirect pix.fr /employeurs "" 301 https://pro.pix.fr/
 checkRedirect pix.org / "" 301 http://pix.org/fr/
 checkRedirect review.scalingo.io / "review.pix.org" 301 http://review.pix.org/fr/
+checkRedirect pix.org /_assets/ "" 403
+checkRedirect review.scalingo.io /_assets/ "review.pix.org" 403


### PR DESCRIPTION
## :unicorn: Problème

Les URL `https://pix.org/_assets` contenant les images extraites dans le bundle sont automatiquement réécrites via la configuration nginx en `https://pix.org/fr/_assets` (ajout de la langue)

## :robot: Solution

Ajouter une exception sur `_assets` dans les réécriture d'URL de la configuration `nginx`

## :rainbow: Remarques

1. Un test a été ajouté afin de vérifier le bon fonctionnement de la conf. nginx 
2. Nous avons supprimé l'URL .org de pix-pro dans le message de déploiement des PRs.

## :100: Pour tester

Aller sur  https://site-pr250.review.pix.org et vérifier que les images s'affichent.

