### PR TITLE
[DESIGN] Changer la position du drop-down ouvert (PIX-2240).

### DIFF
--- a/components/NavigationDropdown.vue
+++ b/components/NavigationDropdown.vue
@@ -38,11 +38,10 @@ export default {
   font-size: 0.875rem;
   font-weight: $font-normal;
   position: absolute;
-  left: -50px;
   border-radius: 3px;
   background: $white;
-  margin-top: 29px;
-  min-width: 228px;
+  margin-top: 16px;
+  min-width: 232px;
   z-index: 1;
 
   ul,


### PR DESCRIPTION
## :unicorn: Problème
Le dropdown ouvert n'a pas la bonne position.

## :robot: Solution
Enlever la propriété left et réduire le margin-top.
.
## :rainbow: Remarques
Légerement augmenter la min-width afin d'avoir le texte "devenir centre de certification" sur une seule ligne.

## :100: Pour tester
ouvrir le dropdown dans la navigation.
