### PR TITLE
[FEATURE] Changement de couleur des labels de navigation (PIX-2233).

### DIFF
--- a/components/LanguageSwitcher.vue
+++ b/components/LanguageSwitcher.vue
@@ -131,7 +131,7 @@ export default {
       font-family: $font-roboto;
       font-size: 0.875rem;
       font-weight: $font-medium;
-      color: $grey-50;
+      color: $grey-60;
       letter-spacing: 0.008rem;
       line-height: 1.375rem;
       border: none;
@@ -200,7 +200,7 @@ export default {
         font-weight: $font-medium;
         letter-spacing: 0.008rem;
         line-height: 1.375rem;
-        color: $grey-50;
+        color: $grey-60;
 
         &:focus,
         &:hover {

--- a/components/NavigationDropdown.vue
+++ b/components/NavigationDropdown.vue
@@ -68,12 +68,12 @@ export default {
   }
 
   a {
-    color: $grey-50;
+    color: $grey-60;
     &:hover {
       color: $blue;
     }
     &:visited {
-      color: $grey-50;
+      color: $grey-60;
       &:hover {
         color: $blue;
       }

--- a/components/slices/ActionsZone.vue
+++ b/components/slices/ActionsZone.vue
@@ -47,7 +47,7 @@ export default {
 
   &__item {
     font-size: 0.875rem;
-    color: $grey-50;
+    color: $grey-60;
     font-family: $font-roboto;
     font-weight: $font-medium;
     letter-spacing: 0.008rem;

--- a/components/slices/NavigationZone.vue
+++ b/components/slices/NavigationZone.vue
@@ -141,7 +141,7 @@ class Navigation {
     height: 100%;
 
     &__item {
-      color: $grey-50;
+      color: $grey-60;
       font-family: $font-roboto;
       font-size: 14px;
       font-weight: $font-medium;


### PR DESCRIPTION
## :unicorn: Problème

Les différents éléments de la barre de navigation de pix-site et pix-pro ne sont pas à la bonne couleur.

## :robot: Solution

Passer de `$grey-50` à `$grey-60`

## :100: Pour tester

Vérifier que les items de navigation et d'action ont la couleur `#505F79` dans les outils CSS du navigateur.
