### PR TITLE
[BUGFIX] Accéder aux pages orphelines (PIX-2487).

### DIFF
--- a/services/get-routes-to-generate.js
+++ b/services/get-routes-to-generate.js
@@ -15,6 +15,7 @@ async function getRoutesInPage(api, page) {
   const { results, total_pages: totalPages } = await api.query('', {
     pageSize: 100,
     page,
+    lang: '*',
   })
   const uids = _.map(results, 'uid')
   const routes = _.reject(uids, _.isEmpty)

--- a/services/get-routes-to-generate.js
+++ b/services/get-routes-to-generate.js
@@ -16,7 +16,7 @@ async function getRoutesInPage(api, page) {
     {
       pageSize: 100,
       page,
-      lang: '*',
+      lang: process.env.SITE === 'pix-site' ? '*' : 'fr-fr',
     }
   )
 

--- a/services/get-routes-to-generate.js
+++ b/services/get-routes-to-generate.js
@@ -1,5 +1,4 @@
 import prismic from 'prismic-javascript'
-import _ from 'lodash'
 
 export default async function () {
   const api = await prismic.getApi(process.env.PRISMIC_API_ENDPOINT)
@@ -12,12 +11,21 @@ export default async function () {
 }
 
 async function getRoutesInPage(api, page) {
-  const { results, total_pages: totalPages } = await api.query('', {
-    pageSize: 100,
-    page,
-    lang: '*',
-  })
-  const uids = _.map(results, 'uid')
-  const routes = _.reject(uids, _.isEmpty)
+  const { results, total_pages: totalPages } = await api.query(
+    prismic.Predicates.any('document.type', ['simple_page', 'form_page']),
+    {
+      pageSize: 100,
+      page,
+      lang: '*',
+    }
+  )
+
+  const routes = results
+    .filter(({ uid, type }) => Boolean(uid))
+    .map(({ uid, lang }) => {
+      if (lang === 'fr-fr') return `/${uid}`
+      return `/${lang}/${uid}`
+    })
+
   return { totalPages, routes }
 }

--- a/tests/services/get-routes-to-generate.test.js
+++ b/tests/services/get-routes-to-generate.test.js
@@ -17,7 +17,11 @@ describe('#getRoutesToGenerate', () => {
     const result = await getRoutesToGenerate(prismic)
 
     // Then
-    expect(prismicApi.query).toBeCalledWith('', { pageSize: 100, page: 1 })
+    expect(prismicApi.query).toBeCalledWith('', {
+      lang: '*',
+      pageSize: 100,
+      page: 1,
+    })
     expect(result).toEqual(expected)
   })
 
@@ -35,7 +39,11 @@ describe('#getRoutesToGenerate', () => {
     const result = await getRoutesToGenerate(prismic)
 
     // Then
-    expect(prismicApi.query).toBeCalledWith('', { pageSize: 100, page: 1 })
+    expect(prismicApi.query).toBeCalledWith('', {
+      lang: '*',
+      pageSize: 100,
+      page: 1,
+    })
     expect(result).toEqual(expected)
   })
 
@@ -67,8 +75,16 @@ describe('#getRoutesToGenerate', () => {
     const result = await getRoutesToGenerate(prismic)
 
     // Then
-    expect(prismicApi.query).toBeCalledWith('', { pageSize: 100, page: 1 })
-    expect(prismicApi.query).toBeCalledWith('', { pageSize: 100, page: 2 })
+    expect(prismicApi.query).toBeCalledWith('', {
+      lang: '*',
+      pageSize: 100,
+      page: 1,
+    })
+    expect(prismicApi.query).toBeCalledWith('', {
+      lang: '*',
+      pageSize: 100,
+      page: 2,
+    })
     expect(result).toEqual(expected)
   })
 })


### PR DESCRIPTION
## :unicorn: Problème
Il n'est pas possible d'accéder aux pages orphelines:
- ORG-FR : pix.org/fr/dp-formulaire-signalement-epreuve/
- ORG-EN : pix.org/en-gb/personal-data-reporting-test

## :robot: Solution
Ajouter l'option `lang: '*'` dans notre requête de récupération de documents Prismic.

## :rainbow: Remarques
Nous n'avons pas pu reproduire le problème en local bien qu'effectivement présent un prod. La solution déployée marque un changement visible si on log getRoutesToGenerate

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._

