### PR TITLE
[FEATURE] Changer la police des titres (PIX-2268).

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -48,7 +48,7 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: 'Nunito', Arial, sans-serif;
+  font-family: $font-open-sans;
 }
 
 p,


### PR DESCRIPTION
## :unicorn: Problème
La police Nunito utilisée dans les titres ne correspond plus à l'identité des titres sur les produits Pix.

## :robot: Solution
La remplacer par Open-Sans

## :rainbow: Remarques
R.A.S

## :100: Pour tester
Vérifier que les titres ont bien la police Open-Sans

