### PR TITLE
[BUGFIX] Fix affichage du favicon sur le site .org (PIX-2351).

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -32,11 +32,11 @@ server {
   rewrite ^/employeurs$ https://pro.pix.fr permanent;
 
   if ($host ~ \.org) {
-    rewrite ^/(?!fr)(?!en-gb)(?!_nuxt)(?!images)(?!_assets) $scheme://$host/fr$request_uri permanent;
+    rewrite ^/(?!fr)(?!en-gb)(?!_nuxt)(?!images)(?!_assets)(?!favicon.ico) $scheme://$host/fr$request_uri permanent;
   }
 
   if ($http_x_forwarded_host ~ \.org) {
-    rewrite ^/(?!fr)(?!en-gb)(?!_nuxt)(?!images)(?!_assets) $scheme://$http_x_forwarded_host/fr$request_uri permanent;
+    rewrite ^/(?!fr)(?!en-gb)(?!_nuxt)(?!images)(?!_assets)(?!favicon.ico) $scheme://$http_x_forwarded_host/fr$request_uri permanent;
   }
 }
 

--- a/tests.sh
+++ b/tests.sh
@@ -34,3 +34,6 @@ checkRedirect pix.org / "" 301 http://pix.org/fr/
 checkRedirect review.scalingo.io / "review.pix.org" 301 http://review.pix.org/fr/
 checkRedirect pix.org /_assets/ "" 403
 checkRedirect review.scalingo.io /_assets/ "review.pix.org" 403
+checkRedirect pix.org /favicon.ico "" 200
+checkRedirect pix.org /favicon.ico "review.pix.org" 200
+


### PR DESCRIPTION
## :unicorn: Problème
Le favicon n'apparait pas sur .org.

## :robot: Solution
Ne pas rediriger le favicon lorsque le nom de domaine est en .org.

## :rainbow: Remarques
R.A.S

## :100: Pour tester
Se rendre sur pix-site et vérifier que le favicon est maintenant affiché.
