### PR TITLE
[TECH] Expliciter les règles utilisées par le hook de merge Github pour agir dans JIRA (PIX-2586).

### DIFF
--- a/.github/workflows/on-dev-merge.yml
+++ b/.github/workflows/on-dev-merge.yml
@@ -23,6 +23,12 @@ jobs:
         uses: atlassian/gajira-find-issue-key@master
         continue-on-error: true
         with:
+          # https://github.com/atlassian/gajira-find-issue-key#usage
+          # Each merge commit contains pull request name, which in turn may contains JIRA ticket name as a suffix in brackets
+          # Eg this merge commit's name is pull request's 268 name, which contains JIRA ticket name PIX-2579
+          # "[TECH] Ajouter le script d'automatisation JIRA post-merge (PIX-2579)."
+          # https://github.com/1024pix/pix-site/commit/ac7e97b795b34cfef7c117cf5b95e48fdb309df5
+          # https://github.com/1024pix/pix-site/pull/268
           from: commits
 
       - name: Transition issue


### PR DESCRIPTION
## :unicorn: Problème
La solution de cette PR #268 fonctionne mais n'est pas explicite

## :robot: Solution
La documenter en commentaire dans la configuration GitHub action

## :rainbow: Remarques
Cela permettra aussi de tester la mise à jour des[ variables d'environnement GH actions ](https://github.com/1024pix/pix-site/settings/secrets/actions)

## :100: Pour tester
Merger cette PR et vérifier que le ticket Jira est déplacé de "TECH/FUNC REVIEW" à "DEPLOYED IN INTEGRATION"
Testé :heavy_check_mark: , [voir le rapport de GH actions](https://github.com/1024pix/pix-site/runs/2564770059)

