### PR TITLE
[TECH] Supprimer la dépendance @nuxtjs/dotenv

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -7,13 +7,11 @@ export default {
   publicRuntimeConfig: {
     languageSwitchEnabled: process.env.LANGUAGE_SWITCH_ENABLED || false,
     orgDomain: process.env.DOMAIN_ORG || 'pix.org',
+    isPixSite: process.env.SITE === 'pix-site',
+    isPixPro: process.env.SITE === 'pix-pro',
   },
   server: {
     port: process.env.PORT || 5000,
-  },
-  env: {
-    isPixSite: process.env.SITE === 'pix-site',
-    isPixPro: process.env.SITE === 'pix-pro',
   },
   dir: {
     pages: `pages/${process.env.SITE}`,
@@ -90,7 +88,6 @@ export default {
   modules: [
     // Doc: https://axios.nuxtjs.org/usage
     '@nuxtjs/axios',
-    '@nuxtjs/dotenv',
     '@nuxtjs/style-resources',
     ['nuxt-i18n', { detectBrowserLanguage: false }],
     '@nuxtjs/moment',

--- a/package-lock.json
+++ b/package-lock.json
@@ -4673,15 +4673,6 @@
         }
       }
     },
-    "@nuxtjs/dotenv": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/dotenv/-/dotenv-1.4.1.tgz",
-      "integrity": "sha512-DpdObsvRwC8d89I9mzz6pBg6e/PEXHazDM57DOI1mmML2ZjHfQ/DvkjlSzUL7T+TnW3b/a4Ks5wQx08DqFBmeQ==",
-      "requires": {
-        "consola": "^2.10.1",
-        "dotenv": "^8.1.0"
-      }
-    },
     "@nuxtjs/eslint-config": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@nuxtjs/eslint-config/-/eslint-config-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.2",
     "@fortawesome/vue-fontawesome": "^2.0.2",
     "@nuxtjs/axios": "^5.13.1",
-    "@nuxtjs/dotenv": "^1.4.1",
     "@nuxtjs/prismic": "^1.2.4",
     "chart.js": "^2.9.4",
     "lodash": "^4.17.21",


### PR DESCRIPTION
## :unicorn: Problème
Depuis `nuxt@2.13`, `@nuxtjs/dotenv` n'est plus utile et n'est pas recommandé.

## :robot: Solution
Supprimer `@nuxtjs/dotenv` en suivant [le guide fourni par Nuxtjs](https://nuxtjs.org/blog/moving-from-nuxtjs-dotenv-to-runtime-config)

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._

