### PR TITLE
Activer ou désactiver les analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ If not set, applications are built and served as static websites.
 - type: Boolean
 - default: false
 
+`MATOMO_URL`
+If not present, nuxt-matomo will not be loaded and analytics will not be active
+
+- presence: optionnal
+- type: Url
+- default: none
+
+
 ## Build Setup pix-site
 
 ```bash

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,7 +1,7 @@
 import { transports } from 'winston'
 import routes from './services/get-routes-to-generate'
 
-export default {
+const config = {
   generate: { routes },
   target: process.env.SSR_ENABLED === 'true' ? 'server' : 'static',
   publicRuntimeConfig: {
@@ -94,7 +94,6 @@ export default {
     '@nuxtjs/style-resources',
     ['nuxt-i18n', { detectBrowserLanguage: false }],
     '@nuxtjs/moment',
-    ['nuxt-matomo', { matomoUrl: process.env.MATOMO_URL, siteId: 1 }],
     [
       'nuxt-fontawesome',
       {
@@ -203,3 +202,12 @@ export default {
     },
   },
 }
+
+if (process.env.MATOMO_URL) {
+  config.modules.push([
+    'nuxt-matomo',
+    { matomoUrl: process.env.MATOMO_URL, siteId: 1 },
+  ])
+}
+
+export default config


### PR DESCRIPTION
## :unicorn: Problème
Le serveur d'analytics peut être indisponible, et nosu souhtatiosn dans ce cas en plus l'alimenter

## :robot: Solution
Conditionner l'utilisation à la variable `MATOMO_URL`

## :rainbow: Remarques
Ajout `sample.env` pour documenter

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._

