### PR TITLE
Expliciter la différence entre les hotnews et le reste du site

### DIFF
--- a/components/HotNewsBanner.vue
+++ b/components/HotNewsBanner.vue
@@ -1,7 +1,12 @@
 <template>
   <div v-if="isOpen && hotNews" class="hot-news">
     <prismic-rich-text :field="hotNews" />
-    <img class="close" src="/images/close-icon.svg" @click.stop="closeBanner" />
+    <img
+      class="close"
+      src="/images/close-icon.svg"
+      alt="Fermer"
+      @click.stop="closeBanner"
+    />
   </div>
 </template>
 
@@ -31,7 +36,7 @@ export default {
   height: 70px;
   width: 100%;
 
-  color: $white;
+  color: $grey-200;
   background-color: $yellow;
   padding: 2px;
 
@@ -47,7 +52,7 @@ export default {
   }
 
   a {
-    color: $white;
+    color: $grey-200;
     text-decoration: underline;
   }
 }

--- a/components/HotNewsBanner.vue
+++ b/components/HotNewsBanner.vue
@@ -32,7 +32,7 @@ export default {
   width: 100%;
 
   color: $white;
-  background-color: $blue;
+  background-color: $yellow;
   padding: 2px;
 
   display: flex;


### PR DESCRIPTION
## :unicorn: Problème
La couleur d'arrière plan des hotnews est bleue, alors que la couleur d'arrière plan du site est bleue.
Or les hotnews signalent des situations extraordinaires (ex: indisponibilité)

## :robot: Solution
Passer la couleur d'arrière plan à jaune

## :rainbow: Remarques
Ceci est une demande du support (remontée par Julien).

## :100: Pour tester
Actuellement, avec le token Prismic en RA, pout tester la fonctionnalité, il faudrait alimenter les hotnews pour la production, ce qui n'est pas souhaitable. Est-il possible de connecter la RA [avec le site Prismic de test](https://pix-site-test.prismic.io/documents/working/) ?
