### PR TITLE
[FEATURE] Pré-remplir les champs de formulaire si des paramètres sont présents dans l'URL (PIX-2710).

### DIFF
--- a/components/FormPage.vue
+++ b/components/FormPage.vue
@@ -17,11 +17,7 @@
     </div>
 
     <div v-if="hasForm" class="content__form">
-      <iframe
-        class="content-form"
-        :style="[heightForIframe]"
-        :src="content.formbuilder_url.url"
-      >
+      <iframe class="content-form" :style="[heightForIframe]" :src="formUrl">
         {{ $t(`form.not-supported`) }}
       </iframe>
     </div>
@@ -38,6 +34,13 @@ export default {
     },
   },
   computed: {
+    formUrl() {
+      const queryParamsAsObject = this.$route.query
+      const queryParamsAsString = Object.keys(queryParamsAsObject)
+        .map((key) => `${key}=${queryParamsAsObject[key]}`)
+        .join('&')
+      return this.content.formbuilder_url.url + `?${queryParamsAsString}`
+    },
     hasDescription() {
       return this.content.title && this.content.body
     },

--- a/tests/components/slices/FormPage.test.js
+++ b/tests/components/slices/FormPage.test.js
@@ -1,0 +1,51 @@
+import { shallowMount } from '@vue/test-utils'
+import FormPage from '~/components/FormPage'
+
+jest.mock('~/services/document-fetcher')
+
+describe('FormPage', () => {
+  let component
+  const stubs = {
+    'pix-image': true,
+    'prismic-rich-tex': true,
+  }
+  const $route = {
+    query: { param1: 'param1', param2: 'param2' },
+  }
+  const $t = () => {}
+
+  describe('#formUrl', () => {
+    beforeEach(() => {
+      component = shallowMount(FormPage, {
+        mocks: { $route, $t },
+        stubs,
+        propsData: { content: { title: '' } },
+      })
+    })
+
+    it('should return the url', async () => {
+      // given
+      await component.setProps({
+        content: {
+          title: '',
+          body: '',
+          formbuilder_url: {
+            url: 'https://formbuilder-url.com/1234/',
+          },
+          image: {
+            url: '',
+          },
+          minimum_height: 0,
+        },
+      })
+
+      // when
+      const result = component.vm.formUrl
+
+      // then
+      expect(result).toEqual(
+        'https://formbuilder-url.com/1234/?param1=param1&param2=param2'
+      )
+    })
+  })
+})


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'une url vers un formulaire est saisie dans le navigateur et qu'elle contient des paramètres, le formulaire n'est pas automatiquement pré-rempli avec ces valeurs.

## :robot: Solution
- récupérer les paramètres depuis l'url
- transmettre ces paramètres dans l'url du formbuilder

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Aller sur `/abc-pix-cnfs?control1714940=PRENOM&control1714939=NOM&control1714941=EMAIL` et vérifier que le formulaire est pré-rempli.

