### PR TITLE
[TECH] Utiliser les mêmes conventions que sur Pix App pour les paramètres Matomo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ If not set, applications are built and served as static websites.
 - type: Boolean
 - default: false
 
-`MATOMO_URL`
-If not present, nuxt-matomo will not be loaded and analytics will not be active
+`WEB_ANALYTICS_ENABLED`
+If not set to true, nuxt-matomo will not be loaded and analytics will not be active
+
+`WEB_ANALYTICS_URL`
+Default is MATOMO_URL=https://analytics.pix.fr/
 
 - presence: optionnal
 - type: Url

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ If not set to true, nuxt-matomo will not be loaded and analytics will not be act
 `WEB_ANALYTICS_URL`
 Default is MATOMO_URL=https://analytics.pix.fr/
 
+`WEB_ANALYTICS_SITEID`
+Sets the siteId
+
 - presence: optionnal
 - type: Url
 - default: none

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -203,10 +203,10 @@ const config = {
   },
 }
 
-if (process.env.MATOMO_URL) {
+if (process.env.WEB_ANALYTICS_ENABLED === 'true') {
   config.modules.push([
     'nuxt-matomo',
-    { matomoUrl: process.env.MATOMO_URL, siteId: 1 },
+    { matomoUrl: process.env.WEB_ANALYTICS_URL, siteId: 1 },
   ])
 }
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -206,7 +206,10 @@ const config = {
 if (process.env.WEB_ANALYTICS_ENABLED === 'true') {
   config.modules.push([
     'nuxt-matomo',
-    { matomoUrl: process.env.WEB_ANALYTICS_URL, siteId: 1 },
+    {
+      matomoUrl: process.env.WEB_ANALYTICS_URL,
+      siteId: process.env.WEB_ANALYTICS_SITEID,
+    },
   ])
 }
 


### PR DESCRIPTION
## :unicorn: Problème
- Pour désactiver Matomo, on supprime la variable d'environnement `MATOMO_URL`. 
- Le `siteId` est écrit en dur dans le code.

## :robot: Solution
- Utiliser les mêmes conventions que sur Pix App : `WEB_ANALYTICS_ENABLED` et `WEB_ANALYTICS_URL`
- Rajouter une variable d'environnement pour le siteId : `WEB_ANALYTICS_SITEID`
