### PR TITLE
[TECH] Utiliser l'auto-import des composants proposé par Nuxt. 

### DIFF
--- a/components/BurgerMenuNav.vue
+++ b/components/BurgerMenuNav.vue
@@ -7,15 +7,8 @@
 </template>
 
 <script>
-import LanguageSwitcher from '@/components/LanguageSwitcher'
-import BurgerMenuNavItems from '@/components/BurgerMenuNavItems'
-
 export default {
   name: 'BurgerMenuNav',
-  components: {
-    LanguageSwitcher,
-    BurgerMenuNavItems,
-  },
   props: {
     items: {
       type: Object,

--- a/components/ChartSection.vue
+++ b/components/ChartSection.vue
@@ -5,13 +5,8 @@
 </template>
 
 <script>
-import LineChart from '@/components/LineChart'
-
 export default {
   name: 'ChartSection',
-  components: {
-    LineChart,
-  },
   props: {
     data: {
       type: Object,

--- a/components/FooterSliceZone.vue
+++ b/components/FooterSliceZone.vue
@@ -6,7 +6,7 @@
         :key="`footer-slice-left-${index}`"
       >
         <template v-if="slice.slice_type === 'logos_zone'">
-          <logos-zone :slice="slice" class="footer-left__logos" />
+          <slices-logos-zone :slice="slice" class="footer-left__logos" />
         </template>
         <prismic-rich-text
           v-if="slice.slice_type === 'text'"
@@ -31,7 +31,7 @@
       </div>
     </div>
     <div class="footer__right">
-      <navigation-group
+      <slices-navigation-group
         v-for="(slice, index) in navigationGroups"
         :key="`footer-slice-right-${index}`"
         class="footer-right__navigation"
@@ -44,15 +44,9 @@
 <script>
 import { mapState } from 'vuex'
 import { groupBy } from 'lodash'
-import LogosZone from '@/components/slices/LogosZone'
-import NavigationGroup from '@/components/slices/NavigationGroup'
 
 export default {
   name: 'FooterSliceZone',
-  components: {
-    LogosZone,
-    NavigationGroup,
-  },
   data() {
     return {
       socialMediasHoverMap: {},

--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -12,10 +12,10 @@
           :key="`navigation-slice-left-${index}`"
         >
           <template v-if="slice.slice_type === 'logos_zone'">
-            <logos-zone :slice="slice" />
+            <slices-logos-zone :slice="slice" />
           </template>
           <template v-if="slice.slice_type === 'navigation_zone'">
-            <navigation-zone :slice="slice" />
+            <slices-navigation-zone :slice="slice" />
           </template>
         </section>
       </div>
@@ -25,7 +25,7 @@
         class="navigation-slice-zone-content__right-side"
       >
         <template v-if="slice.slice_type === 'actions_zone'">
-          <actions-zone :slice="slice" />
+          <slice-actions-zone :slice="slice" />
         </template>
       </section>
     </div>
@@ -35,19 +35,8 @@
 <script>
 import { mapState } from 'vuex'
 import { groupBy } from 'lodash'
-import LogosZone from '@/components/slices/LogosZone'
-import NavigationZone from '@/components/slices/NavigationZone'
-import ActionsZone from '@/components/slices/ActionsZone'
-import BurgerMenuNav from '@/components/BurgerMenuNav'
-
 export default {
   name: 'NavigationSliceZone',
-  components: {
-    ActionsZone,
-    LogosZone,
-    NavigationZone,
-    BurgerMenuNav,
-  },
   computed: {
     isPixPro() {
       return process.env.isPixPro

--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -25,7 +25,7 @@
         class="navigation-slice-zone-content__right-side"
       >
         <template v-if="slice.slice_type === 'actions_zone'">
-          <slice-actions-zone :slice="slice" />
+          <slices-actions-zone :slice="slice" />
         </template>
       </section>
     </div>

--- a/components/NewsItemPost.vue
+++ b/components/NewsItemPost.vue
@@ -25,11 +25,8 @@
 </template>
 
 <script>
-import SliceZone from '@/components/SliceZone'
-
 export default {
   name: 'NewsItemPost',
-  components: { SliceZone },
   props: {
     newsItem: {
       type: Object,

--- a/components/SliceZone.vue
+++ b/components/SliceZone.vue
@@ -5,50 +5,33 @@
         <prismic-rich-text :field="slice.primary.text" />
       </template>
       <template v-if="slice.slice_type === 'pop-in'">
-        <pop-in-campaigns :slice="slice" :index-for-id="index" />
+        <slices-pop-in-campaigns :slice="slice" :index-for-id="index" />
       </template>
       <template v-if="slice.slice_type === 'banner'">
-        <page-banner :slice="slice" :index-for-id="index" />
+        <slices-page-banner :slice="slice" :index-for-id="index" />
       </template>
       <template v-if="slice.slice_type === 'article'">
-        <article-slice :slice="slice" :index-for-id="index" />
+        <slices-article :slice="slice" :index-for-id="index" />
       </template>
       <template v-if="slice.slice_type === 'multiple_block'">
-        <multiple-block-slice :slice="slice" :index-for-id="index" />
+        <slices-multiple-block :slice="slice" :index-for-id="index" />
       </template>
       <template v-if="slice.slice_type === 'partners_logos'">
-        <partners-logos-slice :slice="slice" :index-for-id="index" />
+        <slices-partners-logos :slice="slice" :index-for-id="index" />
       </template>
       <template v-if="slice.slice_type === 'latest_news'">
-        <latest-news-slice :slice="slice" :index-for-id="index" />
+        <slices-latest-news :slice="slice" :index-for-id="index" />
       </template>
       <template v-if="slice.slice_type === 'stat'">
-        <stat :slice="slice" :index-for-id="index" />
+        <slices-stat :slice="slice" :index-for-id="index" />
       </template>
     </section>
   </div>
 </template>
 
 <script>
-import PageBanner from '@/components/slices/PageBanner'
-import ArticleSlice from '@/components/slices/Article'
-import LatestNewsSlice from '@/components/slices/LatestNews'
-import PopInCampaigns from '@/components/slices/PopInCampaigns'
-import MultipleBlockSlice from '@/components/slices/MultipleBlock'
-import PartnersLogosSlice from '@/components/slices/PartnersLogos'
-import Stat from '@/components/slices/Stat'
-
 export default {
   name: 'SliceZone',
-  components: {
-    MultipleBlockSlice,
-    PageBanner,
-    ArticleSlice,
-    LatestNewsSlice,
-    PopInCampaigns,
-    PartnersLogosSlice,
-    Stat,
-  },
   props: {
     slices: {
       type: Array,
@@ -57,5 +40,3 @@ export default {
   },
 }
 </script>
-
-<style></style>

--- a/components/slices/ActionsZone.vue
+++ b/components/slices/ActionsZone.vue
@@ -19,13 +19,8 @@
 </template>
 
 <script>
-import LanguageSwitcher from '@/components/LanguageSwitcher'
-
 export default {
   name: 'ActionsZone',
-  components: {
-    LanguageSwitcher,
-  },
   props: {
     slice: {
       type: Object,

--- a/components/slices/Article.vue
+++ b/components/slices/Article.vue
@@ -69,13 +69,8 @@
 </template>
 
 <script>
-import CtaButton from '../CtaButton'
-
 export default {
   name: 'Article',
-  components: {
-    CtaButton,
-  },
   props: {
     slice: {
       type: Object,

--- a/components/slices/LatestNews.vue
+++ b/components/slices/LatestNews.vue
@@ -29,13 +29,8 @@
 </template>
 
 <script>
-import NewsItemCard from '../NewsItemCard'
-
 export default {
   name: 'LatestNews',
-  components: {
-    NewsItemCard,
-  },
   props: {
     slice: {
       type: Object,

--- a/components/slices/NavigationZone.vue
+++ b/components/slices/NavigationZone.vue
@@ -41,13 +41,8 @@
 </template>
 
 <script>
-import NavigationDropdown from '@/components/NavigationDropdown'
-
 export default {
   name: 'NavigationZone',
-  components: {
-    NavigationDropdown,
-  },
   props: {
     slice: {
       type: Object,

--- a/components/slices/PageBanner.vue
+++ b/components/slices/PageBanner.vue
@@ -49,11 +49,8 @@
 </template>
 
 <script>
-import MediaPlayer from '../MediaPlayer'
-
 export default {
   name: 'PageBanner',
-  components: { MediaPlayer },
   props: {
     slice: {
       type: Object,

--- a/components/slices/Stat.vue
+++ b/components/slices/Stat.vue
@@ -7,13 +7,8 @@
 </template>
 
 <script>
-import ChartSection from '~/components/ChartSection'
-
 export default {
   name: 'StatSlice',
-  components: {
-    ChartSection,
-  },
   props: {
     slice: {
       type: Object,

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -9,20 +9,6 @@
   </div>
 </template>
 
-<script>
-import HotNewsBanner from '@/components/HotNewsBanner'
-import NavigationSliceZone from '@/components/NavigationSliceZone'
-import FooterSliceZone from '@/components/FooterSliceZone'
-
-export default {
-  components: {
-    FooterSliceZone,
-    HotNewsBanner,
-    NavigationSliceZone,
-  },
-}
-</script>
-
 <style lang="scss">
 html {
   font-size: 16px;

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -57,7 +57,7 @@ const config = {
     '~plugins/vue-js-modal',
     { src: '~/plugins/prismicLinks', ssr: false },
   ],
-
+  components: true,
   /*
    ** Nuxt.js dev-modules
    */

--- a/pages/pix-pro/_custom-page.vue
+++ b/pages/pix-pro/_custom-page.vue
@@ -13,9 +13,6 @@
 </template>
 
 <script>
-import FormPage from '@/components/FormPage'
-import SimplePage from '@/components/SimplePage'
-import SliceZone from '@/components/SliceZone'
 import { documentFetcher } from '~/services/document-fetcher'
 
 export default {
@@ -26,11 +23,6 @@ export default {
       'fr-fr': '/:uid',
       'en-gb': '/:uid',
     },
-  },
-  components: {
-    FormPage,
-    SimplePage,
-    SliceZone,
   },
   async asyncData({ params, app, req, error, currentPagePath }) {
     try {

--- a/pages/pix-pro/index.vue
+++ b/pages/pix-pro/index.vue
@@ -13,9 +13,6 @@
 </template>
 
 <script>
-import FormPage from '@/components/FormPage'
-import SimplePage from '@/components/SimplePage'
-import SliceZone from '@/components/SliceZone'
 import { documentFetcher } from '~/services/document-fetcher'
 
 export default {
@@ -26,11 +23,6 @@ export default {
       'fr-fr': '/',
       'en-gb': '/',
     },
-  },
-  components: {
-    FormPage,
-    SimplePage,
-    SliceZone,
   },
   async asyncData({ app, req, error, currentPagePath }) {
     try {
@@ -64,5 +56,3 @@ export default {
   },
 }
 </script>
-
-<style lang="scss"></style>

--- a/pages/pix-site/_custom-page.vue
+++ b/pages/pix-site/_custom-page.vue
@@ -13,9 +13,6 @@
 </template>
 
 <script>
-import FormPage from '@/components/FormPage'
-import SimplePage from '@/components/SimplePage'
-import SliceZone from '@/components/SliceZone'
 import { documentFetcher } from '~/services/document-fetcher'
 
 export default {
@@ -26,11 +23,6 @@ export default {
       'fr-fr': '/:uid',
       'en-gb': '/:uid',
     },
-  },
-  components: {
-    FormPage,
-    SimplePage,
-    SliceZone,
   },
   async asyncData({ params, app, req, error, currentPagePath }) {
     try {

--- a/pages/pix-site/index.vue
+++ b/pages/pix-site/index.vue
@@ -5,7 +5,6 @@
 </template>
 
 <script>
-import SliceZone from '@/components/SliceZone'
 import { documentFetcher } from '~/services/document-fetcher'
 
 export default {
@@ -16,9 +15,6 @@ export default {
       'fr-fr': '/',
       'en-gb': '/',
     },
-  },
-  components: {
-    SliceZone,
   },
   async asyncData({ app, req, error, currentPagePath }) {
     try {
@@ -66,5 +62,3 @@ export default {
   },
 }
 </script>
-
-<style lang="scss"></style>

--- a/pages/pix-site/news/_slug.vue
+++ b/pages/pix-site/news/_slug.vue
@@ -10,7 +10,6 @@
 </template>
 
 <script>
-import NewsItemPost from '@/components/NewsItemPost'
 import { documentFetcher } from '~/services/document-fetcher'
 
 export default {
@@ -20,9 +19,6 @@ export default {
       'fr-fr': '/actualites/:slug',
       'en-gb': '/news/:slug',
     },
-  },
-  components: {
-    NewsItemPost,
   },
   async asyncData({ params, app, req, error, route, currentPagePath }) {
     try {
@@ -51,5 +47,3 @@ export default {
   },
 }
 </script>
-
-<style></style>

--- a/pages/pix-site/news/index.vue
+++ b/pages/pix-site/news/index.vue
@@ -26,7 +26,6 @@
   </div>
 </template>
 <script>
-import NewsItemCard from '@/components/NewsItemCard'
 import { documentFetcher } from '~/services/document-fetcher'
 
 export default {
@@ -37,9 +36,6 @@ export default {
       'fr-fr': '/actualites',
       'en-gb': '/news',
     },
-  },
-  components: {
-    NewsItemCard,
   },
   async asyncData({ app, error, req }) {
     try {

--- a/tests/components/slices/NavigationSliceZone.test.js
+++ b/tests/components/slices/NavigationSliceZone.test.js
@@ -11,9 +11,9 @@ describe('NavigationSliceZone', () => {
     'slide-menu': true,
     'burger-menu-nav': true,
     'organization-nav': true,
-    'logos-zone': true,
-    'navigation-zone': true,
-    'actions-zone': true,
+    'slices-logos-zone': true,
+    'slices-navigation-zone': true,
+    'slices-actions-zone': true,
     fa: true,
   }
 

--- a/tests/components/slices/NavigationZone.test.js
+++ b/tests/components/slices/NavigationZone.test.js
@@ -29,7 +29,7 @@ describe('NavigationZone slice', () => {
     beforeEach(() => {
       component = shallowMount(NavigationZone, {
         mocks: { $route },
-        stubs: { 'pix-link': true, fa: true },
+        stubs: { 'pix-link': true, fa: true, 'navigation-dropdown': true },
         propsData: {
           slice: {
             items: [

--- a/tests/pages/pix-site/index.test.js
+++ b/tests/pages/pix-site/index.test.js
@@ -48,6 +48,9 @@ describe('Index Page', () => {
           return { asText: () => PRISMIC_META }
         },
       },
+      stubs: {
+        'slice-zone': true,
+      },
     })
   })
 
@@ -80,6 +83,9 @@ describe('Index Page', () => {
         $prismic() {
           return { asText: () => '' }
         },
+      },
+      stubs: {
+        'slice-zone': true,
       },
     })
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on crée une application via : https://github.com/nuxt/create-nuxt-app, par défaut les composants sont chargés automatiquement. Cela se fait grâce à l'option : `components: true` dans le fichier : `nuxt.config.js`

## :robot: Solution
Je propose de suivre au plus près notre framework et donc d'ajouter cette option et d'enlever les imports de composant qui étaient faits. 

## :rainbow: Remarques
Pour les composants qui sont dans un dossier, il faut précéder le nom du composant par le nom du dossier (cf: [documentation nested-components](https://github.com/nuxt/components#nested-components))
Pour le composant : 
`composants/slices/logos-zones.vue`
Pour l'utiliser : 
```vue
<slices-logos-zones />
```
## :100: Pour tester
Vérifier le bon fonctionnement du site. 
