### PR TITLE
[BUGFIX] Aligner les logos des partenaires sur un grand écran.

### DIFF
--- a/components/slices/PartnersLogos.vue
+++ b/components/slices/PartnersLogos.vue
@@ -113,6 +113,7 @@ export default {
 @include device-is('large-screen') {
   .partners-logos {
     max-width: 1920px;
+    margin: 0 auto;
 
     &__title h2 {
       height: 49px;


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, si nous allons sur pix.fr avec un grand écran ou un dézoom important, nous pouvons voir que les logos des partenaires ne sont pas alignés avec le reste des éléments de la page. 
<img width="1680" alt="Screenshot 2021-06-29 at 09 34 08" src="https://user-images.githubusercontent.com/26384707/123756535-5156e580-d8bd-11eb-8166-1c1b6cd0c2da.png">


## :robot: Solution
Corriger ce problème d'affichage en centrant l'élément à l'aide de : `margin: 0 auto;`

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._

