### PR TITLE
[FEAT] Ajout de Matomo à Pix Pro (PIX-2800).

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -196,11 +196,15 @@ const config = {
   },
 }
 
-if (process.env.MATOMO_URL) {
+if (process.env.MATOMO_URL && process.env.MATOMO_SITE_ID) {
   config.modules.push([
     'nuxt-matomo',
-    { matomoUrl: process.env.MATOMO_URL, siteId: 1 },
+    { matomoUrl: process.env.MATOMO_URL, siteId: process.env.MATOMO_SITE_ID },
   ])
+} else {
+  console.warn(
+    'Both MATOMO_URL and MATOMO_SITE_ID environment variables must be provided'
+  )
 }
 
 export default config


### PR DESCRIPTION
## :unicorn: Problème

Dans l'optique d'ajouter Matomo à Pix Pro, nous devons associer la variable siteId au site correspondant (pix-site et pix-pro) et ainsi faire en sorte que la variable siteId nécessaire au plugin `nuxt-matomo` ne soit plus codée en dur comme cela était le cas jusqu'à présent.

## :robot: Solution

Ajout d'une variable d'environnement `MATOMO_SITE_ID` et de la vérification de sa présence.

## :rainbow: Remarques

Nous n'avons pas trouvé d'info quant à la gestion d'erreur dans le fichier de config.
Peut-être remplacer le console.warn par un throw d'erreur ferait l'affaire ? Une meilleure option ?

## :100: Pour tester
N/A

