### PR TITLE
[BUGFIX] Afficher correctement le bloc statistiques sur un grand écran.

### DIFF
--- a/assets/scss/components/slices/statistics.scss
+++ b/assets/scss/components/slices/statistics.scss
@@ -96,6 +96,8 @@
   .statistics {
     &__wrapper {
       padding: 0 98px;
+      max-width: 1920px;
+      margin: 0 auto 24px;
     }
   }
 


### PR DESCRIPTION
## :unicorn: Problème
L'affichage du bloc statistiques sur un grand écran n'est pas en accord avec les autres blocs de la page. 

![Screenshot 2021-07-19 at 10 20 48](https://user-images.githubusercontent.com/26384707/126127253-d7ee9f95-65be-4b94-9acd-bb2f21eff86a.png)


## :robot: Solution
Fixer la taille maximum pour le bloc dans le cas d'un grand écran. 

![Screenshot 2021-07-19 at 10 21 52](https://user-images.githubusercontent.com/26384707/126127372-4985651a-9e86-4236-be87-439c8cc6a371.png)


## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Vérifier en dézoomant sur la page d'accueil que le bloc statistiques ne prends pas plus de 1920px.

