### PR TITLE
[TECH] Utilise l'option modern du module prismic pour éviter un appel vers prismic sur la prod

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -167,6 +167,7 @@ const config = {
     linkResolver: '@/plugins/link-resolver',
     htmlSerializer: '@/plugins/html-serializer',
     preview: process.env.SSR_ENABLED === 'true',
+    modern: true,
   },
   router: {
     middleware: 'current-page-path',


### PR DESCRIPTION
## :unicorn: Problème
En production, on compile statiquement le site pour ne pas faire des appels vers prismic. Pourtant, un dernier appel vers l'API de prismic résistait encore et toujours. Voir https://github.com/nuxt-community/prismic-module/issues/134

## :robot: Solution
La version 1.3 du module prismic introduit une option de configuration `modern` qui utilise une autre version du client Prismic qui charge l'API en mode lazy loading.

## :100: Pour tester
Compiler statiquement le site et vérifier qu'au chargement aucun appel vers l'API de prismic n'est fait.

