### PR TITLE
[BUGFIX] Centrer les articles verticaux.

### DIFF
--- a/components/slices/Article.vue
+++ b/components/slices/Article.vue
@@ -247,7 +247,6 @@ export default {
     }
 
     &--vertical {
-      margin: 0 0;
       grid-template-areas:
         '. . a a a a a a a a a a . .'
         '. . b b b b b b b b b b . .';


### PR DESCRIPTION
## :unicorn: Problème
Nous pouvons voir que les articles verticaux ne sont pas centrés sur la page : 


<img width="1680" alt="Screenshot 2021-07-20 at 10 04 12" src="https://user-images.githubusercontent.com/26384707/126285154-7fae6ade-7cdf-4190-917f-816ceba7c1ee.png">

## :robot: Solution
Centrer les articles verticaux. 
<img width="1680" alt="Screenshot 2021-07-20 at 10 10 06" src="https://user-images.githubusercontent.com/26384707/126285366-482240ff-6506-4635-b7ba-bb4f52ee1266.png">


## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se rendre sur https://site-pr287.review.pix.fr/enseignement-scolaire, dézoomer et constater que tout est centré. 


