### PR TITLE
[FEATURE] Créer à chaque déploiement les graphiques de statistiques (PIX-2919). 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,30 @@ If not set, applications are built and served as static websites.
 `MATOMO_URL`
 If not present, nuxt-matomo will not be loaded and analytics will not be active
 
-- presence: optionnal
+- presence: optional
 - type: Url
 - default: none
 
+`METABASE_API_URL`
+If not present, Metabase cards will not be loaded.
+
+- presence: optional
+- type: Url
+- default: none
+
+`METABASE_USERNAME`
+If not present, Metabase cards will not be loaded.
+
+- presence: optional
+- type: String
+- default: none
+
+`METABASE_PASSWORD`
+If not present, Metabase cards will not be loaded.
+
+- presence: optional
+- type: String
+- default: none
 
 ## Build Setup pix-site
 

--- a/components/slices/Stat.vue
+++ b/components/slices/Stat.vue
@@ -7,6 +7,8 @@
 </template>
 
 <script>
+import metabaseFetcher from '~/services/metabase-fetcher'
+
 export default {
   name: 'StatSlice',
   props: {
@@ -19,6 +21,22 @@ export default {
       default: 0,
     },
   },
+  data() {
+    return {
+      values: [],
+      labels: [],
+    }
+  },
+  async fetch() {
+    const metabase = await metabaseFetcher()
+    const { values, labels } = await metabase.getCard({
+      cardId: this.content.metabase_card_id,
+      xAxisLabel: this.content.metabase_x_axis_label,
+      yAxisLabel: this.content.metabase_y_axis_label,
+    })
+    this.values = values
+    this.labels = labels
+  },
   computed: {
     content() {
       return this.slice.primary
@@ -26,7 +44,6 @@ export default {
     data() {
       return this.slice.items
     },
-
     chartData() {
       function backgroundColorFrom(color) {
         const hex = color.replace('#', '')
@@ -37,9 +54,10 @@ export default {
         return 'rgba(' + r + ',' + g + ',' + b + ',0.2)'
       }
 
-      const valueData = this.data.map((data) => data.data_value)
-      const labelData = this.data.map((data) => data.data_date)
-      const chartData = {
+      const valueData = this.values
+      const labelData = this.labels
+
+      return {
         datasets: [
           {
             backgroundColor: backgroundColorFrom(
@@ -53,7 +71,6 @@ export default {
         ],
         labels: labelData,
       }
-      return chartData
     },
   },
 }

--- a/modules/propagate-fetch-error-during-generation.js
+++ b/modules/propagate-fetch-error-during-generation.js
@@ -1,0 +1,16 @@
+// When error on fetch hook in Vue component, no failure in the generation
+// even if `--fail-on-error` option passed on `nuxt generate`.
+// https://github.com/nuxt/nuxt.js/issues/7742
+// This temporary solution should be solved on Nuxt 3 as we can see here :
+// https://github.com/nuxt/nuxt.js/pull/8475
+
+export default function propagateError() {
+  this.nuxt.hook('vue-renderer:ssr:context', (context) => {
+    const fetchError = Object.values(context.nuxt.fetch).find(
+      (data) => data._error
+    )
+    if (fetchError) {
+      context.nuxt.error = fetchError
+    }
+  })
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -84,7 +84,6 @@ const config = {
   modules: [
     // Doc: https://axios.nuxtjs.org/usage
     '@nuxtjs/axios',
-    '@nuxtjs/dotenv',
     '@nuxtjs/style-resources',
     ['nuxt-i18n', { detectBrowserLanguage: false }],
     '@nuxtjs/moment',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -76,6 +76,7 @@ const config = {
         extensions: ['jpg', 'jpeg', 'gif', 'png', 'webp', 'svg', 'mp4', 'pdf'],
       },
     ],
+    '~/modules/propagate-fetch-error-during-generation',
     '@nuxtjs/prismic',
   ],
   /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -5663,15 +5663,6 @@
         }
       }
     },
-    "@nuxtjs/dotenv": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/dotenv/-/dotenv-1.4.1.tgz",
-      "integrity": "sha512-DpdObsvRwC8d89I9mzz6pBg6e/PEXHazDM57DOI1mmML2ZjHfQ/DvkjlSzUL7T+TnW3b/a4Ks5wQx08DqFBmeQ==",
-      "requires": {
-        "consola": "^2.10.1",
-        "dotenv": "^8.1.0"
-      }
-    },
     "@nuxtjs/eslint-config": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@nuxtjs/eslint-config/-/eslint-config-6.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/vue-fontawesome": "^2.0.2",
     "@nuxtjs/axios": "^5.13.6",
-    "@nuxtjs/dotenv": "^1.4.1",
     "@nuxtjs/prismic": "^1.3.1",
     "chart.js": "^2.9.4",
     "lodash": "^4.17.21",

--- a/services/metabase-fetcher.js
+++ b/services/metabase-fetcher.js
@@ -1,0 +1,51 @@
+import axios from 'axios'
+import consola from 'consola'
+
+async function _getMetabaseSessionId(apiUrl, credentials) {
+  const sessionUrl = `${apiUrl}/api/session`
+  const headers = { 'Content-Type': 'application/json' }
+  const response = await axios.post(sessionUrl, credentials, { headers })
+  return response.data.id
+}
+
+export default async function () {
+  const apiUrl = process.env.METABASE_API_URL
+  const credentials = {
+    password: process.env.METABASE_PASSWORD,
+    username: process.env.METABASE_USERNAME,
+  }
+  if (!apiUrl || !credentials.password || !credentials.username) {
+    consola.warn('Metabase environment variables must be provided')
+  }
+
+  const sessionId = await _getMetabaseSessionId(apiUrl, credentials)
+
+  return {
+    async getCard({ cardId, xAxisLabel, yAxisLabel }) {
+      try {
+        const headers = {
+          'X-Metabase-Session': sessionId,
+        }
+        const response = await axios.post(
+          `${apiUrl}/api/card/${cardId}/query/json`,
+          null,
+          {
+            headers,
+          }
+        )
+
+        return response.data.reduce(
+          (acc, current) => {
+            acc.values.push(current[xAxisLabel])
+            acc.labels.push(current[yAxisLabel])
+            return acc
+          },
+          { values: [], labels: [] }
+        )
+      } catch (e) {
+        consola.error(e)
+        throw new Error('Data could not be fetched from Metabase')
+      }
+    },
+  }
+}

--- a/tests/components/slices/Stat.test.js
+++ b/tests/components/slices/Stat.test.js
@@ -26,7 +26,7 @@ describe('Stat slice', () => {
     beforeEach(() => {})
 
     describe('#chartData', () => {
-      it('should return char datas', () => {
+      it('should return char data', () => {
         // given
         component = shallowMount(Stat, {
           stubs: {
@@ -34,11 +34,20 @@ describe('Stat slice', () => {
             'prismic-rich-text': true,
             'chart-section': true,
           },
+          data() {
+            return {
+              values: [1, 2],
+              labels: ['2020-08-12', '2020-09-12'],
+            }
+          },
           propsData: {
             slice: {
               primary: {
                 block_data_name: [{ text: 'Data name' }],
                 block_graph_color: '#4700ff',
+                metabase_card_id: 123,
+                metabase_x_axis_label: 'x_axis',
+                metabase_y_axis_label: 'y_axis',
               },
               items: [
                 { data_value: 45, data_date: '2020-08-12' },
@@ -57,7 +66,7 @@ describe('Stat slice', () => {
             {
               backgroundColor: 'rgba(71,0,255,0.2)',
               borderColor: '#4700ff',
-              data: [45, 100],
+              data: [1, 2],
               label: 'Data name',
               type: 'line',
             },

--- a/tests/services/metabase-fetcher.test.js
+++ b/tests/services/metabase-fetcher.test.js
@@ -1,0 +1,119 @@
+import axios from 'axios'
+import consola from 'consola'
+import metabaseFetcher from '~/services/metabase-fetcher'
+jest.mock('axios')
+jest.mock('consola')
+
+describe('MetabaseFetcher', () => {
+  test('it should get session id', async () => {
+    // given
+    axios.post = jest.fn().mockReturnValue({
+      data: { id: 'session-id' },
+    })
+    process.env.METABASE_API_URL = 'https://test.metabase.fr'
+    process.env.METABASE_USERNAME = 'username'
+    process.env.METABASE_PASSWORD = 'password'
+
+    // when
+    await metabaseFetcher()
+
+    // then
+    const expectedUrl = 'https://test.metabase.fr/api/session'
+    const expectedBody = {
+      username: process.env.METABASE_USERNAME,
+      password: process.env.METABASE_PASSWORD,
+    }
+    const expectedHeaders = { headers: { 'Content-Type': 'application/json' } }
+    expect(axios.post).toHaveBeenCalledWith(
+      expectedUrl,
+      expectedBody,
+      expectedHeaders
+    )
+  })
+
+  describe('#getCard', () => {
+    test('it should call metabase with sessionId and cardId', async () => {
+      // given
+      axios.post = jest
+        .fn()
+        .mockReturnValueOnce({ data: { id: 'session-id' } })
+        .mockReturnValueOnce({ data: [] })
+      const cardId = 1234
+      process.env.METABASE_API_URL = 'https://test.metabase.fr'
+
+      // when
+      const fetcher = await metabaseFetcher()
+      await fetcher.getCard({
+        cardId,
+        xAxisLabel: 'x_axis',
+        yAxisLabel: 'y_axis',
+      })
+
+      // then
+      const expectedUrl = `https://test.metabase.fr/api/card/${cardId}/query/json`
+      const expectedHeaders = {
+        headers: { 'X-Metabase-Session': 'session-id' },
+      }
+      expect(axios.post).nthCalledWith(2, expectedUrl, null, expectedHeaders)
+    })
+
+    test('it should return values and labels', async () => {
+      // given
+      axios.post = jest
+        .fn()
+        .mockReturnValueOnce({ data: { id: 'session-id' } })
+        .mockReturnValueOnce({
+          data: [
+            { x_axis: 'x_axis_1', y_axis: 'y_axis_1' },
+            { x_axis: 'x_axis_2', y_axis: 'y_axis_2' },
+          ],
+        })
+
+      const cardId = 1234
+
+      // when
+      const fetcher = await metabaseFetcher()
+      const data = await fetcher.getCard({
+        cardId,
+        xAxisLabel: 'x_axis',
+        yAxisLabel: 'y_axis',
+      })
+
+      // then
+      expect(data).toEqual({
+        values: ['x_axis_1', 'x_axis_2'],
+        labels: ['y_axis_1', 'y_axis_2'],
+      })
+    })
+
+    describe('When Metabase not respond', () => {
+      it('should throw a Metabase error', async () => {
+        // given
+        const axiosError = new Error('504')
+        axios.post = jest
+          .fn()
+          .mockReturnValueOnce({ data: { id: 'session-id' } })
+          .mockRejectedValueOnce(axiosError)
+        consola.error = jest.fn()
+
+        const cardId = 1234
+
+        // when
+        const fetcher = await metabaseFetcher()
+        try {
+          await fetcher.getCard({
+            cardId,
+            xAxisLabel: 'x_axis',
+            yAxisLabel: 'y_axis',
+          })
+        } catch (error) {
+          // then
+          expect(consola.error).toHaveBeenCalledWith(axiosError)
+          expect(error.message).toEqual(
+            'Data could not be fetched from Metabase'
+          )
+        }
+      })
+    })
+  })
+})


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, l'équipe de communication met à jour tous les mois la page : https://pix.fr/statistiques 
Il s'agit d'une tâche récurrente et qui peut être sujette à des erreurs (mauvais mois copié, mauvais dashboards choisie, …), mais c'est une page importante pour Pix. 

## :robot: Solution
Faciliter la mise à jour de cette page en créant les graphiques à chaque build de l'application.

Ce qui a été fait : 
- Créer un service `metabase-fetcher` qui créé un sessionId et permet de pouvoir récupérer une card Metabase via son id en json. 
- Ajouter sur Prismic les cardId et les colonnes correspondantes pour chaque graphiques
- Supprimer @nuxtjs/dotenv car sinon toutes les variables d'environnement présentes sont ajoutées au build et se retrouve donc accessible par tout le monde. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se rendre sur : https://site-pr288.review.pix.fr/statistiques et vérifier que les graphiques s'affichent. 
Vérifier dans les sources que les variables ne sont pas exposées
