### PR TITLE
[FEATURE] Ajout du tag manager sur le site vitrine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ If not present, nuxt-matomo will not be loaded and analytics will not be active
 - type: Url
 - default: none
 
+`MATOMO_CONTAINER`
+If not present, nuxt-matomo will not be loaded and tag managers will not be active
+
+- presence: optional
+- type: Url
+- default: none
+
+`MATOMO_DEBUG`
+If not present, nuxt-matomo is not in debug mode
+
+- presence: optional
+- type: Boolean
+- default: false
+
 `METABASE_API_URL`
 If not present, Metabase cards will not be loaded.
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -203,6 +203,7 @@ if (process.env.MATOMO_URL && process.env.MATOMO_SITE_ID) {
     { matomoUrl: process.env.MATOMO_URL, siteId: process.env.MATOMO_SITE_ID },
   ])
 } else {
+  // eslint-disable-next-line no-console
   console.warn(
     'Both MATOMO_URL and MATOMO_SITE_ID environment variables must be provided'
   )

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -37,6 +37,19 @@ const config = {
       },
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
+    script: [
+      {
+        type: 'text/javascript',
+        src: process.env.MATOMO_CONTAINER,
+        async: true,
+        defer: true,
+      },
+      {
+        type: 'text/javascript',
+        src: '/scripts/start-matomo-event.js',
+        'data-matomo-debug-mode': process.env.MATOMO_DEBUG,
+      },
+    ],
   },
   /*
    ** Customize the progress-bar color
@@ -200,7 +213,10 @@ const config = {
 if (process.env.MATOMO_URL && process.env.MATOMO_SITE_ID) {
   config.modules.push([
     'nuxt-matomo',
-    { matomoUrl: process.env.MATOMO_URL, siteId: process.env.MATOMO_SITE_ID },
+    {
+      matomoUrl: process.env.MATOMO_URL,
+      siteId: process.env.MATOMO_SITE_ID,
+    },
   ])
 } else {
   // eslint-disable-next-line no-console

--- a/static/scripts/start-matomo-event.js
+++ b/static/scripts/start-matomo-event.js
@@ -1,0 +1,8 @@
+// eslint-disable-next-line no-var,no-use-before-define
+var _mtm = _mtm || []
+
+if (document.querySelector('script[data-matomo-debug-mode="true"]')) {
+  _mtm.push(['enableDebugMode'])
+}
+
+_mtm.push({ 'mtm.startTime': new Date().getTime(), event: 'mtm.Start' })


### PR DESCRIPTION
## :unicorn: Problème
Le site vitrine est branché à Matomo mais pour avoir la gestion des tags, il faut ajouter des scripts en plus

## :robot: Solution
- Ajout de 2 variables env : `MATOMO_CONTAINER`, `MATOMO_DEBUG`
- Ajout du script pour démarrer le suivi d'event 
- Ajout de l'appels des scripts

## :rainbow: Remarques
- A sortir dans un plugin

## :100: Pour tester
- Vérifier qu'on voit les appels sur Matomo
