### PR TITLE
[BUGFIX] Correction de l'affichage sur les écrans large (PIX-2764).

### DIFF
--- a/assets/scss/components/slices/process.scss
+++ b/assets/scss/components/slices/process.scss
@@ -193,6 +193,7 @@
       align-items: stretch;
       flex-wrap: wrap;
       justify-content: space-around;
+      flex-direction: column;
     }
   }
 

--- a/components/FooterSliceZone.vue
+++ b/components/FooterSliceZone.vue
@@ -149,6 +149,7 @@ export default {
   .footer {
     display: flex;
     padding: 47px 98px;
+    justify-content: center;
 
     &__left {
       margin-right: 40px;


### PR DESCRIPTION
## :unicorn: Problème
- Le footer est aligner a gauche.
- Les cards compétences sur la page `les tests` sont sur la meme ligne.

## :robot: Solution
- Aligner le footer au centre.
- Afficher les cards sur 2 lignes.

## :rainbow: Remarques
La vidéo sur la page d'accueil passe toujours en dessous du reste de la page 😢 .

## :100: Pour tester
Vérifier que le footer et les cards sont alignées comme on le souhaite.

