### PR TITLE
Utilise support.pix.org plutôt que support.pix.fr

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -28,7 +28,7 @@ server {
 
   root /app/dist/;
 
-  rewrite ^/(aide|help)$ https://support.pix.fr permanent;
+  rewrite ^/(aide|help)$ https://support.pix.org permanent;
   rewrite ^/employeurs$ https://pro.pix.fr permanent;
 
   if ($host ~ \.org) {

--- a/tests.sh
+++ b/tests.sh
@@ -27,8 +27,8 @@ checkRedirect pix.fr / "" 200
 checkRedirect pix.fr /competences "" 301 http://pix.fr/competences/
 checkRedirect pix.org /_nuxt/LICENSES "" 200
 checkRedirect pix.org /images/ "" 403
-checkRedirect pix.fr /aide "" 301 https://support.pix.fr/
-checkRedirect pix.fr /help "" 301 https://support.pix.fr/
+checkRedirect pix.fr /aide "" 301 https://support.pix.org/
+checkRedirect pix.fr /help "" 301 https://support.pix.org/
 checkRedirect pix.fr /employeurs "" 301 https://pro.pix.fr/
 checkRedirect pix.org / "" 301 http://pix.org/fr/
 checkRedirect review.scalingo.io / "review.pix.org" 301 http://review.pix.org/fr/


### PR DESCRIPTION
## :unicorn: Problème
On a changer il y a quelques mois l'URL du support de support.pix.fr en support.pix.org.

## :robot: Solution
Modifier la redirection vers le support pour éviter une redirection du .fr vers le .org.


## :100: Pour tester
Aller sur `/help` ou `/aide` et vérifier qu'on ait rediriger sur le .org directement.

