### PR TITLE
[BUGFIX] Bouton appel à l'action sur mobile.

### DIFF
--- a/components/CtaButton.vue
+++ b/components/CtaButton.vue
@@ -46,4 +46,10 @@ export default {
     opacity: 1;
   }
 }
+
+@include device-is('tablet') {
+  .cta-button {
+    display: initial;
+  }
+}
 </style>

--- a/components/CtaButton.vue
+++ b/components/CtaButton.vue
@@ -22,8 +22,9 @@ export default {
 
 <style lang="scss">
 .cta-button {
-  width: fit-content;
   background: $blue;
+  display: flex;
+  flex-wrap: wrap;
   border-radius: 5px;
   padding: 15px 20px;
   cursor: pointer;

--- a/components/slices/Article.vue
+++ b/components/slices/Article.vue
@@ -151,7 +151,6 @@ export default {
       display: flex;
       flex-direction: column;
       align-items: center;
-      width: 65%;
     }
 
     &--vertical {

--- a/components/slices/Article.vue
+++ b/components/slices/Article.vue
@@ -127,15 +127,6 @@ export default {
 </script>
 
 <style lang="scss">
-.article-content__title {
-  text-align: left;
-
-  &--only-text,
-  &--vertical {
-    text-align: center;
-  }
-}
-
 .article {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
@@ -184,6 +175,7 @@ export default {
       'b b b b'
       'a a a a';
   }
+
   &--vertical {
     grid-template-areas:
       'a a a a'
@@ -193,6 +185,74 @@ export default {
   &--only-text {
     display: flex;
     justify-content: center;
+  }
+}
+
+.article-content {
+  &__description {
+    margin: 16px 0 24px 0;
+    color: $grey-60;
+    font-size: 1.125rem;
+    line-height: 30px;
+
+    h3 {
+      margin-top: 8px;
+    }
+
+    ul {
+      list-style: none;
+      padding: 0;
+
+      li:before {
+        color: $grey-60;
+      }
+    }
+
+    & p {
+      font-size: 1.125rem;
+      font-weight: $font-normal;
+      letter-spacing: 0;
+      line-height: 1.875rem;
+      margin: 8px 0;
+    }
+
+    &--only-text {
+      text-align: center;
+    }
+  }
+
+  &__link-to {
+    height: 26px;
+    color: $blue;
+    font-family: $font-roboto;
+    font-size: 1.125rem;
+    font-weight: $font-medium;
+    letter-spacing: 0;
+    line-height: 0.009rem;
+
+    &:active,
+    &:focus,
+    &:hover {
+      text-decoration: none;
+      color: $blue;
+    }
+  }
+
+  &__title {
+    text-align: left;
+
+    &--only-text,
+    &--vertical {
+      text-align: center;
+    }
+
+    & h2 {
+      color: $grey-90;
+      font-weight: $font-normal;
+      letter-spacing: 0.00875rem;
+      line-height: 2.875rem;
+      margin-top: 0;
+    }
   }
 }
 
@@ -294,65 +354,6 @@ export default {
 
   @include device-is('large-screen') {
     justify-self: flex-end;
-  }
-}
-
-.article-content {
-  &__description {
-    margin: 16px 0 24px 0;
-    color: $grey-60;
-    font-size: 1.125rem;
-    line-height: 30px;
-
-    h3 {
-      margin-top: 8px;
-    }
-
-    ul {
-      list-style: none;
-      padding: 0;
-
-      li:before {
-        color: $grey-60;
-      }
-    }
-
-    & p {
-      font-size: 1.125rem;
-      font-weight: $font-normal;
-      letter-spacing: 0;
-      line-height: 1.875rem;
-      margin: 8px 0px;
-    }
-
-    &--only-text {
-      text-align: center;
-    }
-  }
-
-  &__link-to {
-    height: 26px;
-    color: $blue;
-    font-family: $font-roboto;
-    font-size: 1.125rem;
-    font-weight: $font-medium;
-    letter-spacing: 0;
-    line-height: 0.009rem;
-
-    &:active,
-    &:focus,
-    &:hover {
-      text-decoration: none;
-      color: $blue;
-    }
-  }
-
-  &__title h2 {
-    color: $grey-90;
-    font-weight: $font-normal;
-    letter-spacing: 0.00875rem;
-    line-height: 2.875rem;
-    margin-top: 0;
   }
 }
 </style>


### PR DESCRIPTION
## :unicorn: Problème
Les cta button sont coupés en deux sur mobile

<img width="486" alt="Capture d’écran 2021-08-20 à 14 53 46" src="https://user-images.githubusercontent.com/22095896/130236223-69ccce72-d31d-4d35-b9f6-fc3b8faa5aad.png">


## :robot: Solution
Ajouter une classe `button-container` avec la propriété `width: max-content` a la div contenant le bouton.

## :rainbow: Remarques

La propriété `flex-wrap` n'est que partiellement compatible avec IE. Cela ne devrait pas poser pas de problème ici puisqu'il s'agit d'une utilisation sur mobile.

## :100: Pour tester
Naviguer sur les différentes pages en mobile et voir que le bouton s'affiche d'une manière lisible.
(Rechargez le cache si vous visualisez une ancienne version)

<img width="406" alt="Capture d’écran 2021-08-20 à 17 00 00" src="https://user-images.githubusercontent.com/22095896/130253170-3e083edf-55bc-4f79-a73e-74799051ad77.png">
