### PR TITLE
[FEATURE] Permettre de changer les paramètres envoyés à 123FormBuilder. 

### DIFF
--- a/components/FormPage.vue
+++ b/components/FormPage.vue
@@ -35,11 +35,20 @@ export default {
   },
   computed: {
     formUrl() {
+      const mapKeys = this.$config.formKeysToMap
       const queryParamsAsObject = this.$route.query
       const queryParamsAsString = Object.keys(queryParamsAsObject)
-        .map((key) => `${key}=${queryParamsAsObject[key]}`)
+        .map((queryParamKey) => {
+          const key = Object.prototype.hasOwnProperty.call(
+            mapKeys,
+            queryParamKey
+          )
+            ? mapKeys[queryParamKey]
+            : queryParamKey
+          return `${key}=${queryParamsAsObject[queryParamKey]}`
+        })
         .join('&')
-      return this.content.formbuilder_url.url + `?${queryParamsAsString}`
+      return `${this.content.formbuilder_url.url}?${queryParamsAsString}`
     },
     hasDescription() {
       return this.content.title && this.content.body

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -7,6 +7,7 @@ const config = {
   publicRuntimeConfig: {
     languageSwitchEnabled: process.env.LANGUAGE_SWITCH_ENABLED || false,
     orgDomain: process.env.DOMAIN_ORG || 'pix.org',
+    formKeysToMap: process.env.FORM_KEYS_TO_MAP || {},
   },
   server: {
     port: process.env.PORT || 5000,

--- a/tests/components/slices/FormPage.test.js
+++ b/tests/components/slices/FormPage.test.js
@@ -13,11 +13,13 @@ describe('FormPage', () => {
     query: { param1: 'param1', param2: 'param2' },
   }
   const $t = () => {}
+  const formKeysToMap = {}
+  const $config = { formKeysToMap }
 
   describe('#formUrl', () => {
     beforeEach(() => {
       component = shallowMount(FormPage, {
-        mocks: { $route, $t },
+        mocks: { $route, $t, $config },
         stubs,
         propsData: { content: { title: '' } },
       })
@@ -45,6 +47,32 @@ describe('FormPage', () => {
       // then
       expect(result).toEqual(
         'https://formbuilder-url.com/1234/?param1=param1&param2=param2'
+      )
+    })
+
+    it('should map query keys thanks to environment variable', async () => {
+      // given
+      formKeysToMap.param1 = 'new-param-key'
+      await component.setProps({
+        content: {
+          title: '',
+          body: '',
+          formbuilder_url: {
+            url: 'https://formbuilder-url.com/1234/',
+          },
+          image: {
+            url: '',
+          },
+          minimum_height: 0,
+        },
+      })
+
+      // when
+      const result = component.vm.formUrl
+
+      // then
+      expect(result).toEqual(
+        'https://formbuilder-url.com/1234/?new-param-key=param1&param2=param2'
       )
     })
   })


### PR DESCRIPTION
## :unicorn: Problème
Nous avons le besoin de pouvoir facilement changer la clé fourni dans l'url d'un formulaire vers une autre clé car 123FormBuilder ne nous laisse pas choisir cette dernière. 

## :robot: Solution
Ajout d'une variable d'environnement `FORM_KEYS_TO_MAP` (du json strigifié) permettant de faire le lien entre l'ancienne clé vers celle voulue.
Le passage par une variable d'environnement s'explique par les [12 factors](https://12factor.net/). 
 

## :rainbow: Remarques
J'ai activé le SSR sur la review app afin de pouvoir faire des previews du nouveau formulaire qui nécessite cette fonctionnalité

## :100: Pour tester

