### PR TITLE
[BUGFIX] Corriger l'alignement des blocs process

### DIFF
--- a/assets/scss/components/slices/process.scss
+++ b/assets/scss/components/slices/process.scss
@@ -55,6 +55,10 @@
       margin-bottom: 0;
     }
 
+    &::after {
+      height: 100%;
+    }
+
     img {
       height: 51px;
       width: 51px;
@@ -89,6 +93,14 @@
 }
 
 @include device-is('tablet') {
+  .process-wrapper {
+    &__row {
+      flex-direction: row;
+      justify-content: center;
+      align-items: stretch;
+    }
+  }
+
   .process {
     &__title h2 {
       margin-top: 60px;
@@ -107,7 +119,7 @@
 
   .process-wrapper-row {
     &__item {
-      margin-bottom: 40px;
+      margin-bottom: 0;
 
       div:first-of-type {
         display: flex;
@@ -142,14 +154,6 @@
     }
   }
 
-  .process-wrapper {
-    &__row {
-      flex-direction: row;
-      justify-content: center;
-      align-items: baseline;
-    }
-  }
-
   .process-wrapper-row {
     &__item {
       &:first-of-type {
@@ -160,7 +164,6 @@
       margin-right: 56px;
       margin-bottom: 0;
       text-align: center;
-      height: 100%;
 
       img {
         margin-right: 0;
@@ -187,7 +190,7 @@
 @include device-is('large-screen') {
   .process {
     &__wrapper {
-      padding: 0 98px 60px 98px;
+      padding: 80px 98px 60px 98px;
       width: 100%;
       display: flex;
       align-items: stretch;
@@ -206,7 +209,6 @@
       max-width: 293px;
       padding: 32px 24px 50px 24px;
       text-align: center;
-      height: 100%;
 
       &:last-of-type {
         margin-right: 0;


### PR DESCRIPTION
## :unicorn: Problème
Sur la page d'accueil, les blocs ne sont pas alignés : 
<img width="1153" alt="Screenshot 2021-09-15 at 17 41 53" src="https://user-images.githubusercontent.com/11294487/133465275-7cf98f0d-d5fb-4f47-81a6-5bd868bdeb8f.png">

## :robot: Solution
- utiliser la propriété CSS `align-items: stretch` sur le parent
- il faut alors enlever la propriété `height: 100%` des enfants et laisser `stretch` gérer

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Vérifier le responsive de ce bloc.

