### PR TITLE
[BUGFIX] Corrige l'alignement vertical dans la bannière de nouvelles.

### DIFF
--- a/components/HotNewsBanner.vue
+++ b/components/HotNewsBanner.vue
@@ -49,6 +49,10 @@ export default {
     line-height: 1rem;
     font-size: 0.875rem;
     margin: 0 auto;
+
+    p {
+      margin: 0;
+    }
   }
 
   a {

--- a/components/HotNewsBanner.vue
+++ b/components/HotNewsBanner.vue
@@ -42,13 +42,13 @@ export default {
 
   display: flex;
   flex-direction: row;
+  align-items: center;
 
   div {
     text-align: center;
     line-height: 1rem;
     font-size: 0.875rem;
     margin: 0 auto;
-    align-self: center;
   }
 
   a {


### PR DESCRIPTION
## :unicorn: Problème
Alignement vertical bouton fermeture hot banner news
![image](https://user-images.githubusercontent.com/5855339/138063086-ee710a9e-fbc7-4bcb-84a1-f180289e0c4b.png)

## :robot: Solution
Flexbox `align-items: center;`

## :100: Pour tester
![image](https://user-images.githubusercontent.com/5855339/138063158-e697c1b4-62eb-47d5-add2-6eacb606306d.png)

