### PR TITLE
[TECH] Ajoute les headers de cache navigateurs pour les dossiers _assets et _nuxt

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -31,6 +31,12 @@ server {
   rewrite ^/(aide|help)$ https://support.pix.org permanent;
   rewrite ^/employeurs$ https://pro.pix.fr permanent;
 
+  location ~ ^/(_assets|_nuxt)/ {
+    expires 1y;
+    add_header Cache-Control public;
+    add_header ETag "";
+  }
+
   if ($host ~ \.org) {
     rewrite ^/(?!fr)(?!en-gb)(?!_nuxt)(?!images)(?!_assets)(?!favicon.ico) $scheme://$host/fr$request_uri permanent;
   }


### PR DESCRIPTION
## :unicorn: Problème
Le dosseier _assets qui contient des assets de prismic et le dossier _nuxt qui ne changent pas ne sont pas correctement mis en cache

## :robot: Solution
Rajouter les bon headers de cache coté nginx

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
1. Aller sur la RA
2. Vérifier que les assets js et images de prismic ont les bons headers de cache pour les navigateur

