### PR TITLE
[TECH] Mise à jour de l'assets-extractor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7162,7 +7162,7 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assets-extractor-module": {
-      "version": "github:1024pix/assets-extractor-module#3683bdee8591ae6e7c3d1559e07fabd2a3f70017",
+      "version": "github:1024pix/assets-extractor-module#11e6147520853b59c491d57c1d9ee45c0b6a6a81",
       "from": "github:1024pix/assets-extractor-module",
       "requires": {
         "@sindresorhus/slugify": "^2.1.0",


### PR DESCRIPTION
## :unicorn: Problème
Le module asset extractor avait un bug concernant le remplacement d'urls avec des parenthèses.

## :robot: Solution
Le mettre a jour avec la dernière version qui corrige le bug en question

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
1. Naviguer sur les pages du site et constater qu'on n'a pas d'images hébergé ailleurs qu'en local.

