### PR TITLE
[TECH] Importer seulement les fonctions de lodash qui sont utilisées.

### DIFF
--- a/components/FooterSliceZone.vue
+++ b/components/FooterSliceZone.vue
@@ -43,7 +43,7 @@
 
 <script>
 import { mapState } from 'vuex'
-import { groupBy } from 'lodash'
+import groupBy from 'lodash/groupBy'
 
 export default {
   name: 'FooterSliceZone',

--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -34,7 +34,8 @@
 
 <script>
 import { mapState } from 'vuex'
-import { groupBy } from 'lodash'
+import groupBy from 'lodash/groupBy'
+
 export default {
   name: 'NavigationSliceZone',
   computed: {


### PR DESCRIPTION
## :unicorn: Problème
Lors des imports, nous importons tout Lodash. 

## :robot: Solution
Importer que les fonctions que nous utilisons. 

## :rainbow: Remarques

On passe alors de 318Kb gzippé à 299Kb. 
 
<img width="1680" alt="avant" src="https://user-images.githubusercontent.com/26384707/138844691-7ecea783-fd87-433f-bedb-78a69cb762f1.png">

<img width="1680" alt="après" src="https://user-images.githubusercontent.com/26384707/138844732-dd5f7f3a-2dfd-44f8-a33c-01571d55a743.png">

## :100: Pour tester
- Vérifier que la navigation et le footer sont identiques à pix.fr

