### PR TITLE
[INFRA] Supprime la dépendance à lodash

### DIFF
--- a/components/FooterSliceZone.vue
+++ b/components/FooterSliceZone.vue
@@ -43,7 +43,7 @@
 
 <script>
 import { mapState } from 'vuex'
-import groupBy from 'lodash/groupBy'
+import { keyBy } from '~/services/key-by'
 
 export default {
   name: 'FooterSliceZone',
@@ -58,11 +58,14 @@ export default {
     },
     ...mapState(['mainFooters']),
     usedMainFooter() {
-      const groupBySite = groupBy(this.mainFooters, 'data.footer_for')
-      if (this.isPixPro && groupBySite['pix-pro']) {
-        return groupBySite['pix-pro'][0]
+      const mainFooterBySite = keyBy(
+        this.mainFooters,
+        (mainFooter) => mainFooter?.data?.footer_for
+      )
+      if (this.isPixPro && mainFooterBySite['pix-pro']) {
+        return mainFooterBySite['pix-pro']
       }
-      return groupBySite['pix-site'][0]
+      return mainFooterBySite['pix-site']
     },
     navigationGroups() {
       return this.usedMainFooter.data.body.filter(

--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -34,7 +34,7 @@
 
 <script>
 import { mapState } from 'vuex'
-import groupBy from 'lodash/groupBy'
+import { keyBy } from '~/services/key-by'
 
 export default {
   name: 'NavigationSliceZone',
@@ -45,11 +45,14 @@ export default {
     ...mapState(['mainNavigations']),
 
     usedMainNavigation() {
-      const groupBySite = groupBy(this.mainNavigations, 'data.navigation_for')
-      if (this.isPixPro && groupBySite['pix-pro']) {
-        return groupBySite['pix-pro'][0]
+      const mainNavBySite = keyBy(
+        this.mainNavigations,
+        (mainNav) => mainNav?.data?.navigation_for
+      )
+      if (this.isPixPro && mainNavBySite['pix-pro']) {
+        return mainNavBySite['pix-pro']
       }
-      return groupBySite['pix-site'][0]
+      return mainNavBySite['pix-site']
     },
 
     leftNavigation() {

--- a/package.json
+++ b/package.json
@@ -32,14 +32,13 @@
     "signal-github": "./scripts/signal_deploy_to_pr.sh"
   },
   "dependencies": {
-    "assets-extractor-module": "1024pix/assets-extractor-module",
     "@fortawesome/fontawesome-svg-core": "^1.2.35",
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/vue-fontawesome": "^2.0.2",
     "@nuxtjs/axios": "^5.13.6",
     "@nuxtjs/prismic": "^1.3.1",
+    "assets-extractor-module": "1024pix/assets-extractor-module",
     "chart.js": "^2.9.4",
-    "lodash": "^4.17.21",
     "nuxt": "^2.15.1",
     "nuxt-fontawesome": "0.4.0",
     "nuxt-i18n": "^6.27.2",

--- a/services/key-by.js
+++ b/services/key-by.js
@@ -1,0 +1,5 @@
+export function keyBy(arr, keyMapper) {
+  return Object.fromEntries(
+    arr.map((value, index) => [keyMapper(value, index), value])
+  )
+}


### PR DESCRIPTION
## :unicorn: Problème
On dépend de lodash uniquement pour pouvoir utiliser la fonction `groupBy`.

## :robot: Solution
Ne plus dépendre de lodash.

## :rainbow: Remarques
On perd environ 5k sur le bundle gzippé.

## :100: Pour tester
Vérifier que le header et footer du site fonctionnent toujours (en .fr et en .org).

