### PR TITLE
[INFRA] Utilise seulement le mode static de Nuxt

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,6 @@ Domain name for `.org` extension.
 - type: String
 - default: none
 
-`SSR_ENABLED`
-Build and serve applications using SSR.
-If not set, applications are built and served as static websites.
-
-- presence: optional
-- type: Boolean
-- default: false
-
 `MATOMO_URL`
 If not present, nuxt-matomo will not be loaded and analytics will not be active
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -3,7 +3,7 @@ import routes from './services/get-routes-to-generate'
 
 const config = {
   generate: { routes },
-  target: process.env.SSR_ENABLED === 'true' ? 'server' : 'static',
+  target: 'static',
   publicRuntimeConfig: {
     languageSwitchEnabled: process.env.LANGUAGE_SWITCH_ENABLED || false,
     orgDomain: process.env.DOMAIN_ORG || 'pix.org',
@@ -173,7 +173,6 @@ const config = {
     endpoint: process.env.PRISMIC_API_ENDPOINT,
     linkResolver: '@/plugins/link-resolver',
     htmlSerializer: '@/plugins/html-serializer',
-    preview: process.env.SSR_ENABLED === 'true',
     modern: true,
   },
   router: {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules .nuxt",
-    "build": "./scripts/build.sh && npm run signal-github",
-    "build:static": "nuxt generate --fail-on-error",
+    "build": "nuxt generate --fail-on-error && npm run signal-github",
     "start": "nuxt start",
     "dev:site": "SITE=pix-site nuxt",
     "build:site": "SITE=pix-site nuxt generate --fail-on-error",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "clean": "rm -rf node_modules .nuxt",
     "build": "./scripts/build.sh && npm run signal-github",
     "build:static": "nuxt generate --fail-on-error",
-    "build:ssr": "nuxt build",
     "start": "nuxt start",
     "dev:site": "SITE=pix-site nuxt",
     "build:site": "SITE=pix-site nuxt generate --fail-on-error",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,9 +1,3 @@
 #!/bin/bash -e
 
-if [ "$SSR_ENABLED" == "true" ]
-then
-  npm run build:ssr
-else
-  npm run build:static
-fi
-
+npm run build:static

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash -e
-
-npm run build:static


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, il est possible de changer de mode de rendu pour passer en mode static ou en mode SSR avec la variable d'env `SSR_ENABLED`. Celle ci n'est aujourd'hui utilisée qu'en dev et permet également d'activer ou désactiver le mode preview de Prismic.

Le fait d'utiliser un mode de rendu différent en dev et en integ/recette/prod peut apporter des écarts de comportement.

## :robot: Solution
Le mode preview de Prismic est maintenant compatible avec le mode static de Nuxt, on peut toujours utiliser le mode de rendu static quelque soit l'environnement.

## :rainbow: Remarques
Peut être qu'il me manque des infos pour comprendre pourquoi `SSR_ENABLED` avait été mis en place.

## :100: Pour tester
Vérifier en local que le serveur de dev fonctionne toujours et que le mode preview Prismic est fonctionnel.