### PR TITLE
[BUGFIX] Espacement de bloc feature

### DIFF
--- a/assets/scss/components/slices/features.scss
+++ b/assets/scss/components/slices/features.scss
@@ -150,7 +150,8 @@
 @include device-is('large-screen') {
   .features {
     &__title h2 {
-      margin-top: 120px;
+      margin-top: 0;
+      padding-top: 120px;
     }
     &__wrapper {
       padding: 60px 0;

--- a/assets/scss/components/slices/features.scss
+++ b/assets/scss/components/slices/features.scss
@@ -6,7 +6,7 @@
     letter-spacing: 0.15px;
     line-height: 49px;
     text-align: center;
-    margin-top: 64px;
+    margin-top: 0;
   }
 
   &__wrapper {
@@ -72,7 +72,7 @@
 @include device-is('tablet') {
   .features {
     &__title h2 {
-      margin-top: 80px;
+      padding: 80px 0 40px 0;
     }
     &__wrapper {
       padding: 80px 0;
@@ -105,7 +105,7 @@
 @include device-is('desktop') {
   .features {
     &__title h2 {
-      margin-top: 80px;
+      padding: 80px 0 40px 0;
     }
 
     &__wrapper {
@@ -150,8 +150,7 @@
 @include device-is('large-screen') {
   .features {
     &__title h2 {
-      margin-top: 0;
-      padding-top: 120px;
+      padding: 100px 0 50px 0;
     }
     &__wrapper {
       padding: 60px 0;


### PR DESCRIPTION
## :unicorn: Problème
Le bloc feature "Comment ça marche ?" est trop collé au bloc précédant.

<img width="1152" alt="image" src="https://user-images.githubusercontent.com/5855339/139254402-53925670-d06c-47b8-a649-eb734be40058.png">

## :robot: Solution
Utilisation d'un `padding-top` plutôt que d'un `margin-top`.

![image](https://user-images.githubusercontent.com/5855339/139257370-3c2d9edc-04ae-49d1-8183-eb8edd76c29f.png)

## :rainbow: Remarques
Allé au plus simple, peut être y a-t-il plus propre ?

## :100: Pour tester
1. Vérifier que le bloc "Comment ça marche ?" est bien aligné sur les différentes réso
2. Vérifier qu'aucun autre bloc n'est impacté
