### PR TITLE
[BUGFIX] Correction lien icones sur le site .org

### DIFF
--- a/components/slices/ActionsZone.vue
+++ b/components/slices/ActionsZone.vue
@@ -13,7 +13,7 @@
         >
           <img
             v-if="menuItem.icon"
-            :src="`images/${menuItem.icon}`"
+            :src="`/images/${menuItem.icon}`"
             class="actions-zone__item__icon"
             width="23"
             height="22"


### PR DESCRIPTION
## :unicorn: Problème
Icônes cassées sur pix.org.

## :robot: Solution
Correction lien src des images.

## :rainbow: Remarques
RAS

## :100: Pour tester
Voir le site en local