### PR TITLE
[BUGFIX] Réaligner les éléments dans le menu action (PIX-3760).

### DIFF
--- a/components/slices/ActionsZone.vue
+++ b/components/slices/ActionsZone.vue
@@ -52,12 +52,8 @@ export default {
     }
     li {
       align-self: center;
-      display: inline;
+      display: flex;
     }
-  }
-
-  & > div:not(:last-child) {
-    margin-right: 16px;
   }
 
   &__item {


### PR DESCRIPTION
## :unicorn: Problème
Il y a un déalignement dans le menu action

## :robot: Solution
Le remettre

## :rainbow: Remarques
Une marge a été retirée pour éviter que le menu des langues soit trop loin du reste

## :100: Pour tester
Regarder les trois sites vitrines
