### PR TITLE
[BUGFIX] Problème de texte alternative sur les icones du menu.

### DIFF
--- a/components/slices/ActionsZone.vue
+++ b/components/slices/ActionsZone.vue
@@ -15,6 +15,8 @@
             v-if="menuItem.icon"
             :src="`/images/${menuItem.icon}`"
             class="actions-zone__item__icon"
+            alt
+            role="presentation"
             width="23"
             height="22"
           />


### PR DESCRIPTION
## :unicorn: Problème
Les icônes de l'action menu n'avaient pas de alt

## :robot: Solution
Mettre un alt vide et préciser le rôle présentation

## :rainbow: Remarques

## :100: Pour tester
Vérifier le alt vide
