### PR TITLE
[BUGFIX] Amélioration de l'auto-merge.

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,25 +1,25 @@
 name: automerge check
+
 on:
   pull_request:
     types:
       - labeled
-  pull_request_review:
-    types:
-      - submitted
   check_suite:
     types:
       - completed
-  status:
+
+permissions: write-all
+
 jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
-        uses: "pascalgn/automerge-action@v0.8.3"
+        uses: "pascalgn/automerge-action@v0.14.3"
         env:
-          GITHUB_TOKEN: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"
+          GITHUB_TOKEN: "${{ github.token }}"
           MERGE_LABELS: ":rocket: Ready to Merge"
           MERGE_COMMIT_MESSAGE: "pull-request-title"
           UPDATE_LABELS: ":rocket: Ready to Merge"
           UPDATE_METHOD: "rebase"
-          MERGE_FORKS: "false" 
+          MERGE_FORKS: "false"


### PR DESCRIPTION
## :unicorn: Problème
L'automerge-action n'est plus à jour

## :robot: Solution
Alignement de l'automerge-action avec ember-testing-library, petite modif de paramétrage a priori sans impact

## :rainbow: Remarques
Est-ce que le changement de trigger ne pose pas soucis ?
On pourra supprimer le token `PIX_SERVICE_ACTIONS_TOKEN` du projet après le merge.

## :100: Pour tester
Devrait run au merge de cette MR :) 