### PR TITLE
[BUGFIX] a11y - Ordre des headers de la page d'actualités

### DIFF
--- a/components/NewsItemCard.vue
+++ b/components/NewsItemCard.vue
@@ -23,7 +23,7 @@
           </span>
         </p>
 
-        <h3 class="news-item-card__title">{{ slice.title[0].text }}</h3>
+        <h2 class="news-item-card__title">{{ slice.title[0].text }}</h2>
 
         <prismic-rich-text
           :field="slice.excerpt"


### PR DESCRIPTION
## :unicorn: Problème
Dans la page des actualités, il n'y avait pas de `h2` avant les `h3`.

## :robot: Solution
Transformer les `h3` en `h2` pour une meilleur a11y.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que les titres n'ont pas changé de tête.

