### PR TITLE
[BUGFIX] Affichage de la vidéo au scroll sur la page d'accueil

### DIFF
--- a/components/slices/PageBanner.vue
+++ b/components/slices/PageBanner.vue
@@ -68,11 +68,11 @@ export default {
         style = {
           background: `no-repeat url(${this.slice.primary.banner_background.url})`,
           backgroundSize: 'cover',
-          backgroundPosition: 'top right',
-          'clip-path': 'ellipse(110% 55% at 50% 40%)',
+          backgroundPosition: 'bottom',
         }
+      } else {
+        style.backgroundColor = this.slice.primary.banner_background_color
       }
-      style.backgroundColor = this.slice.primary.banner_background_color
       return style
     },
     fontContrast() {


### PR DESCRIPTION
## :unicorn: Problème
La vidéo de la page d'accueil semblait passer sous le contenu du site.
![image](https://user-images.githubusercontent.com/5855339/139446816-70109270-8d62-457f-84f8-0adfa3948b57.png)
![image](https://user-images.githubusercontent.com/5855339/139446872-cf26ba4f-586a-4c77-9f53-68799e2f4418.png)

## :robot: Solution
Déplacement de l'image de fond de la `PageBanner` pour ne pas avoir besoin du `clip-path`. L'image gère elle même l'effet arrondi.

## :rainbow: Remarques
Le soucis venait du `clip-path` sur le `PageBanner`. On ne met la couleur de fond bleu seulement si il n'y a pas d'image précisée.

## :100: Pour tester
1. Lancer la vidéo et scroller
2. Vérifier que l'image du `PageBanner` sont correctes sur Pix pro/Pix Org