### PR TITLE
[BUGFIX] Redirections Nginx

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -38,11 +38,10 @@ server {
   }
 
   if ($host ~ \.org) {
-    rewrite ^/(?!fr)(?!en-gb)(?!_nuxt)(?!images)(?!_assets)(?!favicon.ico) $scheme://$host/fr$request_uri permanent;
+    rewrite ^/(?!fr)(?!en-gb)(?!_assets)(?!_nuxt)(?!documents)(?!images)(?!scripts)(?!apple-touch-icon)(?!favicon)(?!robots\.txt) $scheme://$host/fr$request_uri permanent;
   }
 
   if ($http_x_forwarded_host ~ \.org) {
-    rewrite ^/(?!fr)(?!en-gb)(?!_nuxt)(?!images)(?!_assets)(?!favicon.ico) $scheme://$http_x_forwarded_host/fr$request_uri permanent;
+    rewrite ^/(?!fr)(?!en-gb)(?!_assets)(?!_nuxt)(?!documents)(?!images)(?!scripts)(?!apple-touch-icon)(?!favicon)(?!robots\.txt) $http_x_forwarded_proto://$http_x_forwarded_host/fr$request_uri permanent;
   }
 }
-

--- a/tests.sh
+++ b/tests.sh
@@ -8,12 +8,13 @@ function checkRedirect() {
   local host=$1
   local path=$2
   local forwardedHost=$3
-  local expectedStatus=$4
-  local expectedLocation=$5
+  local forwardedScheme=$4
+  local expectedStatus=$5
+  local expectedLocation=$6
 
   echo -e "\nWhen url = $host$path and X-Forwarded-Host header = $forwardedHost"
   echo -e "   It returns $expectedStatus and location header = $expectedLocation"
-  local response=$(curl -w "%{http_code} %{redirect_url}" -k http://localhost$path -H "Host: $host" -H "X-Forwarded-Host: $forwardedHost" -o /dev/null --silent)
+  local response=$(curl -w "%{http_code} %{redirect_url}" -k http://localhost$path -H "Host: $host" -H "X-Forwarded-Host: $forwardedHost" -H "X-Forwarded-Proto: $forwardedScheme" -o /dev/null --silent)
 
   if [ "$response" != "$expectedStatus $expectedLocation" ]; then
     echo "${RED}❌ Expected $expectedStatus $expectedLocation for url $host$path, got $response ${RESET}"
@@ -23,17 +24,16 @@ function checkRedirect() {
   fi
 }
 
-checkRedirect pix.fr / "" 200
-checkRedirect pix.fr /competences "" 301 http://pix.fr/competences/
-checkRedirect pix.org /_nuxt/LICENSES "" 200
-checkRedirect pix.org /images/ "" 403
-checkRedirect pix.fr /aide "" 301 https://support.pix.org/
-checkRedirect pix.fr /help "" 301 https://support.pix.org/
-checkRedirect pix.fr /employeurs "" 301 https://pro.pix.fr/
-checkRedirect pix.org / "" 301 http://pix.org/fr/
-checkRedirect review.scalingo.io / "review.pix.org" 301 http://review.pix.org/fr/
-checkRedirect pix.org /_assets/ "" 403
-checkRedirect review.scalingo.io /_assets/ "review.pix.org" 403
-checkRedirect pix.org /favicon.ico "" 200
-checkRedirect pix.org /favicon.ico "review.pix.org" 200
-
+checkRedirect pix.fr / "" "" 200
+checkRedirect pix.fr /competences "" "" 301 http://pix.fr/competences/
+checkRedirect pix.org /_nuxt/LICENSES "" "" 200
+checkRedirect pix.org /images/ "" "" 403
+checkRedirect pix.fr /aide "" "" 301 https://support.pix.org/
+checkRedirect pix.fr /help "" "" 301 https://support.pix.org/
+checkRedirect pix.fr /employeurs "" "" 301 https://pro.pix.fr/
+checkRedirect pix.org / "" "" 301 http://pix.org/fr/
+checkRedirect review.scalingo.io / "review.pix.org" "https" 301 https://review.pix.org/fr/
+checkRedirect pix.org /_assets/ "" "" 403
+checkRedirect review.scalingo.io /_assets/ "review.pix.org" "https" 403
+checkRedirect pix.org /favicon.ico "" "" 200
+checkRedirect pix.org /favicon.ico "review.pix.org" "" 200


### PR DESCRIPTION
## :unicorn: Problème
Sur https://pix.org/ j'ai remarqué que le chargement de `start-matomo-event.js` échoue car il est en HTTP et non en HTTPS ?!

![image](https://user-images.githubusercontent.com/19571875/139453997-b7c8b106-0e33-4f3d-96d4-788962ce268d.png)

En creusant un peu, je me suis rendu compte que lorsqu'on demande https://pix.org/scripts/start-matomo-event.js on est redirigé vers http://pix.org/fr/scripts/start-matomo-event.js et même si on repasse l'URL en HTTPS elle n'est pas bonne.

## :robot: Solution
Désactiver la redirection sur tous les répertoires/fichiers provenants de static/
Lorsqu'on est en mode "forwardé", utiliser le protocole forwardé pour éviter de basculer en HTTP.

## :rainbow: Remarques
Pas sur que la correction pour rester en HTTPS soit utile, mais c'est quand même plus correct.

## :100: Pour tester
Aller sur la review app org et vérifier que le chargement de `start-matomo-event.js` fonctionne.
