### PR TITLE
[BUGFIX] Retirer le texte des actions de la barre de navigation sur mobile. 

### DIFF
--- a/components/BurgerMenuNav.vue
+++ b/components/BurgerMenuNav.vue
@@ -44,6 +44,11 @@ export default {
 
   .bm-burger-button {
     top: 25px;
+    left: 24px;
+
+    @include device-is('tablet') {
+      left: 48px;
+    }
 
     @include device-is('large-screen') {
       display: none;

--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -95,9 +95,13 @@ export default {
   .navigation-slice-zone__content {
     display: flex;
     justify-content: space-between;
-    margin-left: 100px;
     height: 80px;
     padding-right: 36px;
+    margin-left: 80px;
+
+    @include device-is('tablet') {
+      margin-left: 112px;
+    }
   }
 
   .navigation-slice-zone-content__bottom-side {

--- a/components/slices/ActionsZone.vue
+++ b/components/slices/ActionsZone.vue
@@ -49,6 +49,12 @@ export default {
   ul {
     list-style: none;
     display: flex;
+    padding-left: 0;
+
+    @include device-is('tablet') {
+      padding-left: 10px;
+    }
+
     li::before {
       content: none;
     }
@@ -59,13 +65,18 @@ export default {
   }
 
   &__item {
-    font-size: 0.875rem;
+    font-size: 0;
     color: $grey-60;
     font-family: $font-roboto;
     font-weight: $font-medium;
     letter-spacing: 0.008rem;
     line-height: 1.375rem;
     display: inline-flex;
+    align-items: center;
+
+    @include device-is('tablet') {
+      font-size: 0.875rem;
+    }
 
     &__icon {
       margin-right: 5px;

--- a/components/slices/LogosZone.vue
+++ b/components/slices/LogosZone.vue
@@ -36,7 +36,11 @@ export default {
   justify-content: flex-end;
 
   .logos-zone__content {
-    margin-right: 24px;
+    margin-right: 12px;
+
+    @include device-is('large-screen') {
+      margin-right: 24px;
+    }
 
     img {
       height: 50px;


### PR DESCRIPTION
## :unicorn: Problème
L'affichage sur mobile de la navbar est disgracieux. 

## :robot: Solution
Retirer le texte des actions sur mobile afin que les logos soient de taille adéquate.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._

