### PR TITLE
[BUGFIX] Ajoute les attributs `width` et `height` aux icônes

### DIFF
--- a/components/FooterSliceZone.vue
+++ b/components/FooterSliceZone.vue
@@ -24,7 +24,11 @@
               :field="socialMedia.socialmedia_url"
               class="footer-social-media__icon"
             >
-              <pix-image :field="socialMedia.socialmedia_image" />
+              <pix-image
+                :field="socialMedia.socialmedia_image"
+                width="30"
+                height="30"
+              />
             </pix-link>
           </li>
         </ul>

--- a/components/slices/LogosZone.vue
+++ b/components/slices/LogosZone.vue
@@ -6,9 +6,9 @@
       class="logos-zone__content"
     >
       <pix-link v-if="hasLink(logo)" :field="logo.url">
-        <pix-image :field="logo.image" />
+        <pix-image :field="logo.image" width="60.6" height="50" />
       </pix-link>
-      <pix-image v-else :field="logo.image" />
+      <pix-image v-else :field="logo.image" width="54.7" height="50" />
     </div>
   </div>
 </template>
@@ -43,7 +43,6 @@ export default {
     }
 
     img {
-      height: 50px;
       margin: 15px 0 15px 0;
     }
 


### PR DESCRIPTION
## :unicorn: Problème
Layout shift remonté par Lighthouse : 
<img width="793" alt="image" src="https://user-images.githubusercontent.com/5855339/141786811-c1951e26-0192-46e2-8760-82822d75c73d.png">

## :robot: Solution
Ajouter les attributs `width` et `height` aux images.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que les attributs sont bien ajoutés et que le score Lighthouse est amélioré.

