### PR TITLE
[TECH] Migration vers @nuxt/image (PIX-3945)

### DIFF
--- a/assets/scss/components/slices/features.scss
+++ b/assets/scss/components/slices/features.scss
@@ -2,176 +2,102 @@
   &__title h2 {
     color: $grey-80;
     font-weight: normal;
-    height: 49px;
     letter-spacing: 0.15px;
     line-height: 49px;
     text-align: center;
     margin-top: 0;
+    padding: 100px 0 0;
   }
 
   &__wrapper {
-    padding: 64px 0;
+    padding: 60px 10%;
+    display: flex;
+    flex-direction: column;
+    // align-items: center;
+    margin: 0 auto;
+    word-break: break-word;
   }
 }
 
 .features-wrapper {
-  &__row {
-    display: flex;
-    align-items: center;
-    flex-direction: column;
-    margin-bottom: 24px;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-}
-
-.features-wrapper-row {
-  &__item {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-bottom: 24px;
-
-    &:last-child {
-      margin-right: 0;
-      margin-bottom: 0;
-    }
-
-    img {
-      margin-right: 25px;
-      max-height: 74px;
-    }
-  }
-}
-
-.features-wrapper-row-item {
-
-    &__title h3 {
-      width: 217px;
-      color: $grey-90;
-      font-size: 1rem;
-      letter-spacing: 0;
-      line-height: 30px;
-      font-family: $font-open-sans;
-      font-weight: $font-medium;
-      margin-top: 16px;
-    }
-
-    &__description {
-      width: 217px;
-      color: $grey-60;
-      font-family: $font-roboto;
-      font-size: 0.875rem;
-      letter-spacing: 0.15px;
-      line-height: 24px;
-    }
-}
-
-@include device-is('tablet') {
-  .features {
-    &__title h2 {
-      padding: 80px 0 40px 0;
-    }
-    &__wrapper {
-      padding: 80px 0;
-    }
-  }
-
-  .features-wrapper-row {
     &__item {
-      margin-bottom: 40px;
-
-      img {
-        margin-right: 32px;
-      }
-    }
-  }
-
-  .features-wrapper-row-item {
-
-    &__title h3 {
-      width: 518px;
-      font-size: 1.25rem;
+        display: flex;
+        align-items: center;
+        margin-bottom: 40px;
     }
 
-    &__description {
-      width: 518px;
+    &-item {
+        &__image {
+            min-width: 100px;
+            height: 74px;
+            display: flex;
+            justify-content: center;
+        }
+    
+        &__content {
+            margin-left: 20px;
+        }
+
+        &-content {
+            &__title h3 {
+                color: $grey-90;
+                font-size: 1.25rem;
+                letter-spacing: 0;
+                line-height: 30px;
+                font-family: $font-open-sans;
+                font-weight: $font-medium;
+                margin-top: 16px;
+            }
+
+            &__description {
+                color: $grey-60;
+                font-family: $font-roboto;
+                font-size: 0.875rem;
+                letter-spacing: 0.15px;
+                line-height: 24px;
+            }
+        }
     }
-  }
-}
-
-@include device-is('desktop') {
-  .features {
-    &__title h2 {
-      padding: 80px 0 40px 0;
-    }
-
-    &__wrapper {
-      padding: 80px 0 84px;
-    }
-  }
-
-  .features-wrapper {
-    &__row {
-      flex-direction: row;
-      justify-content: center;
-      align-items: baseline;
-    }
-  }
-
-  .features-wrapper-row {
-    &__item {
-      display: block;
-      margin-right: 98px;
-      text-align: center;
-
-      img {
-        margin-right: 0;
-      }
-    }
-  }
-
-  .features-wrapper-row-item {
-
-    &__title h3 {
-      width: 200px;
-      font-size: 1.25rem;
-    }
-
-    &__description {
-      margin-top: 8px;
-      width: 200px;
-    }
-  }
+    
 }
 
 @include device-is('large-screen') {
-  .features {
-    &__title h2 {
-      padding: 100px 0 50px 0;
-    }
-    &__wrapper {
-      padding: 60px 0;
-    }
-  }
+    $column-width: 294px;
+    $column-gap: 74px;
 
-  .features-wrapper-row {
-    &__item {
-      margin-right: 76px;
-      text-align: center;
-    }
-  }
+    .features {
+        &__wrapper {
+            display: flex;
+            flex-direction: row;
+            gap: $column-gap;
+            flex-wrap: wrap;
+            justify-content: center;
+            align-items: stretch;
 
-  .features-wrapper-row-item {
-
-    &__title h3 {
-      width: 294px;
+            &-5-items {
+                /* Si 5 items */
+                /* Afficher 3 items sur une ligne puis 2 items sur une autre */
+                padding: 60px 0;
+                max-width: calc(3 * ($column-gap + $column-width));
+                margin: 0 auto;
+            }
+        }
     }
 
-    &__description {
-      width: 294px;
+    .features-wrapper {
+        &__item {
+            width: $column-width;
+            text-align: center;
+            display: block;
+        }
+
+        &-item__image {
+            height: 74px;
+            display: block;
+        }
+
+        &-item__content {
+            margin-left: 0;
+        }
     }
-  }
 }

--- a/assets/scss/components/slices/process.scss
+++ b/assets/scss/components/slices/process.scss
@@ -2,7 +2,6 @@
   &__title h2 {
     color: $grey-90;
     font-weight: $font-normal;
-    height: 49px;
     letter-spacing: 0.009rem;
     line-height: 49px;
     text-align: center;
@@ -15,217 +14,102 @@
     top: 8px;
     font-size: 1rem;
     font-weight: $font-light;
-    height: 49px;
     letter-spacing: 0.009rem;
     line-height: 49px;
     text-align: center;
   }
 
   &__wrapper {
-    padding: 48px 32px;
+    padding: 48px 10%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
   }
 }
 
 .process-wrapper {
-  &__row {
-    display: flex;
-    align-items: center;
-    flex-direction: column;
-    margin-bottom: 24px;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-}
-
-.process-wrapper-row {
-  &__item {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-bottom: 24px;
-    width: 293px;
-    padding: 24px;
-    box-shadow: 0 24px 32px 0 rgba($grey-200, 0.03),
-    0 8px 32px 0 rgba($grey-200, 0.06);
-    border-radius: 20px;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-
-    &::after {
-      height: 100%;
-    }
-
-    img {
-      height: 51px;
-      width: 51px;
-    }
-  }
-}
-
-.process-wrapper-row-item {
-
-  &__title h3 {
-    width: 175px;
-    color: $grey-45;
-    font-size: 1.25rem;
-    letter-spacing: 0;
-    line-height: 30px;
-    font-weight: $font-semi-bold;
-    margin: 0 8px 0 24px;
-  }
-
-  &__description {
-    width: 175px;
-    color: $grey-45;
-    font-size: 0.875rem;
-    letter-spacing: 0.009rem;
-    line-height: 22px;
-    margin-left: 24px;
-
-    p {
-      margin: 0;
-    }
-  }
-}
-
-@include device-is('tablet') {
-  .process-wrapper {
-    &__row {
-      flex-direction: row;
-      justify-content: center;
-      align-items: stretch;
-    }
-  }
-
-  .process {
-    &__title h2 {
-      margin-top: 60px;
-    }
-
-    &__subtitle h3 {
-      top: 0;
-      margin-bottom: 48px;
-    }
-
-    &__wrapper {
-      flex-direction: row;
-      padding: 80px 0;
-    }
-  }
-
-  .process-wrapper-row {
     &__item {
-      margin-bottom: 0;
-
-      div:first-of-type {
+        width: 293px;
+        padding: 24px;
+        box-shadow: 0 24px 32px 0 rgba($grey-200, 0.03),
+        0 8px 32px 0 rgba($grey-200, 0.06);
+        border-radius: 20px;
         display: flex;
-        flex-direction: column;
         align-items: center;
-      }
-
-      img {
         margin-bottom: 24px;
-      }
-    }
-  }
-
-  .process-wrapper-row-item {
-    &__title h3 {
-      margin-bottom: 8px;
-    }
-  }
-}
-
-@include device-is('desktop') {
-  .process {
-    &__title h2 {
-      margin-top: 60px;
     }
 
-    &__wrapper {
-      padding: 80px 0 84px;
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: space-around;
-    }
-  }
-
-  .process-wrapper-row {
-    &__item {
-      &:first-of-type {
-        margin-left: 56px;
-      }
-      padding: 32px 24px 56px 24px;
-      display: block;
-      margin-right: 56px;
-      margin-bottom: 0;
-      text-align: center;
-
-      img {
-        margin-right: 0;
-      }
-    }
-  }
-
-  .process-wrapper-row-item {
-
-    &__title h3 {
-      width: 245px;
-      font-size: 1.25rem;
-      margin-left: 0;
+    &-item {
+        &-content {
+            &__title h3 {
+                color: $grey-45;
+                font-size: 1.25rem;
+                letter-spacing: 0;
+                line-height: 30px;
+                font-weight: $font-semi-bold;
+              }
+            
+              &__description {
+                color: $grey-45;
+                font-size: 0.875rem;
+                letter-spacing: 0.009rem;
+                line-height: 22px;
+            
+                p {
+                  margin: 0;
+                }
+              }
+        }
     }
 
-    &__description {
-      margin-top: 8px;
-      width: 245px;
-      margin-left: 0;
+    &-item__image {
+        min-width: 51px;
+        height: 51px;
+        display: flex;
+        justify-content: center;
     }
-  }
+
+    &-item__content {
+        margin-left: 20px;
+
+        h3 {
+            margin-top: 0;
+        }
+    }
 }
 
 @include device-is('large-screen') {
-  .process {
-    &__wrapper {
-      padding: 80px 98px 60px 98px;
-      width: 100%;
-      display: flex;
-      align-items: stretch;
-      flex-wrap: wrap;
-      justify-content: space-around;
-      flex-direction: column;
+    .process {
+        &__wrapper {
+            display: flex;
+            flex-direction: row;
+            gap: 56px;
+            flex-wrap: wrap;
+            justify-content: center;
+            align-items: stretch;
+        }
     }
-  }
 
-  .process-wrapper-row {
-    &__item {
-      &:first-of-type {
-        margin-left: 0;
-      }
+    .process-wrapper {
+        &__item {
+            text-align: center;
+            display: block;
+            padding: 32px 24px 50px;
+            margin-bottom: 40px;
+        }
 
-      max-width: 293px;
-      padding: 32px 24px 50px 24px;
-      text-align: center;
+        &-item__image {
+            min-width: 100%;
+            height: 51px;
+            display: block;
+        }
 
-      &:last-of-type {
-        margin-right: 0;
-      }
+        &-item__content {
+            margin-left: 0;
+        }
 
-      img {
-        height: 51px;
-        width: 51px;
-      }
+        &-item-content__title h3 {
+            margin: 30px 0 8px 0;
+        }
     }
-  }
-
-  .process-wrapper-row-item {
-
-    &__description {
-      margin-top: 8px;
-      width: 245px;
-    }
-  }
 }

--- a/assets/scss/components/slices/statistics.scss
+++ b/assets/scss/components/slices/statistics.scss
@@ -1,31 +1,10 @@
 .statistics {
-  &__title h2 {
-    color: $grey-90;
-    font-weight: normal;
-    letter-spacing: 0.15px;
-    line-height: 40px;
-    text-align: center;
-    margin: 60px 0 64px 0;
-  }
-
-  &__subtitle h3 {
-    position: relative;
-    top: 24px;
-    font-size: 1rem;
-    font-weight: $font-light;
-    height: 49px;
-    letter-spacing: 0.009rem;
-    line-height: 49px;
-    text-align: center;
-  }
-
   &__wrapper {
     padding: 0 34px 61px 34px;
   }
 }
 
-.statistics-wrapper {
-  &__row {
+.statistics__wrapper {
     display: flex;
     flex-direction: column;
     margin-bottom: 24px;
@@ -33,10 +12,9 @@
     &:last-child {
       margin-bottom: 0;
     }
-  }
 }
 
-.statistics-wrapper-row {
+.statistics-wrapper {
   &__item {
     height: 196px;
     width: 100%;
@@ -56,7 +34,27 @@
   }
 }
 
-.statistics-wrapper-row-item {
+.statistics-wrapper-item-content {
+
+  &__title h2 {
+    color: $grey-90;
+    font-weight: normal;
+    letter-spacing: 0.15px;
+    line-height: 40px;
+    text-align: center;
+    margin: 60px 0 64px 0;
+  }
+
+  &__subtitle h3 {
+    position: relative;
+    top: 24px;
+    font-size: 1rem;
+    font-weight: $font-light;
+    height: 49px;
+    letter-spacing: 0.009rem;
+    line-height: 49px;
+    text-align: center;
+  }
 
   &__title h3 {
     width: 293px;
@@ -85,23 +83,19 @@
 }
 
 @include device-is('tablet') {
-  .statistics-wrapper {
-    &__row {
+  .statistics__wrapper {
       flex-direction: row;
-    }
   }
 }
 
 @include device-is('large-screen') {
-  .statistics {
-    &__wrapper {
+  .statistics__wrapper {
       padding: 0 98px;
       max-width: 1920px;
       margin: 0 auto 24px;
-    }
   }
 
-  .statistics-wrapper-row {
+  .statistics-wrapper {
     &__item {
       margin-bottom: 61px;
     }

--- a/components/FooterSliceZone.vue
+++ b/components/FooterSliceZone.vue
@@ -30,8 +30,8 @@
             >
               <pix-image
                 :field="socialMedia.socialmedia_image"
-                width="30"
-                height="30"
+                :has-fixed-dimensions="true"
+                :max-height="30"
               />
             </pix-link>
           </li>

--- a/components/FooterSliceZone.vue
+++ b/components/FooterSliceZone.vue
@@ -6,7 +6,11 @@
         :key="`footer-slice-left-${index}`"
       >
         <template v-if="slice.slice_type === 'logos_zone'">
-          <slices-logos-zone :slice="slice" class="footer-left__logos" />
+          <slices-logos-zone
+            :slice="slice"
+            class="footer-left__logos"
+            :max-height="96"
+          />
         </template>
         <prismic-rich-text
           v-if="slice.slice_type === 'text'"

--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -11,7 +11,7 @@
           v-for="(slice, index) in logos"
           :key="`navigation-slice-left-${index}`"
         >
-          <slices-logos-zone :slice="slice" />
+          <slices-logos-zone :slice="slice" :max-height="50" />
         </section>
       </div>
       <section

--- a/components/PixImage.vue
+++ b/components/PixImage.vue
@@ -18,6 +18,10 @@ export default {
       type: Object,
       default: null,
     },
+    hasFixedDimensions: {
+      type: Boolean,
+      default: false,
+    },
     maxHeight: {
       type: Number,
       default: undefined,
@@ -35,6 +39,9 @@ export default {
   },
   methods: {
     computeHeight(image) {
+      if (!this.hasFixedDimensions) {
+        return
+      }
       const imageHeight = image.dimensions.height
 
       return this.isImageHeightTooBig(imageHeight)
@@ -42,6 +49,9 @@ export default {
         : imageHeight
     },
     computeWidth(image) {
+      if (!this.hasFixedDimensions) {
+        return
+      }
       const imageWidth = image.dimensions.width
       const imageHeight = image.dimensions.height
       const imageWidthIfHeightTooBig =

--- a/components/PixImage.vue
+++ b/components/PixImage.vue
@@ -4,8 +4,8 @@
     :src="image.url"
     :alt="image.alt"
     :role="image.role"
-    :width="image.width"
-    :height="image.height"
+    :width="computeWidth(image)"
+    :height="computeHeight(image)"
   />
 </template>
 
@@ -18,6 +18,10 @@ export default {
       type: Object,
       default: null,
     },
+    maxHeight: {
+      type: Number,
+      default: undefined,
+    },
   },
   computed: {
     image() {
@@ -27,6 +31,28 @@ export default {
         image.role = 'presentation'
       }
       return image
+    },
+  },
+  methods: {
+    computeHeight(image) {
+      const imageHeight = image.dimensions.height
+
+      return this.isImageHeightTooBig(imageHeight)
+        ? this.maxHeight
+        : imageHeight
+    },
+    computeWidth(image) {
+      const imageWidth = image.dimensions.width
+      const imageHeight = image.dimensions.height
+      const imageWidthIfHeightTooBig =
+        imageWidth * (this.maxHeight / imageHeight)
+
+      return this.isImageHeightTooBig(imageHeight)
+        ? Math.round(imageWidthIfHeightTooBig)
+        : imageWidth
+    },
+    isImageHeightTooBig(imageHeight) {
+      return this.maxHeight && imageHeight > this.maxHeight
     },
   },
 }

--- a/components/PixImage.vue
+++ b/components/PixImage.vue
@@ -1,5 +1,12 @@
 <template>
-  <prismic-image :field="image" :role="image.role" />
+  <nuxt-img
+    v-if="image.url"
+    :src="image.url"
+    :alt="image.alt"
+    :role="image.role"
+    :width="image.width"
+    :height="image.height"
+  />
 </template>
 
 <script>

--- a/components/slices/Article.vue
+++ b/components/slices/Article.vue
@@ -166,7 +166,6 @@ export default {
   &__secondary-content {
     grid-area: b;
     align-self: center;
-    max-height: 80%;
   }
 
   &--reverse {

--- a/components/slices/LogosZone.vue
+++ b/components/slices/LogosZone.vue
@@ -6,9 +6,18 @@
       class="logos-zone__content"
     >
       <pix-link v-if="hasLink(logo)" :field="logo.url">
-        <pix-image :field="logo.image" :max-height="maxHeight" />
+        <pix-image
+          :field="logo.image"
+          :has-fixed-dimensions="true"
+          :max-height="maxHeight"
+        />
       </pix-link>
-      <pix-image v-else :field="logo.image" :max-height="maxHeight" />
+      <pix-image
+        v-else
+        :field="logo.image"
+        :has-fixed-dimensions="true"
+        :max-height="maxHeight"
+      />
     </div>
   </div>
 </template>

--- a/components/slices/LogosZone.vue
+++ b/components/slices/LogosZone.vue
@@ -6,9 +6,9 @@
       class="logos-zone__content"
     >
       <pix-link v-if="hasLink(logo)" :field="logo.url">
-        <pix-image :field="logo.image" />
+        <pix-image :field="logo.image" :max-height="maxHeight" />
       </pix-link>
-      <pix-image v-else :field="logo.image" />
+      <pix-image v-else :field="logo.image" :max-height="maxHeight" />
     </div>
   </div>
 </template>
@@ -20,6 +20,10 @@ export default {
     slice: {
       type: Object,
       default: null,
+    },
+    maxHeight: {
+      type: Number,
+      default: undefined,
     },
   },
   methods: {
@@ -43,7 +47,6 @@ export default {
     }
 
     img {
-      height: 50px;
       margin: 15px 0 15px 0;
     }
 

--- a/components/slices/MultipleBlock.vue
+++ b/components/slices/MultipleBlock.vue
@@ -29,6 +29,7 @@
           <pix-image
             v-if="hasImage(item)"
             :field="item.item_image"
+            :has-fixed-dimensions="true"
             :max-height="74"
           />
           <div>

--- a/components/slices/MultipleBlock.vue
+++ b/components/slices/MultipleBlock.vue
@@ -15,33 +15,31 @@
       :class="`${blockClass}__subtitle`"
       :field="subtitle"
     />
-    <div :class="`${blockClass}__wrapper`">
+    <div
+      :class="`${blockClass}__wrapper ${blockClass}__wrapper-${items.length}-items`"
+    >
       <div
-        v-for="(itemsByRow, rowIndex) in rows"
-        :key="`row-${rowIndex}`"
-        :class="`${blockClass}-wrapper__row`"
+        v-for="(item, itemIndex) in items"
+        :key="`item-${itemIndex}`"
+        :class="`${blockClass}-wrapper__item`"
       >
-        <div
-          v-for="(item, itemIndex) in itemsByRow"
-          :key="`item-${itemIndex}`"
-          :class="`${blockClass}-wrapper-row__item`"
-        >
+        <div :class="`${blockClass}-wrapper-item__image`">
           <pix-image
             v-if="hasImage(item)"
             :field="item.item_image"
             :has-fixed-dimensions="true"
-            :max-height="74"
+            :max-height="imageMaxHeight"
           />
-          <div>
-            <prismic-rich-text
-              :class="`${blockClass}-wrapper-row-item__title`"
-              :field="item.item_title"
-            />
-            <prismic-rich-text
-              :class="`${blockClass}-wrapper-row-item__description`"
-              :field="item.item_description"
-            />
-          </div>
+        </div>
+        <div :class="`${blockClass}-wrapper-item__content`">
+          <prismic-rich-text
+            :class="`${blockClass}-wrapper-item-content__title`"
+            :field="item.item_title"
+          />
+          <prismic-rich-text
+            :class="`${blockClass}-wrapper-item-content__description`"
+            :field="item.item_description"
+          />
         </div>
       </div>
     </div>
@@ -49,11 +47,6 @@
 </template>
 
 <script>
-import {
-  EXTRA_LARGE_SCREEN_MIN_WIDTH,
-  DESKTOP_MIN_WIDTH,
-} from '~/config/breakpoints'
-
 export default {
   name: 'MultipleBlock',
   props: {
@@ -111,48 +104,22 @@ export default {
     subtitle() {
       return this.slice.primary.block_subtitle
     },
-  },
-  mounted() {
-    this.rows = this.splitItemsIntoRows()
+    imageMaxHeight() {
+      switch (this.blockClass) {
+        case 'process':
+          return 51
+        case 'statistics':
+          return 64
+        case 'features':
+          return 74
+      }
+      return 100
+    },
   },
   methods: {
     hasImage(item) {
-      const isLengthDifferentThanZero = Object.keys(item.item_image).length
-      const isObjectConstructor = item.item_image.constructor === Object
-      return isLengthDifferentThanZero && isObjectConstructor
-    },
-    numberItemsPerRowForScreenWidth() {
-      if (process.client) {
-        const isLargeScreen = document.body.clientWidth >= DESKTOP_MIN_WIDTH
-        const isExtraLargeScreen =
-          document.body.clientWidth >= EXTRA_LARGE_SCREEN_MIN_WIDTH
-
-        if (this.items.length === 4 && isExtraLargeScreen) {
-          return 4
-        }
-
-        if (isLargeScreen) {
-          return 3
-        }
-
-        return 2
-      }
-    },
-    splitItemsIntoRows() {
-      const rows = []
-      const numberOfItemsPerRow = this.numberItemsPerRowForScreenWidth()
-      for (
-        let item = 0;
-        item < this.items.length;
-        item += numberOfItemsPerRow
-      ) {
-        const screenSizedItems = this.items.slice(
-          item,
-          item + numberOfItemsPerRow
-        )
-        rows.push(screenSizedItems)
-      }
-      return rows
+      const image = item.item_image
+      return image?.url !== undefined && image?.url !== null
     },
   },
 }

--- a/components/slices/MultipleBlock.vue
+++ b/components/slices/MultipleBlock.vue
@@ -26,7 +26,11 @@
           :key="`item-${itemIndex}`"
           :class="`${blockClass}-wrapper-row__item`"
         >
-          <pix-image v-if="hasImage(item)" :field="item.item_image" />
+          <pix-image
+            v-if="hasImage(item)"
+            :field="item.item_image"
+            :max-height="74"
+          />
           <div>
             <prismic-rich-text
               :class="`${blockClass}-wrapper-row-item__title`"

--- a/components/slices/PageBanner.vue
+++ b/components/slices/PageBanner.vue
@@ -66,7 +66,10 @@ export default {
       let style = {}
       if (this.hasBackgroundImage) {
         style = {
-          background: `no-repeat url(${this.slice.primary.banner_background.url})`,
+          // Use @nuxt/image to download image during static build
+          background: `no-repeat url(${this.$img(
+            this.slice.primary.banner_background.url
+          )})`,
           backgroundSize: 'cover',
           backgroundPosition: 'bottom',
         }

--- a/components/slices/PartnersLogos.vue
+++ b/components/slices/PartnersLogos.vue
@@ -12,7 +12,11 @@
         :key="`item-${itemIndex}`"
         class="partners-logos-wrapper__item"
       >
-        <pix-image :field="item.logos_image" />
+        <pix-image
+          :field="item.logos_image"
+          :has-fixed-dimensions="true"
+          :max-height="112"
+        />
       </div>
     </div>
   </section>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -78,18 +78,6 @@ const config = {
   buildModules: [
     // Doc: https://github.com/nuxt-community/eslint-module
     ['@nuxtjs/eslint-module', { fix: true }],
-    [
-      'assets-extractor-module',
-      {
-        hostnames: [
-          'images.prismic.io',
-          'prismic-io.s3.amazonaws.com',
-          'storage.gra.cloud.ovh.net',
-          'pix-site.cdn.prismic.io',
-        ],
-        extensions: ['jpg', 'jpeg', 'gif', 'png', 'webp', 'svg', 'mp4', 'pdf'],
-      },
-    ],
     '~/modules/propagate-fetch-error-during-generation',
     '@nuxtjs/prismic',
     '@nuxt/image',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -96,8 +96,13 @@ const config = {
   ],
 
   image: {
-    provider: 'prismic',
-    prismic: {},
+    provider: 'static',
+    domains: [
+      'images.prismic.io',
+      'pix-site.cdn.prismic.io',
+      'storage.gra.cloud.ovh.net',
+      'prismic-io.s3.amazonaws.com',
+    ],
   },
 
   /*

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -92,7 +92,14 @@ const config = {
     ],
     '~/modules/propagate-fetch-error-during-generation',
     '@nuxtjs/prismic',
+    '@nuxt/image',
   ],
+
+  image: {
+    provider: 'prismic',
+    prismic: {},
+  },
+
   /*
    ** Nuxt.js modules
    */

--- a/package-lock.json
+++ b/package-lock.json
@@ -2890,11 +2890,6 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-2.0.6.tgz",
       "integrity": "sha512-V3vT3flY15AKbUS31aZOP12awQI3aAzkr2B1KnqcHLmwrmy51DW3pwyBczKdypV8QxBZ8U68Hl2XxK2nudTxpg=="
     },
-    "@gar/promisify": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
-      "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw=="
-    },
     "@humanwhocodes/config-array": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
@@ -3549,25 +3544,6 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
-      }
-    },
-    "@npmcli/fs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.0.0.tgz",
-      "integrity": "sha512-8ltnOpRR/oJbOp8vaGUnipOi3bqkcW+sLHFlyXIr08OGHmVJLB1Hn7QtGXbYcpVtH1gAYZTlmDXtE4YV0+AMMQ==",
-      "requires": {
-        "@gar/promisify": "^1.0.1",
-        "semver": "^7.3.5"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@npmcli/move-file": {
@@ -5268,38 +5244,6 @@
       "resolved": "https://registry.npmjs.org/@prismicio/vue/-/vue-2.0.11.tgz",
       "integrity": "sha512-GVphn9svLs2Lu+FR9XACGPPxXOS3lNoOH15xOMJnKB9Yfj6BiMpzWNwsNUqB1EFOYw8kjqUSNfHqhMvloJW6oQ=="
     },
-    "@sindresorhus/slugify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-2.1.0.tgz",
-      "integrity": "sha512-gU3Gdm/V167BmUwIn8APHZ3SeeRVRUSOdXxnt7Q/JkUHLXaaTA/prYmoRumwsSitJZWUDYMzDWdWgrOdvE8IRQ==",
-      "requires": {
-        "@sindresorhus/transliterate": "^1.0.0",
-        "escape-string-regexp": "^5.0.0"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
-        }
-      }
-    },
-    "@sindresorhus/transliterate": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-1.5.0.tgz",
-      "integrity": "sha512-/sfSkoNelLq5riqNRp5uBjHIKBi1MWZk9ubRT1WiBQuTfmDf7BeQkph2DJzRB83QagMPHk2VDjuvpy0VuwyzdA==",
-      "requires": {
-        "escape-string-regexp": "^5.0.0",
-        "lodash.deburr": "^4.1.0"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
-        }
-      }
-    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -5321,7 +5265,8 @@
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
     },
     "@types/anymatch": {
       "version": "1.3.1",
@@ -6015,7 +5960,8 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
     },
     "accepts": {
       "version": "1.3.7",
@@ -6065,18 +6011,9 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
       "requires": {
         "debug": "4"
-      }
-    },
-    "agentkeepalive": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.4.tgz",
-      "integrity": "sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==",
-      "requires": {
-        "debug": "^4.1.0",
-        "depd": "^1.1.2",
-        "humanize-ms": "^1.2.1"
       }
     },
     "aggregate-error": {
@@ -6209,6 +6146,8 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -6218,6 +6157,8 @@
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -6231,12 +6172,16 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true,
+          "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -6565,16 +6510,6 @@
             "inherits": "2.0.1"
           }
         }
-      }
-    },
-    "assets-extractor-module": {
-      "version": "github:1024pix/assets-extractor-module#11e6147520853b59c491d57c1d9ee45c0b6a6a81",
-      "from": "github:1024pix/assets-extractor-module#11e6147520853b59c491d57c1d9ee45c0b6a6a81",
-      "requires": {
-        "@sindresorhus/slugify": "^2.1.0",
-        "fs-extra": "^10.0.0",
-        "get-urls": "^10.0.0",
-        "node-fetch": "^2.6.1"
       }
     },
     "assign-symbols": {
@@ -7863,7 +7798,9 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true,
+      "optional": true
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -8139,7 +8076,9 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true,
+      "optional": true
     },
     "consolidate": {
       "version": "0.15.1",
@@ -8807,7 +8746,9 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true,
+      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -9147,26 +9088,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "optional": true,
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "optional": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
-    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -9198,16 +9119,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
-    },
-    "env-paths": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
-    },
-    "err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
     },
     "errno": {
       "version": "0.1.8",
@@ -11311,6 +11222,8 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -11325,12 +11238,16 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true,
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11339,6 +11256,8 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11349,6 +11268,8 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11434,22 +11355,6 @@
             "has": "^1.0.3",
             "has-symbols": "^1.0.1"
           }
-        }
-      }
-    },
-    "get-urls": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/get-urls/-/get-urls-10.0.1.tgz",
-      "integrity": "sha512-5usUMF4FE0cTS7yUuRvBsB4tSs5u8KFn7v01+IDGL/18tuoADu5ehthqw+y2EHnJsWhsp1443K5P+C/XWZQ04g==",
-      "requires": {
-        "normalize-url": "^5.1.0",
-        "url-regex-safe": "^2.0.2"
-      },
-      "dependencies": {
-        "normalize-url": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.3.1.tgz",
-          "integrity": "sha512-K1c7+vaAP+Yh5bOGmA10PGPpp+6h7WZrl7GwqKhUflBc9flU9pzG27DDeB9+iuhZkE3BJZOcgN1P/2sS5pqrWw=="
         }
       }
     },
@@ -11826,7 +11731,9 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true,
+      "optional": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -12095,11 +12002,6 @@
         }
       }
     },
-    "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
-    },
     "http-errors": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
@@ -12116,6 +12018,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
       "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
       "requires": {
         "@tootallnate/once": "1",
         "agent-base": "6",
@@ -12138,17 +12041,10 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
-      }
-    },
-    "humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
-      "requires": {
-        "ms": "^2.0.0"
       }
     },
     "iconv-lite": {
@@ -12356,11 +12252,6 @@
       "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==",
       "dev": true
     },
-    "install-artifact-from-github": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/install-artifact-from-github/-/install-artifact-from-github-1.2.0.tgz",
-      "integrity": "sha512-3OxCPcY55XlVM3kkfIpeCgmoSKnMsz2A3Dbhsq0RXpIknKQmrX1YiznCeW9cD2ItFmDxziA3w6Eg8d80AoL3oA=="
-    },
     "internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -12398,11 +12289,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-    },
-    "ip-regex": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
     },
     "ipx": {
       "version": "0.8.0",
@@ -12678,11 +12564,6 @@
           }
         }
       }
-    },
-    "is-lambda": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU="
     },
     "is-negative-zero": {
       "version": "2.0.0",
@@ -14569,11 +14450,6 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
-    "lodash.deburr": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
-      "integrity": "sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s="
-    },
     "lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
@@ -14692,69 +14568,6 @@
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
-      }
-    },
-    "make-fetch-happen": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
-      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
-      "requires": {
-        "agentkeepalive": "^4.1.3",
-        "cacache": "^15.2.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.3",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^1.3.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.2",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^6.0.0",
-        "ssri": "^8.0.0"
-      },
-      "dependencies": {
-        "cacache": {
-          "version": "15.3.0",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
-          "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
-          "requires": {
-            "@npmcli/fs": "^1.0.0",
-            "@npmcli/move-file": "^1.0.1",
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "glob": "^7.1.4",
-            "infer-owner": "^1.0.4",
-            "lru-cache": "^6.0.0",
-            "minipass": "^3.1.1",
-            "minipass-collect": "^1.0.2",
-            "minipass-flush": "^1.0.5",
-            "minipass-pipeline": "^1.2.2",
-            "mkdirp": "^1.0.3",
-            "p-map": "^4.0.0",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^3.0.2",
-            "ssri": "^8.0.1",
-            "tar": "^6.0.2",
-            "unique-filename": "^1.1.1"
-          }
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
         }
       }
     },
@@ -14983,17 +14796,6 @@
         "minipass": "^3.0.0"
       }
     },
-    "minipass-fetch": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
-      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
-      "requires": {
-        "encoding": "^0.1.12",
-        "minipass": "^3.1.0",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.0.0"
-      }
-    },
     "minipass-flush": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
@@ -15006,14 +14808,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
       "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "requires": {
-        "minipass": "^3.0.0"
-      }
-    },
-    "minipass-sized": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
       "requires": {
         "minipass": "^3.0.0"
       }
@@ -15219,7 +15013,8 @@
     "nan": {
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
     },
     "nanocolors": {
       "version": "0.2.13",
@@ -15457,6 +15252,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dev": true,
       "requires": {
         "abbrev": "1"
       }
@@ -15508,6 +15304,8 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -15531,7 +15329,9 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true,
+      "optional": true
     },
     "nuxt": {
       "version": "2.15.1",
@@ -17416,15 +17216,6 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
     },
-    "promise-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "requires": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      }
-    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -17614,74 +17405,6 @@
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/defu/-/defu-2.0.4.tgz",
           "integrity": "sha512-G9pEH1UUMxShy6syWk01VQSRVs3CDWtlxtZu7A+NyqjxaCA4gSlWAKDBx6QiUEKezqS8+DUlXLI14Fp05Hmpwg=="
-        }
-      }
-    },
-    "re2": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/re2/-/re2-1.16.0.tgz",
-      "integrity": "sha512-eizTZL2ZO0ZseLqfD4t3Qd0M3b3Nr0MBWpX81EbPMIud/1d/CSfUIx2GQK8fWiAeHoSekO5EOeFib2udTZLwYw==",
-      "requires": {
-        "install-artifact-from-github": "^1.2.0",
-        "nan": "^2.14.2",
-        "node-gyp": "^8.0.0"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-          "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-        },
-        "node-gyp": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.3.0.tgz",
-          "integrity": "sha512-e+vmKyTiybKgrmvs4M2REFKCnOd+NcrAAnn99Yko6NQA+zZdMlRvbIUHojfsHrSQ1CddLgZnHicnEVgDHziJzA==",
-          "requires": {
-            "env-paths": "^2.2.0",
-            "glob": "^7.1.4",
-            "graceful-fs": "^4.2.6",
-            "make-fetch-happen": "^9.1.0",
-            "nopt": "^5.0.0",
-            "npmlog": "^4.1.2",
-            "rimraf": "^3.0.2",
-            "semver": "^7.3.5",
-            "tar": "^6.1.2",
-            "which": "^2.0.2"
-          }
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "tar": {
-          "version": "6.1.11",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-          "requires": {
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "minipass": "^3.0.0",
-            "minizlib": "^2.1.1",
-            "mkdirp": "^1.0.3",
-            "yallist": "^4.0.0"
-          }
         }
       }
     },
@@ -18331,7 +18054,8 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.1",
@@ -18555,11 +18279,6 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
-    "smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
-    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -18666,35 +18385,6 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
-    "socks": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
-      "requires": {
-        "ip": "^1.1.5",
-        "smart-buffer": "^4.1.0"
-      }
-    },
-    "socks-proxy-agent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.0.tgz",
-      "integrity": "sha512-57e7lwCN4Tzt3mXz25VxOErJKXlPfXmkMLnk310v/jwW20jWRVcgsOit+xNkN3eIEdB47GwnfAEBLacZ/wVIKg==",
-      "requires": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.1",
-        "socks": "^2.6.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "requires": {
-            "ms": "2.1.2"
           }
         }
       }
@@ -19506,11 +19196,6 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
-    "tlds": {
-      "version": "1.225.0",
-      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.225.0.tgz",
-      "integrity": "sha512-W6lNjs+IT3rjXumIJJindITMnv4R17mNBRsMkp6Kr0bF8vQcGW2Y//2VvMqegGmBnizBZFryv1thcPcpJQ3+CA=="
-    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -19947,16 +19632,6 @@
             "ajv-keywords": "^3.5.2"
           }
         }
-      }
-    },
-    "url-regex-safe": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/url-regex-safe/-/url-regex-safe-2.0.2.tgz",
-      "integrity": "sha512-n5qtPAWvMLTmgYMCX1195CKV9oJE6SkSa5bVsMrHSFA/hnqila9J1KVf6gF2M66lCWwPDhJyQlX1tEXqtzBOPQ==",
-      "requires": {
-        "ip-regex": "^4.3.0",
-        "re2": "^1.15.9",
-        "tlds": "^1.217.0"
       }
     },
     "use": {
@@ -21165,6 +20840,8 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4302,6 +4302,67 @@
         }
       }
     },
+    "@nuxt/image": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/image/-/image-0.6.0.tgz",
+      "integrity": "sha512-3oWeVaMMnZ7E8bJ/ZGfAXp6CL0HSsdlNHQgZfCk0pboTxIxNrdfAhpsMfX+VJ2FDwMftr2PzQ3X+/2TetEfHUA==",
+      "dev": true,
+      "requires": {
+        "consola": "^2.15.3",
+        "defu": "^5.0.0",
+        "fs-extra": "^10.0.0",
+        "hasha": "^5.2.2",
+        "image-meta": "^0.0.1",
+        "ipx": "^0.8.0",
+        "is-https": "^4.0.0",
+        "lru-cache": "^6.0.0",
+        "node-fetch": "^2.6.1",
+        "p-limit": "^3.1.0",
+        "rc9": "^1.2.0",
+        "requrl": "^3.0.2",
+        "semver": "^7.3.5",
+        "ufo": "^0.7.9",
+        "upath": "^2.0.1"
+      },
+      "dependencies": {
+        "consola": {
+          "version": "2.15.3",
+          "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
+          "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
+          "dev": true
+        },
+        "defu": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/defu/-/defu-5.0.0.tgz",
+          "integrity": "sha512-VHg73EDeRXlu7oYWRmmrNp/nl7QkdXUxkQQKig0Zk8daNmm84AbGoC8Be6/VVLJEKxn12hR0UBmz8O+xQiAPKQ==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "ufo": {
+          "version": "0.7.9",
+          "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.7.9.tgz",
+          "integrity": "sha512-6t9LrLk3FhqTS+GW3IqlITtfRB5JAVr5MMNjpBECfK827W+Vh5Ilw/LhTcHWrt6b3hkeBvcbjx4Ti7QVFzmcww==",
+          "dev": true
+        }
+      }
+    },
     "@nuxt/loading-screen": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@nuxt/loading-screen/-/loading-screen-2.0.3.tgz",
@@ -6137,6 +6198,13 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
+    "arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "dev": true,
+      "optional": true
+    },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
@@ -6994,6 +7062,31 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -7566,6 +7659,118 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
+    },
+    "clipboardy": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-2.3.0.tgz",
+      "integrity": "sha512-mKhiIL2DrQIsuXMgBgnfEHOZOryC7kY7YO//TN6c63wlEm3NG5tz+YgY5rVi29KCmq/QQjKYvM7a19+MDOTHOQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "arch": "^2.1.1",
+        "execa": "^1.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "dev": true,
+          "optional": true
+        },
+        "is-wsl": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+          "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-docker": "^2.0.0"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true,
+          "optional": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "dev": true,
+          "optional": true
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
     },
     "cliui": {
       "version": "7.0.4",
@@ -8311,6 +8516,13 @@
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
+    "cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=",
+      "dev": true,
+      "optional": true
+    },
     "cssnano": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.10.tgz",
@@ -8495,11 +8707,28 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "mimic-response": "^3.1.0"
+      }
+    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "optional": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -8511,6 +8740,13 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "optional": true
     },
     "define-properties": {
       "version": "1.1.3",
@@ -10444,6 +10680,13 @@
         }
       }
     },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "optional": true
+    },
     "expect": {
       "version": "27.3.1",
       "resolved": "https://registry.npmjs.org/expect/-/expect-27.3.1.tgz",
@@ -10967,6 +11210,13 @@
         }
       }
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "optional": true
+    },
     "fs-extra": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
@@ -11144,6 +11394,16 @@
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
       "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA=="
     },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
     "get-symbol-description": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -11219,6 +11479,13 @@
       "requires": {
         "git-up": "^4.0.0"
       }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+      "dev": true,
+      "optional": true
     },
     "glob": {
       "version": "7.1.6",
@@ -11632,6 +11899,24 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "hasha": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+      "dev": true,
+      "requires": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -11837,6 +12122,13 @@
         "debug": "4"
       }
     },
+    "http-shutdown": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/http-shutdown/-/http-shutdown-1.2.2.tgz",
+      "integrity": "sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==",
+      "dev": true,
+      "optional": true
+    },
     "https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
@@ -11889,6 +12181,12 @@
       "version": "5.1.8",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+    },
+    "image-meta": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/image-meta/-/image-meta-0.0.1.tgz",
+      "integrity": "sha512-FhTB6WW/zfswIFQwjItrisL/Pt/aKbMCAkVdDtdfsaWwo6QwhpM7XMdwtDw8qs5y2IZsHcQ7TPG/JznJYVphSg==",
+      "dev": true
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -12106,6 +12404,50 @@
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
       "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
     },
+    "ipx": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/ipx/-/ipx-0.8.0.tgz",
+      "integrity": "sha512-6jW8SIJgw98wE82G4TYQ/snCNh5+MortHyNfX89zmTIQBOnq5MeaKoo+UNEU7wPpD2SgLjJJIZ6oPRqovYiKmw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "consola": "^2.15.3",
+        "defu": "^5.0.0",
+        "destr": "^1.1.0",
+        "etag": "^1.8.1",
+        "fs-extra": "^10.0.0",
+        "image-meta": "^0.0.1",
+        "is-valid-path": "^0.1.1",
+        "listhen": "^0.2.4",
+        "node-fetch": "^2.6.1",
+        "sharp": "^0.29.0",
+        "ufo": "^0.7.9",
+        "xss": "^1.0.9"
+      },
+      "dependencies": {
+        "consola": {
+          "version": "2.15.3",
+          "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
+          "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
+          "dev": true,
+          "optional": true
+        },
+        "defu": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/defu/-/defu-5.0.0.tgz",
+          "integrity": "sha512-VHg73EDeRXlu7oYWRmmrNp/nl7QkdXUxkQQKig0Zk8daNmm84AbGoC8Be6/VVLJEKxn12hR0UBmz8O+xQiAPKQ==",
+          "dev": true,
+          "optional": true
+        },
+        "ufo": {
+          "version": "0.7.9",
+          "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.7.9.tgz",
+          "integrity": "sha512-6t9LrLk3FhqTS+GW3IqlITtfRB5JAVr5MMNjpBECfK827W+Vh5Ilw/LhTcHWrt6b3hkeBvcbjx4Ti7QVFzmcww==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "is-absolute-url": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
@@ -12308,6 +12650,35 @@
       "resolved": "https://registry.npmjs.org/is-https/-/is-https-4.0.0.tgz",
       "integrity": "sha512-FeMLiqf8E5g6SdiVJsPcNZX8k4h2fBs1wp5Bb6uaNxn58ufK1axBqQZdmAQsqh0t9BuwFObybrdVJh6MKyPlyg=="
     },
+    "is-invalid-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
+      "integrity": "sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true,
+          "optional": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
+    },
     "is-lambda": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
@@ -12418,6 +12789,16 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
+    },
+    "is-valid-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
+      "integrity": "sha1-EQ+f90w39mPh7HkV60UfLbk6yd8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "is-invalid-path": "^0.1.0"
+      }
     },
     "is-weakref": {
       "version": "1.0.1",
@@ -14102,6 +14483,48 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
+    "listhen": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/listhen/-/listhen-0.2.5.tgz",
+      "integrity": "sha512-7stTOFjeQHVkDqpPl0AtGdzXNu1XN5sE2Pi4mudeZ597c100OKvUpmPuv3MKemDScIWqmIbeUOeP3PBo0w49XQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "clipboardy": "^2.3.0",
+        "colorette": "^1.2.2",
+        "defu": "^5.0.0",
+        "get-port-please": "^2.1.0",
+        "http-shutdown": "^1.2.2",
+        "open": "^8.0.5",
+        "selfsigned": "^1.10.8"
+      },
+      "dependencies": {
+        "colorette": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+          "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+          "dev": true,
+          "optional": true
+        },
+        "defu": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/defu/-/defu-5.0.0.tgz",
+          "integrity": "sha512-VHg73EDeRXlu7oYWRmmrNp/nl7QkdXUxkQQKig0Zk8daNmm84AbGoC8Be6/VVLJEKxn12hR0UBmz8O+xQiAPKQ==",
+          "dev": true,
+          "optional": true
+        },
+        "get-port-please": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-2.2.0.tgz",
+          "integrity": "sha512-1c7Np/cpA7XCB6IrPAdaBaJjlGHTqg4P82h/ZqyBL6dCdwRzZBOFGZO7FL2KaZ2uNvD6v8QilA7LZwMpmIggDQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs-memo": "^1.2.0"
+          }
+        }
+      }
+    },
     "loader-runner": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -14508,6 +14931,13 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
       "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="
     },
+    "mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "optional": true
+    },
     "min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -14640,6 +15070,13 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "optional": true
     },
     "moment": {
       "version": "2.29.1",
@@ -14812,6 +15249,13 @@
         "to-regex": "^3.0.1"
       }
     },
+    "napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+      "dev": true,
+      "optional": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -14828,6 +15272,13 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true,
+      "optional": true
+    },
     "no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -14841,6 +15292,28 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
           "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        }
+      }
+    },
+    "node-abi": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.5.0.tgz",
+      "integrity": "sha512-LtHvNIBgOy5mO8mPEUtkCW/YCRWYEKshIvqhe1GHHyXEHEB5mgICyYnAcl4qan3uFeRROErKGzatFHPf6kDxWw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -14864,6 +15337,13 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "node-forge": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "dev": true,
+      "optional": true
     },
     "node-html-parser": {
       "version": "2.2.0",
@@ -15316,6 +15796,30 @@
         }
       }
     },
+    "open": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+          "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-docker": "^2.0.0"
+          }
+        }
+      }
+    },
     "opener": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
@@ -15358,6 +15862,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true,
+      "optional": true
     },
     "p-limit": {
       "version": "2.3.0",
@@ -16754,6 +17265,28 @@
         "uniq": "^1.0.1"
       }
     },
+    "prebuild-install": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.0.tgz",
+      "integrity": "sha512-IvSenf33K7JcgddNz2D5w521EgO+4aMMjFt73Uk9FRzQ7P+QZPKrp7qPsDydsSwjGt3T5xRNnM1bj1zMTD5fTA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "npmlog": "^4.0.1",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -17044,6 +17577,28 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "rc9": {
       "version": "1.2.0",
@@ -17393,6 +17948,12 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "requrl": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/requrl/-/requrl-3.0.2.tgz",
+      "integrity": "sha512-f3gjR6d8MhOpn46PP+DSJywbmxi95fxQm3coXBFwognjFLla9X6tr8BdNyaIKNOEkaRbRcm0/zYAqN19N1oyhg==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
@@ -17673,6 +18234,16 @@
       "resolved": "https://registry.npmjs.org/scule/-/scule-0.1.1.tgz",
       "integrity": "sha512-1j2RlmUNADEprCkzDaeo8w2tdum/mvQWAKdRaS2raud7IOnPaDbLSFKhcY5xXPbAFYWk4ZQ0BUnfmg0ZUcI+Pg=="
     },
+    "selfsigned": {
+      "version": "1.10.11",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.11.tgz",
+      "integrity": "sha512-aVmbPOfViZqOZPgRBT0+3u4yZFHpmnIghLMlAcb5/xhp5ZtB/RVnKhz5vl2M32CLXAqR4kha9zfhNg0Lf/sxKA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "node-forge": "^0.10.0"
+      }
+    },
     "semver": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -17802,6 +18373,74 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "sharp": {
+      "version": "0.29.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.29.3.tgz",
+      "integrity": "sha512-fKWUuOw77E4nhpyzCCJR1ayrttHoFHBT2U/kR/qEMRhvPEcluG4BKj324+SCO1e84+knXHwhJ1HHJGnUt4ElGA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "color": "^4.0.1",
+        "detect-libc": "^1.0.3",
+        "node-addon-api": "^4.2.0",
+        "prebuild-install": "^7.0.0",
+        "semver": "^7.3.5",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.1.1",
+        "tunnel-agent": "^0.6.0"
+      },
+      "dependencies": {
+        "color": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/color/-/color-4.0.1.tgz",
+          "integrity": "sha512-rpZjOKN5O7naJxkH2Rx1sZzzBgaiWECc6BYXjeCE6kF0kcASJYbUq02u7JqIHwCb/j3NhV+QhRL2683aICeGZA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1",
+            "color-string": "^1.6.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-string": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
+          "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "^1.0.0",
+            "simple-swizzle": "^0.2.2"
+          }
+        },
+        "node-addon-api": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.2.0.tgz",
+          "integrity": "sha512-eazsqzwG2lskuzBqCGPi7Ac2UgOoMz8JVOXVhTvvPDYhthvNpefx8jWD8Np7Gv+2Sz0FlPWZk0nJV0z598Wn8Q==",
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -17860,6 +18499,25 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+    },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "optional": true
+    },
+    "simple-get": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.0.tgz",
+      "integrity": "sha512-ZalZGexYr3TA0SwySsr5HlgOOinS4Jsa8YB2GJ6lUNAazyAu4KG/VmzMTwAt2YVXzzVj8QmefmAonZIK2BSGcQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -18430,6 +19088,13 @@
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true,
+      "optional": true
+    },
     "strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -18598,6 +19263,42 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
+      }
+    },
+    "tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
       }
     },
     "terminal-link": {
@@ -18980,6 +19681,16 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "type-check": {
       "version": "0.4.0",
@@ -20687,6 +21398,26 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "xss": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.10.tgz",
+      "integrity": "sha512-qmoqrRksmzqSKvgqzN0055UFWY7OKx1/9JWeRswwEVX9fCG5jcYRxa/A2DHcmZX6VJvjzHRQ2STeeVcQkrmLSw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.16.0",
+    "@nuxt/image": "^0.6.0",
     "@nuxtjs/eslint-config": "^7.0.0",
     "@nuxtjs/eslint-module": "^3.0.2",
     "@nuxtjs/moment": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@fortawesome/vue-fontawesome": "^2.0.6",
     "@nuxtjs/i18n": "^7.1.0",
     "@nuxtjs/prismic": "^1.3.2",
-    "assets-extractor-module": "1024pix/assets-extractor-module#11e6147520853b59c491d57c1d9ee45c0b6a6a81",
     "chart.js": "^2.9.4",
     "nuxt": "^2.15.1",
     "nuxt-fontawesome": "0.4.0",

--- a/tests/components/PixImage.test.js
+++ b/tests/components/PixImage.test.js
@@ -6,7 +6,7 @@ describe('Component: PixImage', () => {
 
   beforeEach(() => {
     component = shallowMount(PixImage, {
-      stubs: { 'prismic-image': true },
+      stubs: { 'nuxt-img': true },
       props: { field: {} },
     })
   })
@@ -17,7 +17,7 @@ describe('Component: PixImage', () => {
       const imageWithAlt = {
         alt: 'Alternative Message',
         copyright: null,
-        dimension: {
+        dimensions: {
           height: 345,
           width: 453,
         },
@@ -36,7 +36,7 @@ describe('Component: PixImage', () => {
       const imageWithoutAlt = {
         alt: null,
         copyright: null,
-        dimension: {
+        dimensions: {
           height: 345,
           width: 453,
         },
@@ -51,6 +51,52 @@ describe('Component: PixImage', () => {
 
       // Then
       expect(component.vm.image).toEqual(expectedImage)
+    })
+
+    it('should return an image with default width & height if small enough', async () => {
+      // Given
+      const image = {
+        alt: 'Alternative Message',
+        copyright: null,
+        dimensions: {
+          height: 345,
+          width: 453,
+        },
+        url: 'https://url.fr',
+      }
+
+      // When
+      await component.setProps({ field: image })
+
+      // Then
+      expect(component.vm.image).toEqual(image)
+    })
+
+    it('should return an image with recomputed width & height if too large', async () => {
+      // Given
+      const maxHeight = 300
+      const image = {
+        alt: 'Alternative Message',
+        copyright: null,
+        dimensions: {
+          height: 345,
+          width: 453,
+        },
+        url: 'https://url.fr',
+      }
+
+      // When
+      await component.setProps({ field: image })
+      await component.setProps({ maxHeight })
+
+      // Then
+      expect(component.vm.computeHeight(image)).toEqual(maxHeight)
+
+      const computedWidth =
+        image.dimensions.width * (maxHeight / image.dimensions.height)
+      expect(component.vm.computeWidth(image)).toEqual(
+        Math.round(computedWidth)
+      )
     })
   })
 })

--- a/tests/components/PixImage.test.js
+++ b/tests/components/PixImage.test.js
@@ -53,7 +53,7 @@ describe('Component: PixImage', () => {
       expect(component.vm.image).toEqual(expectedImage)
     })
 
-    it('should return an image with default width & height if small enough', async () => {
+    it('should return an image without width & height if hasFixedDimensions not set', async () => {
       // Given
       const image = {
         alt: 'Alternative Message',
@@ -70,6 +70,30 @@ describe('Component: PixImage', () => {
 
       // Then
       expect(component.vm.image).toEqual(image)
+      expect(component.vm.computeHeight(image)).toEqual(undefined)
+      expect(component.vm.computeWidth(image)).toEqual(undefined)
+    })
+
+    it('should return an image with default width & height if small enough', async () => {
+      // Given
+      const image = {
+        alt: 'Alternative Message',
+        copyright: null,
+        dimensions: {
+          height: 345,
+          width: 453,
+        },
+        url: 'https://url.fr',
+      }
+
+      // When
+      await component.setProps({ hasFixedDimensions: true })
+      await component.setProps({ field: image })
+
+      // Then
+      expect(component.vm.image).toEqual(image)
+      expect(component.vm.computeHeight(image)).toEqual(345)
+      expect(component.vm.computeWidth(image)).toEqual(453)
     })
 
     it('should return an image with recomputed width & height if too large', async () => {
@@ -87,9 +111,11 @@ describe('Component: PixImage', () => {
 
       // When
       await component.setProps({ field: image })
+      await component.setProps({ hasFixedDimensions: true })
       await component.setProps({ maxHeight })
 
       // Then
+      expect(component.vm.image).toEqual(image)
       expect(component.vm.computeHeight(image)).toEqual(maxHeight)
 
       const computedWidth =


### PR DESCRIPTION
## :unicorn: Problème
Il est conseillé de préférer l'utilisation de `<nuxt-img>` (`@nuxt/image`) à la place de `<prismic-image>`. Cela permet entre autres l'optimisation automatisée des images. Exemple : si les `width` et `height` sont précisées, les images sont retaillées à la compilation pour ne pas prendre l'image originale.

Voir https://prismic.io/blog/nuxt-image-is-out-so-is-its-prismic-integration pour plus d'infos.

## :robot: Solution
Installation du package `@nuxt/image`  et utilisation de la balise `<nuxt-img>`.

## :rainbow: Remarques
En dev, les images viennent directement des CDN Prismic.

Il a fallu modifier la manière dont on calculait le nombre de colonnes (en JS) car @nuxt/image n'est pas capable de détecter les images téléchargées côté client (`mounted` + `process.client`). C'est maintenant fait en CSS, j'ai pris la liberté de ne gérer plus que 2 layout (mobile et large-screen) plutôt que 4 auparavant.

## :100: Pour tester
Vérifier dans la RA que les images sont toujours affichées, qu'elles sont bien rapatriées depuis Prismic (= hebergées sur pix-site = les images ont des `src` == `/_nuxt/images/...`) et que celles qui ont les attributs `width` et `height` ont bien les dimensions souhaitées (elles doivent être redimensionnées à la compil).

Vérifier que les layouts sont acceptables en desktop ET en mobile. Vérifier aussi que les tailles des images sont correctes.