### PR TITLE
[FEATURE] Corriger les titles pour les actualités.

### DIFF
--- a/assets/scss/shared/_text.scss
+++ b/assets/scss/shared/_text.scss
@@ -141,3 +141,15 @@
     color: $grey-45;
   }
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  display: inline;
+}

--- a/components/NewsItemCard.vue
+++ b/components/NewsItemCard.vue
@@ -4,13 +4,13 @@
       class="news-item-card__link"
       :to="localePath({ name: 'news-slug', params: { slug: uid } })"
     >
-      <header class="news-item-card__header">
+      <div class="news-item-card__header">
         <!-- /!\ We keep this line if we think that an image would be better -->
         <div
           class="news-item-card__illustration"
           :style="`background-image: url(${slice.illustration.url})`"
         ></div>
-      </header>
+      </div>
 
       <div class="news-item-card__body">
         <p class="news-item-card__meta">
@@ -23,7 +23,7 @@
           </span>
         </p>
 
-        <h2 class="news-item-card__title">{{ slice.title[0].text }}</h2>
+        <h3 class="news-item-card__title">{{ slice.title[0].text }}</h3>
 
         <prismic-rich-text
           :field="slice.excerpt"

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -23,6 +23,7 @@ export default {
     'form-id': '28772',
   },
   'news-page-title': 'News',
+  'news-page-title-level-two': 'News List',
   'news-page-no-news': 'No news available for the moment.',
   announcement: 'Announcement',
   engineering: 'Engineering',

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -23,6 +23,7 @@ export default {
     'form-id': '22797',
   },
   'news-page-title': 'Actualités',
+  'news-page-title-level-two': 'Liste des actualités',
   'news-page-no-news': "Il n’y a pas encore d'actualités",
   announcement: 'Annonce',
   engineering: 'Ingénierie',

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -23,6 +23,7 @@ export default {
     'form-id': '22797',
   },
   'news-page-title': 'Actualités',
+  'news-page-title-level-two': 'Liste des actualités',
   'news-page-no-news': "Il n’y a pas encore d'actualités",
   announcement: 'Annonce',
   engineering: 'Ingénierie',

--- a/pages/pix-site/news/index.vue
+++ b/pages/pix-site/news/index.vue
@@ -9,6 +9,9 @@
     </header>
 
     <main class="page-body">
+      <h2 class="sr-only">
+        {{ $t('news-page-title-level-two') }}
+      </h2>
       <ul class="news__list">
         <template v-if="newsItems && newsItems.length">
           <news-item-card


### PR DESCRIPTION
## :unicorn: Problème
Les titres des components NewsCards devaient être des H2 ou des H3 selon la page affichée.

## :robot: Solution
Ajouter un titre de niveau H2, non visible, sur la page d'actualité pour pouvoir mettre du h3 à chaque fois.

## :rainbow: Remarques
- Retirer un header mal placé autour d'une image

## :100: Pour tester
Vérifier la hierarchie des titres sur la page d'accueil et sur la page actualités.
