### PR TITLE
[BUGFIX] Relance le job `test` à chaque push + PR label/unlabel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v1
         with:
           node-version: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,23 +4,8 @@ on:
   push:
   pull_request:
     types:
-      - assigned
-      - unassigned
       - labeled
       - unlabeled
-      - opened
-      - edited
-      - closed
-      - reopened
-      - synchronize
-      - converted_to_draft
-      - ready_for_review
-      - locked
-      - unlocked
-      - review_requested
-      - review_request_removed
-      - auto_merge_enabled
-      - auto_merge_disabled
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,26 @@
 name: Pix Site CI
 
 on:
+  push:
   pull_request:
+    types:
+      - assigned
+      - unassigned
+      - labeled
+      - unlabeled
+      - opened
+      - edited
+      - closed
+      - reopened
+      - synchronize
+      - converted_to_draft
+      - ready_for_review
+      - locked
+      - unlocked
+      - review_requested
+      - review_request_removed
+      - auto_merge_enabled
+      - auto_merge_disabled
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          persist-credentials: false
       - uses: actions/setup-node@v1
         with:
           node-version: 14


### PR DESCRIPTION
## :unicorn: Problème
Il arrive que le job `test` ne se lance pas.

## :robot: Solution
Nous avons ajouté les triggers au `push` et quand un label est ajouté/retiré de la PR. Cela semble couvrir nos besoins.

## :rainbow: Remarques
Idéalement migrer vers Circle CI par la suite ?

## :100: Pour tester
Constater qu'il n'y a plus de job qui bloquent 🤔 

