### PR TITLE
[INFRA] Mettre en cache les contenus des dossiers `images` et `scripts`

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -31,7 +31,7 @@ server {
   rewrite ^/(aide|help)$ https://support.pix.org permanent;
   rewrite ^/employeurs$ https://pro.pix.fr permanent;
 
-  location ~ ^/(_assets|_nuxt)/ {
+  location ~ ^/(_assets|_nuxt|images|scripts)/ {
     expires 1y;
     add_header Cache-Control public;
     add_header ETag "";


### PR DESCRIPTION
## :unicorn: Problème
Pour le moment les dossiers `images` (qui contient les icônes de la navbar entre autres) et `scripts` (qui contient le script d'init de matomo) ne sont pas mis en cache. Cela peut causer des problèmes de performance comme remonté par l'audit Lighthouse.

## :robot: Solution
Ajouter ces dossiers dans la liste des infos mises en cache.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier les headers des fichiers de ces dossiers dans la RA.
