### PR TITLE
[TECH] Utilise le PIX_SERVICE_ACTIONS_TOKEN dans l'action d'automerge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,15 +10,13 @@ on:
 
 jobs:
   automerge:
-    if: >
-      ${{ contains(github.event.pull_request.labels.*.name, ':rocket: Ready to Merge') }}
     runs-on: ubuntu-latest
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.14.3"
         env:
-          GITHUB_TOKEN: "${{ github.token }}"
-          MERGE_LABELS: ":rocket: Ready to Merge"
+          GITHUB_TOKEN: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"
+          MERGE_LABELS: ":rocket: Ready to Merge,!:warning: Blocked,!:earth_africa: i18n needed,!:busts_in_silhouette: Panel Review Needed,!Development in progress,!:eyes: Design Review Needed,!:eyes: Func Review Needed,!:eyes: Tech Review Needed"
           MERGE_COMMIT_MESSAGE: "pull-request-title"
           UPDATE_LABELS: ":rocket: Ready to Merge"
           UPDATE_METHOD: "rebase"


### PR DESCRIPTION
## :unicorn: Problème
Comme vu dans https://github.com/1024pix/pix/pull/3624, il semble que le token de base n'est pas suffisant.

## :robot: Solution
On utilise maintenant un secret token (qui existait déjà).

## :rainbow: Remarques
On en profite pour uniformiser par rapport à https://github.com/1024pix/pix.

## :100: Pour tester
Vérifier que l'autre PR ouverte avec le label `:rocket: Ready to merge` se rebase + merge correctement après avoir mergé celle-ci.
