### PR TITLE
[BUGFIX] Correction logo pix-pro

### DIFF
--- a/components/slices/LogosZone.vue
+++ b/components/slices/LogosZone.vue
@@ -6,9 +6,9 @@
       class="logos-zone__content"
     >
       <pix-link v-if="hasLink(logo)" :field="logo.url">
-        <pix-image :field="logo.image" width="60.6" height="50" />
+        <pix-image :field="logo.image" />
       </pix-link>
-      <pix-image v-else :field="logo.image" width="54.7" height="50" />
+      <pix-image v-else :field="logo.image" />
     </div>
   </div>
 </template>
@@ -43,6 +43,7 @@ export default {
     }
 
     img {
+      height: 50px;
       margin: 15px 0 15px 0;
     }
 


### PR DESCRIPTION
This reverts commit 54e49eaea5245cf7b5e15666764c587ec1b5bcbe.

## :unicorn: Problème
Après avoir release, on s'est rendu compte que le logo pix-pro n'avait pas les mêmes dimensions que le logo pix. Avec les `width` et `height` en dur, le logo pix-pro parait donc distordu.

![image](https://user-images.githubusercontent.com/5855339/142459886-80e1a473-4a74-4b1e-876a-7261d85fc261.png)


## :robot: Solution
On annule cette modification le temps de réfléchir à une meilleure solution.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que les logos République Française, Pix et Pix Pro ont une taille correcte.

