### PR TITLE
[TECH] Nettoyage document fetcher (PIX-3929, PIX-3932)

### DIFF
--- a/components/FooterSliceZone.vue
+++ b/components/FooterSliceZone.vue
@@ -47,7 +47,7 @@
 
 <script>
 import { keyBy } from '~/services/key-by'
-import { documentFetcher, documents } from '~/services/document-fetcher'
+import { documentFetcher, DOCUMENTS } from '~/services/document-fetcher'
 
 export default {
   name: 'FooterSliceZone',
@@ -61,7 +61,7 @@ export default {
     this.mainFooters = await documentFetcher(
       this.$prismic,
       this.$i18n
-    ).findByType(documents.mainFooter)
+    ).findByType(DOCUMENTS.MAIN_FOOTER)
   },
   computed: {
     isPixPro() {

--- a/components/FooterSliceZone.vue
+++ b/components/FooterSliceZone.vue
@@ -46,36 +46,27 @@
 </template>
 
 <script>
-import { keyBy } from '~/services/key-by'
-import { documentFetcher, DOCUMENTS } from '~/services/document-fetcher'
+import { documentFetcher } from '~/services/document-fetcher'
 
 export default {
   name: 'FooterSliceZone',
   data() {
     return {
       socialMediasHoverMap: {},
-      mainFooters: null,
+      usedMainFooter: null,
     }
   },
   async fetch() {
-    this.mainFooters = await documentFetcher(
+    const mainFooter = await documentFetcher(
       this.$prismic,
       this.$i18n
-    ).findByType(DOCUMENTS.MAIN_FOOTER)
+    ).findMainFooter()
+
+    this.usedMainFooter = mainFooter.data.body
   },
   computed: {
     isPixPro() {
       return process.env.isPixPro
-    },
-    usedMainFooter() {
-      const mainFooterBySite = keyBy(
-        this.mainFooters,
-        (mainFooter) => mainFooter?.data?.footer_for
-      )
-      if (this.isPixPro && mainFooterBySite['pix-pro']) {
-        return mainFooterBySite['pix-pro'].data.body
-      }
-      return mainFooterBySite['pix-site'].data.body
     },
     navigationGroups() {
       return this.usedMainFooter.filter(

--- a/components/HotNewsBanner.vue
+++ b/components/HotNewsBanner.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script>
-import { documentFetcher, DOCUMENTS } from '~/services/document-fetcher'
+import { documentFetcher } from '~/services/document-fetcher'
 
 export default {
   name: 'HotNewsBanner',
@@ -22,9 +22,10 @@ export default {
     }
   },
   async fetch() {
-    const hotNews = await documentFetcher(this.$prismic, this.$i18n).findByType(
-      DOCUMENTS.HOT_NEWS
-    )
+    const hotNews = await documentFetcher(
+      this.$prismic,
+      this.$i18n
+    ).findHotNewsBanner()
 
     this.hotNews = hotNews?.data?.description
   },

--- a/components/HotNewsBanner.vue
+++ b/components/HotNewsBanner.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script>
-import { documentFetcher, documents } from '~/services/document-fetcher'
+import { documentFetcher, DOCUMENTS } from '~/services/document-fetcher'
 
 export default {
   name: 'HotNewsBanner',
@@ -23,7 +23,7 @@ export default {
   },
   async fetch() {
     const hotNews = await documentFetcher(this.$prismic, this.$i18n).findByType(
-      documents.hotNews
+      DOCUMENTS.HOT_NEWS
     )
 
     this.hotNews = hotNews?.data?.description

--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -30,7 +30,7 @@
 
 <script>
 import { keyBy } from '~/services/key-by'
-import { documentFetcher, documents } from '~/services/document-fetcher'
+import { documentFetcher, DOCUMENTS } from '~/services/document-fetcher'
 
 export default {
   name: 'NavigationSliceZone',
@@ -43,7 +43,7 @@ export default {
     this.mainNavigations = await documentFetcher(
       this.$prismic,
       this.$i18n
-    ).findByType(documents.mainNavigation)
+    ).findByType(DOCUMENTS.MAIN_NAVIGATION)
   },
   computed: {
     isPixPro() {

--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -29,60 +29,50 @@
 </template>
 
 <script>
-import { keyBy } from '~/services/key-by'
-import { documentFetcher, DOCUMENTS } from '~/services/document-fetcher'
+import { documentFetcher } from '~/services/document-fetcher'
 
 export default {
   name: 'NavigationSliceZone',
   data() {
     return {
-      mainNavigations: [],
+      usedMainNavigation: null,
     }
   },
   async fetch() {
-    this.mainNavigations = await documentFetcher(
+    const mainNavigation = await documentFetcher(
       this.$prismic,
       this.$i18n
-    ).findByType(DOCUMENTS.MAIN_NAVIGATION)
+    ).findMainNavigation()
+
+    this.usedMainNavigation = mainNavigation.data.body
   },
   computed: {
     isPixPro() {
       return process.env.isPixPro
     },
 
-    usedMainNavigation() {
-      const mainNavBySite = keyBy(
-        this.mainNavigations,
-        (mainNav) => mainNav?.data?.navigation_for
-      )
-      if (this.isPixPro && mainNavBySite['pix-pro']) {
-        return mainNavBySite['pix-pro']
-      }
-      return mainNavBySite['pix-site']
-    },
-
     logos() {
-      const headerBlocks = this.usedMainNavigation.data.body
+      const headerBlocks = this.usedMainNavigation
       return headerBlocks.filter((block) => block.slice_type === 'logos_zone')
     },
 
     actions() {
-      const headerBlocks = this.usedMainNavigation.data.body
+      const headerBlocks = this.usedMainNavigation
       return headerBlocks.filter((block) => block.slice_type === 'actions_zone')
     },
 
     navigation() {
-      const headerBlocks = this.usedMainNavigation.data.body
+      const headerBlocks = this.usedMainNavigation
       return headerBlocks.filter(
         (block) => block.slice_type === 'navigation_zone'
       )
     },
 
     burgerMenuLinks() {
-      const navigationZone = this.usedMainNavigation.data.body.find(
+      const navigationZone = this.usedMainNavigation.find(
         (slice) => slice.slice_type === 'navigation_zone'
       )
-      const actionsZone = this.usedMainNavigation.data.body.find(
+      const actionsZone = this.usedMainNavigation.find(
         (slice) => slice.slice_type === 'actions_zone'
       )
       return {

--- a/pages/pix-pro/_custom-page.vue
+++ b/pages/pix-pro/_custom-page.vue
@@ -1,19 +1,19 @@
 <template>
   <div>
-    <div v-if="type === 'form_page'">
+    <div v-if="type === FORM_PAGE">
       <form-page :content="document.data" />
     </div>
-    <div v-if="type === 'simple_page'">
+    <div v-if="type === SIMPLE_PAGE">
       <simple-page :content="document.data" />
     </div>
-    <div v-if="type === 'slices_page'">
+    <div v-if="type === SLICES_PAGE">
       <slice-zone :slices="document.data.body" />
     </div>
   </div>
 </template>
 
 <script>
-import { documentFetcher } from '~/services/document-fetcher'
+import { documentFetcher, DOCUMENTS } from '~/services/document-fetcher'
 
 export default {
   name: 'CustomPage',
@@ -36,6 +36,13 @@ export default {
       return { currentPagePath, meta, document }
     } catch (e) {
       error({ statusCode: 404, message: 'Page not found' })
+    }
+  },
+  data() {
+    return {
+      FORM_PAGE: DOCUMENTS.FORM_PAGE,
+      SIMPLE_PAGE: DOCUMENTS.SIMPLE_PAGE,
+      SLICES_PAGE: DOCUMENTS.SLICES_PAGE,
     }
   },
   head() {

--- a/pages/pix-pro/index.vue
+++ b/pages/pix-pro/index.vue
@@ -1,19 +1,19 @@
 <template>
   <div>
-    <div v-if="type === 'form_page'">
+    <div v-if="type === FORM_PAGE">
       <form-page :content="document.data" />
     </div>
-    <div v-if="type === 'simple_page'">
+    <div v-if="type === SIMPLE_PAGE">
       <simple-page :content="document.data" />
     </div>
-    <div v-if="type === 'slices_page'">
+    <div v-if="type === SLICES_PAGE">
       <slice-zone :slices="document.data.body" />
     </div>
   </div>
 </template>
 
 <script>
-import { documentFetcher } from '~/services/document-fetcher'
+import { documentFetcher, DOCUMENTS } from '~/services/document-fetcher'
 
 export default {
   name: 'Index',
@@ -36,6 +36,13 @@ export default {
       return { currentPagePath, meta, document }
     } catch (e) {
       error({ statusCode: 404, message: 'Page not found' })
+    }
+  },
+  data() {
+    return {
+      FORM_PAGE: DOCUMENTS.FORM_PAGE,
+      SIMPLE_PAGE: DOCUMENTS.SIMPLE_PAGE,
+      SLICES_PAGE: DOCUMENTS.SLICES_PAGE,
     }
   },
   head() {

--- a/pages/pix-site/_custom-page.vue
+++ b/pages/pix-site/_custom-page.vue
@@ -1,19 +1,19 @@
 <template>
   <div>
-    <div v-if="type === 'form_page'">
+    <div v-if="type === FORM_PAGE">
       <form-page :content="document.data" />
     </div>
-    <div v-if="type === 'simple_page'">
+    <div v-if="type === SIMPLE_PAGE">
       <simple-page :content="document.data" />
     </div>
-    <div v-if="type === 'slices_page'">
+    <div v-if="type === SLICES_PAGE">
       <slice-zone :slices="slices" />
     </div>
   </div>
 </template>
 
 <script>
-import { documentFetcher } from '~/services/document-fetcher'
+import { documentFetcher, DOCUMENTS } from '~/services/document-fetcher'
 
 export default {
   name: 'CustomPage',
@@ -42,6 +42,13 @@ export default {
       return { currentPagePath, meta, document, latestNewsItems }
     } catch (e) {
       error({ statusCode: 404, message: 'Page not found' })
+    }
+  },
+  data() {
+    return {
+      FORM_PAGE: DOCUMENTS.FORM_PAGE,
+      SIMPLE_PAGE: DOCUMENTS.SIMPLE_PAGE,
+      SLICES_PAGE: DOCUMENTS.SLICES_PAGE,
     }
   },
   head() {

--- a/plugins/link-resolver.js
+++ b/plugins/link-resolver.js
@@ -1,13 +1,20 @@
+import { DOCUMENTS } from '~/services/document-fetcher'
+
 export default function (doc) {
-  const staticRoute = ['competences', 'statistiques', 'simple_page']
+  const staticRoute = [
+    DOCUMENTS.COMPETENCES,
+    DOCUMENTS.STATISTIQUES,
+    DOCUMENTS.SIMPLE_PAGE,
+  ]
+
   if (staticRoute.includes(doc.type)) {
     const locale = doc.lang !== 'fr-fr' ? `/${doc.lang}` : ''
     return `${locale}/${doc.uid}`
   }
-  if (doc.type === 'news_item') {
+  if (doc.type === DOCUMENTS.NEWS_ITEM) {
     return `/actualites/${doc.uid}`
   }
-  if (doc.type === 'index') {
+  if (doc.type === DOCUMENTS.INDEX) {
     return `/`
   }
 }

--- a/services/document-fetcher.js
+++ b/services/document-fetcher.js
@@ -1,5 +1,3 @@
-import LinkResolver from '~/plugins/link-resolver.js'
-
 export const documents = {
   hotNews: 'hot_news',
   index: 'index',
@@ -53,9 +51,6 @@ export function documentFetcher(
         { lang }
       )
       return document.results[0]
-    },
-    getPreviewUrl: (previewToken) => {
-      return prismic.api.previewSession(previewToken, LinkResolver, '/')
     },
     getPageByUid: async (uid) => {
       const simplePage = await getSimplePageByUid(uid)

--- a/services/document-fetcher.js
+++ b/services/document-fetcher.js
@@ -1,8 +1,14 @@
-export const documents = {
-  hotNews: 'hot_news',
-  index: 'index',
-  mainFooter: 'main_footer',
-  mainNavigation: 'main_navigation',
+export const DOCUMENTS = {
+  HOT_NEWS: 'hot_news',
+  INDEX: 'index',
+  MAIN_FOOTER: 'main_footer',
+  MAIN_NAVIGATION: 'main_navigation',
+  NEWS_ITEM: 'news_item',
+  SIMPLE_PAGE: 'simple_page',
+  FORM_PAGE: 'form_page',
+  SLICES_PAGE: 'slices_page',
+  COMPETENCES: 'competences',
+  STATISTIQUES: 'statistiques',
 }
 
 export function documentFetcher(
@@ -35,11 +41,11 @@ export function documentFetcher(
     },
     findNewsItems: async ({ page, pageSize } = { page: 1, pageSize: 20 }) => {
       const documents = await prismic.api.query(
-        prismic.predicates.at('document.type', 'news_item'),
+        prismic.predicates.at('document.type', DOCUMENTS.NEWS_ITEM),
         {
           page,
           pageSize,
-          orderings: '[my.news_item.date desc]',
+          orderings: `[my.${DOCUMENTS.NEWS_ITEM}.date desc]`,
           lang,
         }
       )
@@ -47,7 +53,7 @@ export function documentFetcher(
     },
     getNewsItemByUid: async (slug) => {
       const document = await prismic.api.query(
-        prismic.predicates.at('my.news_item.uid', slug),
+        prismic.predicates.at(`my.${DOCUMENTS.NEWS_ITEM}.uid`, slug),
         { lang }
       )
       return document.results[0]
@@ -67,7 +73,7 @@ export function documentFetcher(
 
   async function getSimplePageByUid(uid) {
     const document = await prismic.api.query(
-      prismic.predicates.at('my.simple_page.uid', uid),
+      prismic.predicates.at(`my.${DOCUMENTS.SIMPLE_PAGE}.uid`, uid),
       { lang }
     )
     return document.results[0]
@@ -75,7 +81,7 @@ export function documentFetcher(
 
   async function getFormPageByUid(uid) {
     const document = await prismic.api.query(
-      prismic.predicates.at('my.form_page.uid', uid),
+      prismic.predicates.at(`my.${DOCUMENTS.FORM_PAGE}.uid`, uid),
       { lang }
     )
     return document.results[0]
@@ -83,7 +89,7 @@ export function documentFetcher(
 
   async function getSlicesPageByUid(uid) {
     const document = await prismic.api.query(
-      prismic.predicates.at('my.slices_page.uid', uid),
+      prismic.predicates.at(`my.${DOCUMENTS.SLICES_PAGE}.uid`, uid),
       { lang }
     )
     return document.results[0]

--- a/services/document-fetcher.js
+++ b/services/document-fetcher.js
@@ -19,13 +19,6 @@ export function documentFetcher(
   const lang = i18n.locale || i18n.defaultLocale
   return {
     get: getSingle,
-    findByType: async (type) => {
-      const documents = await prismic.api.query(
-        prismic.predicates.at('document.type', type),
-        { lang }
-      )
-      return documents.results
-    },
     findHotNewsBanner: async () => {
       const documents = await prismic.api.query(
         prismic.predicates.at('document.type', DOCUMENTS.HOT_NEWS),

--- a/services/document-fetcher.js
+++ b/services/document-fetcher.js
@@ -26,6 +26,39 @@ export function documentFetcher(
       )
       return documents.results
     },
+    findHotNewsBanner: async () => {
+      const documents = await prismic.api.query(
+        prismic.predicates.at('document.type', DOCUMENTS.HOT_NEWS),
+        { lang }
+      )
+      return documents.results
+    },
+    findMainNavigation: async () => {
+      const documents = await prismic.api.query(
+        [
+          prismic.predicates.at('document.type', DOCUMENTS.MAIN_NAVIGATION),
+          prismic.predicates.at(
+            `my.${DOCUMENTS.MAIN_NAVIGATION}.navigation_for`,
+            process.env.SITE === 'pix-site' ? 'pix-site' : 'pix-pro'
+          ),
+        ],
+        { lang }
+      )
+      return documents.results[0]
+    },
+    findMainFooter: async () => {
+      const documents = await prismic.api.query(
+        [
+          prismic.predicates.at('document.type', DOCUMENTS.MAIN_FOOTER),
+          prismic.predicates.at(
+            `my.${DOCUMENTS.MAIN_FOOTER}.footer_for`,
+            process.env.SITE === 'pix-site' ? 'pix-site' : 'pix-pro'
+          ),
+        ],
+        { lang }
+      )
+      return documents.results[0]
+    },
     getEmployers: async () => {
       const document = await prismic.api.getSingle('employers', {
         lang,

--- a/services/get-routes-to-generate.js
+++ b/services/get-routes-to-generate.js
@@ -1,4 +1,5 @@
 import Prismic from '@prismicio/client'
+import { DOCUMENTS } from './document-fetcher'
 
 export default async function () {
   const api = await Prismic.getApi(process.env.PRISMIC_API_ENDPOINT)
@@ -12,7 +13,10 @@ export default async function () {
 
 async function getRoutesInPage(api, page) {
   const { results, total_pages: totalPages } = await api.query(
-    Prismic.Predicates.any('document.type', ['simple_page', 'form_page']),
+    Prismic.Predicates.any('document.type', [
+      DOCUMENTS.SIMPLE_PAGE,
+      DOCUMENTS.FORM_PAGE,
+    ]),
     {
       pageSize: 100,
       page,

--- a/tests/components/slices/NavigationSliceZone.test.js
+++ b/tests/components/slices/NavigationSliceZone.test.js
@@ -69,12 +69,7 @@ describe('NavigationSliceZone', () => {
           // given
           component = shallowMount(NavigationSliceZone, {
             data() {
-              return {
-                mainNavigations: [
-                  expectedSiteNavigation,
-                  expectedProNavigation,
-                ],
-              }
+              return { usedMainNavigation: expectedSiteNavigation.data.body }
             },
             stubs,
           })
@@ -83,7 +78,7 @@ describe('NavigationSliceZone', () => {
           const result = component.vm.usedMainNavigation
 
           // then
-          expect(result).toEqual(expectedSiteNavigation)
+          expect(result).toEqual(expectedSiteNavigation.data.body)
         })
       })
 
@@ -98,12 +93,7 @@ describe('NavigationSliceZone', () => {
           // given
           component = shallowMount(NavigationSliceZone, {
             data() {
-              return {
-                mainNavigations: [
-                  expectedSiteNavigation,
-                  expectedProNavigation,
-                ],
-              }
+              return { usedMainNavigation: expectedProNavigation.data.body }
             },
             stubs,
           })
@@ -112,7 +102,7 @@ describe('NavigationSliceZone', () => {
           const result = component.vm.usedMainNavigation
 
           // then
-          expect(result).toEqual(expectedProNavigation)
+          expect(result).toEqual(expectedProNavigation.data.body)
         })
       })
 
@@ -127,7 +117,7 @@ describe('NavigationSliceZone', () => {
           // given
           component = shallowMount(NavigationSliceZone, {
             data() {
-              return { mainNavigations: [expectedSiteNavigation] }
+              return { usedMainNavigation: expectedProNavigation.data.body }
             },
             stubs,
           })
@@ -136,7 +126,7 @@ describe('NavigationSliceZone', () => {
           const result = component.vm.usedMainNavigation
 
           // then
-          expect(result).toEqual(expectedSiteNavigation)
+          expect(result).toEqual(expectedSiteNavigation.data.body)
         })
       })
     })

--- a/tests/pages/pix-site/index.test.js
+++ b/tests/pages/pix-site/index.test.js
@@ -1,6 +1,6 @@
 import VueMeta from 'vue-meta'
 import { getInitialised, createLocalVue } from './utils'
-import { documentFetcher } from '~/services/document-fetcher'
+import { documentFetcher, DOCUMENTS } from '~/services/document-fetcher'
 import getMeta, { fallbackDescription } from '~/services/meta-builder'
 
 const localVue = createLocalVue()
@@ -41,7 +41,7 @@ describe('Index Page', () => {
           },
         }),
     })
-    wrapper = await getInitialised('index', {
+    wrapper = await getInitialised(DOCUMENTS.INDEX, {
       localVue,
       computed: {
         $prismic() {
@@ -77,7 +77,7 @@ describe('Index Page', () => {
   })
 
   test('uses the fallback meta description when not filled in Prismic', async () => {
-    wrapper = await getInitialised('index', {
+    wrapper = await getInitialised(DOCUMENTS.INDEX, {
       localVue,
       computed: {
         $prismic() {

--- a/tests/services/document-fetcher.test.js
+++ b/tests/services/document-fetcher.test.js
@@ -1,5 +1,5 @@
 import prismic from '@prismicio/client'
-import { documentFetcher } from '~/services/document-fetcher'
+import { documentFetcher, DOCUMENTS } from '~/services/document-fetcher'
 
 jest.mock('@prismicio/client')
 
@@ -56,18 +56,27 @@ describe('DocumentFetcher', () => {
     expect(prismicApi.query).toBeCalledWith(expectedPredicatesAtValue, {
       lang: 'fr-fr',
     })
-    expect(prismicPredicates.at).toBeCalledWith('my.simple_page.uid', uid)
-    expect(prismicPredicates.at).toBeCalledWith('my.slices_page.uid', uid)
-    expect(prismicPredicates.at).toBeCalledWith('my.form_page.uid', uid)
+    expect(prismicPredicates.at).toBeCalledWith(
+      `my.${DOCUMENTS.SIMPLE_PAGE}.uid`,
+      uid
+    )
+    expect(prismicPredicates.at).toBeCalledWith(
+      `my.${DOCUMENTS.SLICES_PAGE}.uid`,
+      uid
+    )
+    expect(prismicPredicates.at).toBeCalledWith(
+      `my.${DOCUMENTS.FORM_PAGE}.uid`,
+      uid
+    )
     expect(response).toEqual(expectedValue)
   })
 
   test('#findByType', async () => {
     // Given
-    const type = 'main_navigation'
+    const type = DOCUMENTS.MAIN_NAVIGATION
     const expectedValue = [
-      { type: 'main_navigation', navigation_for: 'pix-site' },
-      { type: 'main_navigation', navigation_for: 'pix-pro' },
+      { type: DOCUMENTS.MAIN_NAVIGATION, navigation_for: 'pix-site' },
+      { type: DOCUMENTS.MAIN_NAVIGATION, navigation_for: 'pix-pro' },
     ]
     const expectedPredicatesAtValue = Symbol('AT')
     const findMock = () => ({ results: expectedValue })

--- a/tests/services/get-routes-to-generate.test.js
+++ b/tests/services/get-routes-to-generate.test.js
@@ -1,11 +1,12 @@
 import prismic from '@prismicio/client'
 import getRoutesToGenerate from '@/services/get-routes-to-generate'
+import { DOCUMENTS } from '~/services/document-fetcher'
 jest.mock('@prismicio/client')
 
 describe('#getRoutesToGenerate', () => {
   const prismicDocPredicates = prismic.Predicates.any('document.type', [
-    'simple_page',
-    'form_page',
+    DOCUMENTS.SIMPLE_PAGE,
+    DOCUMENTS.FORM_PAGE,
   ])
 
   test('it should fetch routes to generate document for each lang', async () => {


### PR DESCRIPTION
## :unicorn: Problème
1. Des chaines de caractères avec les noms des documents Prismic sont en dur à plusieurs endroits de l'appli. 
2. On récupère des documents Prismic non utiles car spécifiques pix-site/pix-pro quelque soit l'environnement.

## :robot: Solution
1. Centrer la totalité des documents Prismic dans le même objet.
2. Se baser sur la variable d'env pour requêter seulement les infos de pix-site ou pix-pro.

## :rainbow: Remarques
J'en ai profité pour supprimer un bout de code mort (`getPreviewUrl`).

## :100: Pour tester
Non reg sur la Review App pour les différents env.

