### PR TITLE
[TECH] Les pages en erreur renvoient une erreur Nginx

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -2,7 +2,7 @@ import { transports } from 'winston'
 import routes from './services/get-routes-to-generate'
 
 const config = {
-  generate: { routes },
+  generate: { routes, fallback: '404.html' },
   target: 'static',
   publicRuntimeConfig: {
     languageSwitchEnabled: process.env.LANGUAGE_SWITCH_ENABLED || false,

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -31,6 +31,8 @@ server {
   rewrite ^/(aide|help)$ https://support.pix.org permanent;
   rewrite ^/employeurs$ https://pro.pix.fr permanent;
 
+  error_page 400 401 403 404 418 500 502 503 504 /404.html;
+
   location ~ ^/(_assets|_nuxt|images|scripts)/ {
     expires 1y;
     add_header Cache-Control public;


### PR DESCRIPTION
## :unicorn: Problème
Pour le moment, les erreurs affichent une erreur Nginx pas très élégante.
![image](https://user-images.githubusercontent.com/5855339/144063742-d5b08546-3ad6-4d08-80a6-7fcd764b771a.png)

## :robot: Solution
Avec la PR, on affiche une page custom Pix pour les erreurs `400 401 403 404 418 500 502 503 504` (on préfère être safe)
![image](https://user-images.githubusercontent.com/5855339/144063911-bac5f130-228a-4ef5-9b01-5a3263a947a2.png)

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier sur la RA que `/page-inexistante` renvoie bien une page custom avec un lien pour revenir à l'accueil.

