### PR TITLE
[BUGFIX] Ajout de roles sémantiques dans les balises html (PIX-3999)

### DIFF
--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="navigation-slice-zone">
+  <header class="navigation-slice-zone" role="banner">
     <client-only>
       <slide-menu width="320" class="burger-menu">
         <burger-menu-nav :items="burgerMenuLinks" />

--- a/components/slices/NavigationZone.vue
+++ b/components/slices/NavigationZone.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="navigation-zone">
+  <nav class="navigation-zone" role="navigation">
     <ul>
       <li
         v-for="(menuItem, index) in navigationLinks"

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,7 +2,7 @@
   <div id="app" class="app-viewport">
     <hot-news-banner />
     <navigation-slice-zone />
-    <main>
+    <main role="main">
       <nuxt />
     </main>
     <footer-slice-zone />


### PR DESCRIPTION
## :unicorn: Problème
Manquement des balises d'accessibilité pour permettre une lecture simplifié pour le screen reader.

## :robot: Solution
Ajout dans les différentes balises HTML d'un rôle que le screen reader va interpréter

## :rainbow: Remarques
Pour le menu hamburger, nous n'avons pas réussi à ajouter le rôle " navigation" car on utilise un package.
Une demande de PR a été fait pour ajouter le rôle dans le package.
Le rôle "contentinfo" est déjà présent pour le footer.

## :100: Pour tester
Accéder aux RA. 
Vérifier via la console si les rôles suivant sont accessibles dans les balises:
`<main role="main"/>`
`<nav role="navigation"/>`
`<header role="banner"/>`
