### PR TITLE
[BUGFIX] Boucle infinie Nginx sur les 404 pix.org

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -40,10 +40,10 @@ server {
   }
 
   if ($host ~ \.org) {
-    rewrite ^/(?!fr)(?!en-gb)(?!_assets)(?!_nuxt)(?!documents)(?!images)(?!scripts)(?!apple-touch-icon)(?!favicon)(?!robots\.txt) $scheme://$host/fr$request_uri permanent;
+    rewrite ^/(?!404.html)(?!fr)(?!en-gb)(?!_assets)(?!_nuxt)(?!documents)(?!images)(?!scripts)(?!apple-touch-icon)(?!favicon)(?!robots\.txt) $scheme://$host/fr$request_uri permanent;
   }
 
   if ($http_x_forwarded_host ~ \.org) {
-    rewrite ^/(?!fr)(?!en-gb)(?!_assets)(?!_nuxt)(?!documents)(?!images)(?!scripts)(?!apple-touch-icon)(?!favicon)(?!robots\.txt) $http_x_forwarded_proto://$http_x_forwarded_host/fr$request_uri permanent;
+    rewrite ^/(?!404.html)(?!fr)(?!en-gb)(?!_assets)(?!_nuxt)(?!documents)(?!images)(?!scripts)(?!apple-touch-icon)(?!favicon)(?!robots\.txt) $http_x_forwarded_proto://$http_x_forwarded_host/fr$request_uri permanent;
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'on accède à une erreur 404 sur pix.org on tombe dans une boucle infinie Nginx qui rajoute des /fr devant notre page.

## :robot: Solution
⚠️ Solution temporaire : utiliser la 404.html générique dans tous les cas.

## :rainbow: Remarques
Pour le moment, ceci ne permet pas les traductions d'erreur (qui ne sont pas prêtes de toute façon). Il faudra creuser plus loin pour trouver une solution internationisable plus tard.

## :100: Pour tester
Vérifier sur la RA pix.org que les erreurs 404 s'affichent correctement.

