### PR TITLE
[BUGFIX] Éviter les redirections permanentes sur des liens qui peuvent changer

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -28,8 +28,8 @@ server {
 
   root /app/dist/;
 
-  rewrite ^/(aide|help)$ https://support.pix.org permanent;
-  rewrite ^/employeurs$ https://pro.pix.fr permanent;
+  rewrite ^/(aide|help)$ https://support.pix.org redirect;
+  rewrite ^/employeurs$ https://pro.pix.fr redirect;
 
   error_page 400 401 403 404 418 500 502 503 504 /404.html;
 
@@ -40,10 +40,10 @@ server {
   }
 
   if ($host ~ \.org) {
-    rewrite ^/(?!404.html)(?!fr)(?!en-gb)(?!_assets)(?!_nuxt)(?!documents)(?!images)(?!scripts)(?!apple-touch-icon)(?!favicon)(?!robots\.txt) $scheme://$host/fr$request_uri permanent;
+    rewrite ^/(?!404.html)(?!fr)(?!en-gb)(?!_assets)(?!_nuxt)(?!documents)(?!images)(?!scripts)(?!apple-touch-icon)(?!favicon)(?!robots\.txt) $scheme://$host/fr$request_uri redirect;
   }
 
   if ($http_x_forwarded_host ~ \.org) {
-    rewrite ^/(?!404.html)(?!fr)(?!en-gb)(?!_assets)(?!_nuxt)(?!documents)(?!images)(?!scripts)(?!apple-touch-icon)(?!favicon)(?!robots\.txt) $http_x_forwarded_proto://$http_x_forwarded_host/fr$request_uri permanent;
+    rewrite ^/(?!404.html)(?!fr)(?!en-gb)(?!_assets)(?!_nuxt)(?!documents)(?!images)(?!scripts)(?!apple-touch-icon)(?!favicon)(?!robots\.txt) $http_x_forwarded_proto://$http_x_forwarded_host/fr$request_uri redirect;
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui on fait des redirections `301` sur des liens qui peuvent toujours changer (ex : pix.fr/aide => support.pix.org).

## :robot: Solution
Utiliser des `302` avec le mot clé `redirect` plutôt que `permanent` dans nos `rewrite` rules.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier qu'on a bien une 302 sur <RA_URL>/aide pour rediriger vers support.pix.org

⚠️ En prod il faut penser à vider son cache navigateur 301/302 si vous essayez de réaccéder à une page qui faisait ce genre de redirection
   * chrome: https://dev.to/epranka/clear-the-301-302-redirection-cache-chrome-4dio
   * firefox: https://superuser.com/questions/467999/clear-301-redirect-cache-in-firefox