### PR TITLE
[BUGFIX] Laisse Google indexer le site seulement si `SEO_ENABLE_INDEXING` est settée à `true` (PIX-4040)

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,6 +1,6 @@
 import { transports } from 'winston'
 import routes from './services/get-routes-to-generate'
-import isSeoIndexationEnabled from './services/is-seo-indexation-enabled'
+import isSeoIndexingEnabled from './services/is-seo-indexing-enabled'
 
 const config = {
   generate: { routes, fallback: '404.html' },
@@ -37,7 +37,7 @@ const config = {
         content:
           'Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques tout au long de la vie.',
       },
-      isSeoIndexationEnabled() ? {} : { name: 'robots', content: 'noindex' },
+      isSeoIndexingEnabled() ? {} : { name: 'robots', content: 'noindex' },
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
     script: [
@@ -189,7 +189,7 @@ const config = {
   robots: () => {
     return {
       UserAgent: '*',
-      Disallow: isSeoIndexationEnabled() ? '' : '/',
+      Disallow: isSeoIndexingEnabled() ? '' : '/',
     }
   },
   /*

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,5 +1,6 @@
 import { transports } from 'winston'
 import routes from './services/get-routes-to-generate'
+import isSeoIndexationEnabled from './services/is-seo-indexation-enabled'
 
 const config = {
   generate: { routes, fallback: '404.html' },
@@ -36,6 +37,7 @@ const config = {
         content:
           'Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques tout au long de la vie.',
       },
+      isSeoIndexationEnabled() ? {} : { name: 'robots', content: 'noindex' },
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
     script: [
@@ -100,6 +102,7 @@ const config = {
     '@nuxtjs/style-resources',
     ['@nuxtjs/i18n', { detectBrowserLanguage: false }],
     '@nuxtjs/moment',
+    '@nuxtjs/robots',
     [
       'nuxt-fontawesome',
       {
@@ -182,6 +185,12 @@ const config = {
   router: {
     middleware: 'current-page-path',
     linkExactActiveClass: 'current-active-link',
+  },
+  robots: () => {
+    return {
+      UserAgent: '*',
+      Disallow: isSeoIndexationEnabled() ? '' : '/',
+    }
   },
   /*
    ** Build configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -5180,6 +5180,12 @@
         }
       }
     },
+    "@nuxtjs/robots": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/robots/-/robots-2.5.0.tgz",
+      "integrity": "sha512-z1F3HXb05NiZga8Cuq6k5bbowfJOScPtbSOakip0nege+1aI9pGoajzap8eR5s1qwLXAk9Ts+NcgetoUn5lwrQ==",
+      "dev": true
+    },
     "@nuxtjs/style-resources": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@nuxtjs/style-resources/-/style-resources-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@nuxtjs/eslint-config": "^7.0.0",
     "@nuxtjs/eslint-module": "^3.0.2",
     "@nuxtjs/moment": "1.6.1",
+    "@nuxtjs/robots": "^2.5.0",
     "@nuxtjs/style-resources": "^1.2.1",
     "@vue/test-utils": "^1.2.2",
     "autoprefixer": "^10.4.0",

--- a/services/is-seo-indexation-enabled.js
+++ b/services/is-seo-indexation-enabled.js
@@ -1,3 +1,0 @@
-export default function isSeoIndexationEnabled() {
-  return process.env.SEO_ENABLE_INDEXATION === 'true'
-}

--- a/services/is-seo-indexation-enabled.js
+++ b/services/is-seo-indexation-enabled.js
@@ -1,0 +1,3 @@
+export default function isSeoIndexationEnabled() {
+  return process.env.SEO_ENABLE_INDEXATION === 'true'
+}

--- a/services/is-seo-indexing-enabled.js
+++ b/services/is-seo-indexing-enabled.js
@@ -1,0 +1,3 @@
+export default function isSeoIndexingEnabled() {
+  return process.env.SEO_ENABLE_INDEXING === 'true'
+}

--- a/static/README.md
+++ b/static/README.md
@@ -6,6 +6,6 @@ This directory contains your static files.
 Each file inside this directory is mapped to `/`.
 Thus you'd want to delete this README.md before deploying to production.
 
-Example: `/static/robots.txt` is mapped as `/robots.txt`.
+Example: `/static/favicon.ico` is mapped as `/favicon.ico`.
 
 More information about the usage of this directory in [the documentation](https://nuxtjs.org/guide/assets#static).

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,0 @@
-# http://www.robotstxt.org
-User-agent: *
-Disallow:


### PR DESCRIPTION
## :unicorn: Problème
Les sites d'intégration sont aujourd'hui indexés par Google car on utilise toujours la même configuration de crawling.

## :robot: Solution
Ajouter un `Disallow: '/'` dans le robots.txt en fonction d'une variable d'env. Il faut aussi ajouter une balise `<meta name="robots" content="noindex">`.

## :rainbow: Remarques
Ajout d'une var d'env ~`SEO_ENABLE_INDEXATION`~`SEO_ENABLE_INDEXING` à setter sur les différents environnements.

Les vrais sites admin, certif, mon-pix, orga utilisent une clé dépréciée dans le robots.txt `Noindex: /`, il faudra corriger ça.

## :100: Pour tester
Sur les RA :
- Vérifier que la balise `meta` `name="robots"` est bien settée
- Vérifier que le robots.txt a bien la valeur `Disallow: /`

⚠️ Bien vérifier en prod après le déploiement que les valeurs précédantes sont toujours là.
