### PR TITLE
[BUGFIX] Logo Pix qui bouge selon les environnements (PIX-3927)

### DIFF
--- a/components/FooterSliceZone.vue
+++ b/components/FooterSliceZone.vue
@@ -93,7 +93,6 @@ export default {
     justify-content: flex-start;
 
     .logos-zone__content {
-      margin-right: 32px;
       display: inline;
 
       img {


### PR DESCRIPTION
## :unicorn: Problème
Le logo se trouvant dans le le footer bouge de quelques pixels entre la prod et le dev.

## :robot: Solution
- Après vérification, une propriété était inutile dans le SCSS de ".footer-left" vu que les enfants surchargent dans tout les cas cette propriété.

## :rainbow: Remarques
- Possible que le `style scoped` bloque l'override d'une proprieté par les  enfants en Prod.

## :100: Pour tester
- Vérifier que les classes enfants  surchargent bien cette propriété.

exemple : `@media (min-width: 1281px)
.logos-zone .logos-zone__content[data-v-a4949296] {
    margin-right: 24px;
}`

