### PR TITLE
[FEATURE] Ajouter le langage 'FR-BE' dans pix-site (PIX-4035)

### DIFF
--- a/components/PixLink.vue
+++ b/components/PixLink.vue
@@ -58,6 +58,7 @@ function getLocaleUrl(url, localePath) {
   if (
     url.startsWith('/fr') ||
     url.startsWith('/en-gb') ||
+    url.startsWith('/fr-be') ||
     url.startsWith('/fr-fr')
   ) {
     return url

--- a/lang/fr-be.js
+++ b/lang/fr-be.js
@@ -1,0 +1,57 @@
+export default {
+  fr: 'Français',
+  'fr-fr': 'Franco-Français',
+  'en-gb': 'English',
+  'contact-digital-mediation': {
+    'page-title': "Demande d'information",
+    'form-id': '24665',
+  },
+  'higher-education-establishment-registration': {
+    'page-title': 'Demande d’espace Pix Orga',
+    'form-id': '22367',
+  },
+  'pix-certification-application': {
+    'page-title': "Demande d'agrément comme centre de certification Pix",
+    'form-id': '23331',
+  },
+  'pix-orga-registration': {
+    'page-title': "Demande d'information",
+    'form-id': '22370',
+  },
+  'pix-orga-higher-school-registration': {
+    'page-title': "Finalisez votre demande d'espace Pix Orga",
+    'form-id': '22797',
+  },
+  'news-page-title': 'Actualités',
+  'news-page-title-level-two': 'Liste des actualités',
+  'news-page-no-news': "Il n’y a pas encore d'actualités",
+  announcement: 'Annonce',
+  engineering: 'Ingénierie',
+  event: 'Événement',
+  feature: 'Nouveauté',
+  society: 'Société',
+  form: {
+    'not-supported':
+      "Votre navigateur ne supporte pas les iframes. Le formulaire de contact ne peut pas être affiché. Merci d'utiliser une autre méthode de contact (téléphone, fax, etc.)",
+  },
+  'language-switcher-label': 'Langues',
+  'page-titles': {
+    'contact-digital-mediation': "Demande d'information | Pix",
+    'higher-education-establishment-registration':
+      "Demande d'espace | Pix Orga sup",
+    news: 'Actualités | Pix',
+    'pix-certification-application':
+      "Demande d'agrément comme centre de certification | Pix",
+    'pix-orga-higher-school-registration':
+      "Finaliser la demande d'espace | Pix Orga sup",
+    'pix-orga-registration': "Demande d'information | Pix pro",
+  },
+  'preview-page-load': 'Chargement de la page de prévisualisation...',
+  'error-content':
+    '<p>Oups ! Un problème est survenu, mais pas de panix !</p>' +
+    '<p>Vous pouvez revenir sur la ' +
+    "<a href='http://pix.fr/'>page d'accueil</a>." +
+    '<br/>Si vous avez besoin d’aide, vous pouvez consulter le ' +
+    '<a href="https://support.pix.fr/">support</a>.' +
+    '</p>',
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -162,6 +162,10 @@ const config = {
               code: 'en-gb',
               file: 'en-gb.js',
             },
+            {
+              code: 'fr-be',
+              file: 'fr-be.js',
+            },
           ],
     lazy: true,
     langDir: 'lang/',

--- a/pages/pix-site/_custom-page.vue
+++ b/pages/pix-site/_custom-page.vue
@@ -22,6 +22,7 @@ export default {
       fr: '/:uid',
       'fr-fr': '/:uid',
       'en-gb': '/:uid',
+      'fr-be': '/:uid',
     },
   },
   async asyncData({ params, app, req, error, currentPagePath }) {

--- a/pages/pix-site/index.vue
+++ b/pages/pix-site/index.vue
@@ -14,6 +14,7 @@ export default {
       fr: '/',
       'fr-fr': '/',
       'en-gb': '/',
+      'fr-be': '/',
     },
   },
   async asyncData({ app, req, error, currentPagePath }) {


### PR DESCRIPTION
## :unicorn: Problème
Ajouter la possibilité d'avoir un langage "fr-be" à pix mon site.

## :robot: Solution
- Configurer le fichier nuxt.config.js
- Ajouter un fichier de langage

## :rainbow: Remarques


## :100: Pour tester
ajouter dans l'url : /fr-be
Vérifier si  le logo de la fédération Wallonie - Bruxelles se trouve dans le Footer.

