### PR TITLE
[TECH] Utiliser la github action d'auto-merge commune de Pix

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -5,9 +5,6 @@ on:
     types:
       - labeled
       - unlabeled
-  pull_request_review:
-    types:
-      - submitted
   check_suite:
     types:
       - completed

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,6 +14,8 @@ on:
 
 jobs:
   automerge:
-    uses: "1024pix/pix-actions/.github/workflows/auto-merge.yml@v0.1.0"
-    secrets:
-      auto_merge_token: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 1024pix/pix-actions/auto-merge@v0.1.1
+        with:
+          auto_merge_token: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,13 +4,9 @@ on:
   pull_request:
     types:
       - labeled
-      - unlabeled
   check_suite:
     types:
       - completed
-  status:
-    types:
-      - success
 
 jobs:
   automerge:

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,20 +4,19 @@ on:
   pull_request:
     types:
       - labeled
+      - unlabeled
+  pull_request_review:
+    types:
+      - submitted
   check_suite:
     types:
       - completed
+  status:
+    types:
+      - success
 
 jobs:
   automerge:
-    runs-on: ubuntu-latest
-    steps:
-      - name: automerge
-        uses: "pascalgn/automerge-action@v0.14.3"
-        env:
-          GITHUB_TOKEN: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"
-          MERGE_LABELS: ":rocket: Ready to Merge,!:warning: Blocked,!:earth_africa: i18n needed,!:busts_in_silhouette: Panel Review Needed,!Development in progress,!:eyes: Design Review Needed,!:eyes: Func Review Needed,!:eyes: Tech Review Needed"
-          MERGE_COMMIT_MESSAGE: "pull-request-title"
-          UPDATE_LABELS: ":rocket: Ready to Merge"
-          UPDATE_METHOD: "rebase"
-          MERGE_FORKS: "false"
+    uses: "1024pix/pix-actions/.github/workflows/auto-merge.yml@v0.1.0"
+    secrets:
+      auto_merge_token: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"


### PR DESCRIPTION
## :unicorn: Problème
On ne centralise pas pour le moment l'automerge ce qui peut emmener des différences entre les différents repos.

## :robot: Solution
Utiliser un [reusable workflow](https://github.blog/2021-11-29-github-actions-reusable-workflows-is-generally-available/) commun entre nos projets.

## :rainbow: Remarques
RAS

## :100: Pour tester
~Faire une autre PR et vérifier que l'action marche toujours.~
Vérifier que cette PR se merge d'elle même après avoir ajouté le label `:rocket: Ready to Merge` (ça utilise directement l'action de PR).