### PR TITLE
[BUGFIX] Affichage de la bannière de nouveautés

### DIFF
--- a/services/document-fetcher.js
+++ b/services/document-fetcher.js
@@ -24,7 +24,7 @@ export function documentFetcher(
         prismic.predicates.at('document.type', DOCUMENTS.HOT_NEWS),
         { lang }
       )
-      return documents.results
+      return documents.results[0]
     },
     findMainNavigation: async () => {
       const documents = await prismic.api.query(

--- a/tests/services/document-fetcher.test.js
+++ b/tests/services/document-fetcher.test.js
@@ -100,7 +100,7 @@ describe('DocumentFetcher', () => {
       'document.type',
       DOCUMENTS.HOT_NEWS
     )
-    expect(response).toEqual(expectedValue)
+    expect(response).toEqual(expectedValue[0])
   })
 
   test('#findMainNavigation', async () => {


### PR DESCRIPTION
## :unicorn: Problème
La "hot banner news" ne s'affiche plus car le document fetcher renvoie une liste à la place de l'entité Prismic.

## :robot: Solution
Renvoyer l'entité Prismic.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que la bannière s'affiche bien sur la RA.

