### PR TITLE
[TECH] Ajoute un log pour afficher le nombre de routes générées

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,5 +15,7 @@ module.exports = {
   ],
   plugins: ['prettier'],
   // add your custom rules here
-  rules: {},
+  rules: {
+    'no-console': 'off',
+  },
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -212,7 +212,6 @@ if (process.env.MATOMO_URL && process.env.MATOMO_SITE_ID) {
     },
   ])
 } else {
-  // eslint-disable-next-line no-console
   console.warn(
     'Both MATOMO_URL and MATOMO_SITE_ID environment variables must be provided'
   )

--- a/pages/pix-site/index.vue
+++ b/pages/pix-site/index.vue
@@ -41,7 +41,6 @@ export default {
         latestNewsItems,
       }
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.error({ e })
       error({ statusCode: 404, message: 'Page not found' })
     }

--- a/pages/pix-site/news/_slug.vue
+++ b/pages/pix-site/news/_slug.vue
@@ -32,7 +32,6 @@ export default {
       ).getNewsItemByUid(params.slug)
       return { currentPagePath, newsItem }
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.error({ e })
       error({ statusCode: 404, message: 'Page not found' })
     }

--- a/pages/pix-site/news/index.vue
+++ b/pages/pix-site/news/index.vue
@@ -52,7 +52,6 @@ export default {
       ).findNewsItems()
       return { newsItems }
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.error({ e })
       error({ statusCode: 404, message: 'Page not found' })
     }

--- a/services/get-routes-to-generate.js
+++ b/services/get-routes-to-generate.js
@@ -5,10 +5,14 @@ import { DOCUMENTS } from './document-fetcher'
 export default async function () {
   const api = await Prismic.getApi(process.env.PRISMIC_API_ENDPOINT)
   const { routes, totalPages } = await getRoutesInPage(api, 1)
+
   for (let page = 2; page <= totalPages; page++) {
     const { routes: nextPageRoutes } = await getRoutesInPage(api, page)
     routes.push(...nextPageRoutes)
   }
+
+  console.info(`${routes.length} routes will be generated`)
+
   return routes
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui un peu difficile de savoir combien de routes doivent être générées, permet de tracer l'évolution du nombre de pages.

## :robot: Solution
Dans un premier temps : ajouter un petit log pour en savoir plus.

![image](https://user-images.githubusercontent.com/5855339/149918802-c97c8019-fdf3-4fd8-ae7c-ca7700c014e8.png)

## :rainbow: Remarques
Passage de la règle eslint `no-console` à `off` pour toute l'application.

## :100: Pour tester
Rien de spécial à faire, juste un log ajouté :) 