### PR TITLE
[BUGFIX] Ne pas inclure les routes à générer si la langue n'est pas gérée (PIX-4173)

### DIFF
--- a/services/get-routes-to-generate.js
+++ b/services/get-routes-to-generate.js
@@ -1,4 +1,5 @@
 import Prismic from '@prismicio/client'
+import { language } from '../config/language'
 import { SITES_PRISMIC_TAGS } from './available-sites'
 import { DOCUMENTS } from './document-fetcher'
 
@@ -29,8 +30,10 @@ async function getRoutesInPage(api, page) {
     }
   )
 
+  const availableLangs = language.locales.map((locale) => locale.code)
   const routes = results
-    .filter(({ uid, type }) => Boolean(uid))
+    .filter(({ uid }) => Boolean(uid))
+    .filter(({ lang }) => availableLangs.includes(lang))
     .map(({ uid, lang }) => {
       if (lang === 'fr-fr') return `/${uid}`
       return `/${lang}/${uid}`

--- a/tests/services/get-routes-to-generate.test.js
+++ b/tests/services/get-routes-to-generate.test.js
@@ -39,6 +39,37 @@ describe('#getRoutesToGenerate', () => {
     expect(result).toEqual(expected)
   })
 
+  test('it should filter unhandled languages', async () => {
+    // Given
+    const expected = [
+      '/route-to-generate',
+      '/fr/route-to-generate',
+      '/en-gb/route-to-generate',
+    ]
+    const prismicApi = {
+      query: jest.fn().mockResolvedValueOnce({
+        results: [
+          { uid: 'route-to-generate', lang: 'fr-fr' },
+          { uid: 'route-to-generate', lang: 'fr' },
+          { uid: 'route-to-generate', lang: 'en-gb' },
+          { uid: 'route-to-generate', lang: 'xh-ZA' },
+        ],
+      }),
+    }
+    prismic.getApi = () => prismicApi
+
+    // When
+    const result = await getRoutesToGenerate(prismic)
+
+    // Then
+    expect(prismicApi.query).toBeCalledWith(prismicDocPredicates, {
+      lang: '*',
+      pageSize: 100,
+      page: 1,
+    })
+    expect(result).toEqual(expected)
+  })
+
   test('it should not return null routes', async () => {
     // Given
     const expected = ['/route-to-generate']


### PR DESCRIPTION
## :unicorn: Problème
Jusqu'à présent nous n'avions jamais conditionné les langages disponibles. Avec l'arrivée de `fr-be`, certaines pages de type `simple_page` et `form_page` n'arrivent pas à builder en prod car on ne gère pas encore cette langue côté appli.

Lors de la récupération des routes à générer l'API Prismic ne permet de récuperer seulement une langue ou la totalité des langues. 

## :robot: Solution

Le correctif consiste à filtrer les langues, après avoir tout récupéré, si on ne les gère pas dans l'application.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que le build de la RA passe toujours (avec `fr-be`).

Vérifier que le build en local fonctionne toujours (sans `fr-be` => `IS_FR_BE_LANGUAGE_LOCALE_AVAILABLE=false`)