### PR TITLE
[STYLE] Correctifs sur le switch de langue sur Pix.org (PIX-4133).

### DIFF
--- a/components/LanguageSwitcher.vue
+++ b/components/LanguageSwitcher.vue
@@ -201,18 +201,18 @@ export default {
       color: $grey-60;
       letter-spacing: 0.008rem;
       line-height: 1.375rem;
+      margin-bottom: 2px;
       border: none;
       outline: inherit;
       height: 1.5rem;
-      background-size: 1.5rem;
+      background-size: 1.3rem;
+      background-position: 5% 50%;
       padding: 2px 3px 0 30px;
       cursor: pointer;
       background-image: url('/images/globe.svg');
       background-repeat: no-repeat;
-      &:hover,
-      &:focus {
+      &:hover {
         color: $blue;
-        background-image: url('/images/globe-blue.svg');
       }
     }
     &__dropdown-menu {

--- a/components/LanguageSwitcher.vue
+++ b/components/LanguageSwitcher.vue
@@ -300,7 +300,6 @@ export default {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        &:focus,
         &:hover {
           color: $blue;
           background: $grey-10;
@@ -315,7 +314,6 @@ export default {
         width: 100%;
         border: none;
         background: white;
-        &:focus,
         &:hover {
           color: $blue;
           background: $grey-10;

--- a/components/LanguageSwitcherLegacy.vue
+++ b/components/LanguageSwitcherLegacy.vue
@@ -136,10 +136,12 @@ export default {
       color: $grey-60;
       letter-spacing: 0.008rem;
       line-height: 1.375rem;
+      margin-bottom: 2px;
       border: none;
       outline: inherit;
       height: 1.5rem;
-      background-size: 1.5rem;
+      background-size: 1.3rem;
+      background-position: 5% 50%;
       padding: 2px 3px 0 30px;
       cursor: pointer;
       background-image: url('/images/globe.svg');

--- a/components/LanguageSwitcherLegacy.vue
+++ b/components/LanguageSwitcherLegacy.vue
@@ -144,10 +144,8 @@ export default {
       cursor: pointer;
       background-image: url('/images/globe.svg');
       background-repeat: no-repeat;
-      &:hover,
-      &:focus {
+      &:hover {
         color: $blue;
-        background-image: url('/images/globe-blue.svg');
       }
     }
     &__dropdown-menu {

--- a/components/LanguageSwitcherLegacy.vue
+++ b/components/LanguageSwitcherLegacy.vue
@@ -204,7 +204,6 @@ export default {
         line-height: 1.375rem;
         color: $grey-60;
 
-        &:focus,
         &:hover {
           color: $blue-hover;
         }


### PR DESCRIPTION
## :unicorn: Problème

Le comportement du switch de langue diffère des autres éléments de la navbar.
Nous pouvons notamment noter : 
- Effet de hover en lieu et place de l'effet de focus
- Effet de hover qui colore également l'icône associée au switch
- Effet de clignotement sur l'icône au changement de couleur dû au hover
- Taille de l'icône non identique à celle de login

## :robot: Solution

Divers correctifs CSS.

## :rainbow: Remarques

Nous pouvons noter un problème d'a11y lié à ce composant.
En effet lors de la navigation au clavier (après l'application des correctifs CSS), nous pouvons noter que l'effet de focus n'est pas appliqué au switch comme il peut l'être aux autres éléments de navigation.
Cela est dû, je pense, à l'imbrication du composant dans une `div` parente, utilisée par Vue en tant que `root element` nécessaire au template.

⚠️ La tabulation permet toutefois d'accéder aux différentes langues par pression de la barre d'espace et l'accessibilité ne s'en trouve donc que peu altérée. Il s'git avant tout d'un effet visuel.

Je pense qu'un refacto du composant reste possible mais n'est pas la priorité dans le cadre du déploiement en production lundi 24 janvier du site belge, et a donc été remis à plus tard.

## :100: Pour tester

Vérifier que le comportement au hover et focus du switch de langue est identique aux autres composant de la barre de navigation.

