### PR TITLE
[FIX] Correction des redirections vers le site belge renvoyant une page 404.

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -70,7 +70,6 @@ const config = {
    ** Plugins to load before mounting the App
    */
   plugins: [
-    '~/plugins/i18n.js',
     '~/plugins/components.js',
     '~/plugins/meta.js',
     { src: '~plugins/slide-menu', ssr: false },

--- a/plugins/i18n.js
+++ b/plugins/i18n.js
@@ -1,6 +1,0 @@
-export default function ({ app: { $prismic, i18n, store } }) {
-  i18n.onLanguageSwitched = () => {
-    store.dispatch('updateMainNavigations', { prismic: $prismic, i18n })
-    store.dispatch('updateMainFooters', { prismic: $prismic, i18n })
-  }
-}


### PR DESCRIPTION
## :unicorn: Problème

Depuis la mise en production de la version belge de `pix.org`, plusieurs problèmes nous ont été remontés quant à diverses redirections ne s'effectuant pas correctement.

Notamment : 
- A partir de la page des partenaires institutionnels sur `pix.fr`, la redirection renvoie une page 404.
- Idem à partir d'un accès direct au site à partir d'une recherche Google.
- Idem à partir de https://pix.org/fr/federation-wallonie-bruxelles

## :robot: Solution

A partir des accès mentionnés ci-dessus, un appel au store est fait dans le plugin `i18n.js`. Or le store a été supprimé dans la PR #320. L'appel à la fonction engendre donc une erreur.
La suppression de ce plugin entraine le rechargement de la page sans passer par le store, corrigeant l'erreur.

## :rainbow: Remarques
N/A

## :100: Pour tester

Aller sur la RA et essayer les différents liens, constater que nous ne sommes plus redirigés vers une page 404.
Vérifier qu'il n'y ait pas d'erreur en console. (notamment liées à i18n)

