### PR TITLE
[BUGFIX] Les URLs inter-locales ne fonctionnent pas correctement

### DIFF
--- a/components/PixLink.vue
+++ b/components/PixLink.vue
@@ -23,23 +23,22 @@ export default {
         return null
       }
       let template = ''
-      const url = prismicDOM.Link.url(this.field, this.$prismic.linkResolver)
-      const relativeLinkPrefix = getRelativeLinkPrefix(url)
+      let url = prismicDOM.Link.url(this.field, this.$prismic.linkResolver)
+
+      url = removeHostIfCurrentSite(url, this.$i18n.locale)
 
       if (this.field.link_type === 'Document') {
-        const localeURL = getLocaleUrl(url, this.localePath)
+        const localeURL = getLocaleURL(url, this.$i18n, this.localePath)
         template = `
-          <router-link to="${localeURL}" exact>
+          <nuxt-link to="${localeURL}" exact>
             <slot/>
-          </router-link>
+          </nuxt-link>
         `
-      } else if (relativeLinkPrefix) {
-        const relativeUrl = url.replace(relativeLinkPrefix, '/')
-        const localeURL = getLocaleUrl(relativeUrl, this.localePath)
+      } else if (isCurrentLocaleURL(url, this.$i18n)) {
         template = `
-          <router-link to="${localeURL}" exact>
+          <nuxt-link to="${url}" exact>
             <slot/>
-          </router-link>
+          </nuxt-link>
         `
       } else {
         const target = this.field.target
@@ -56,31 +55,56 @@ export default {
   },
 }
 
-function getLocaleUrl(url, localePath) {
-  if (
-    url.startsWith('/fr') ||
-    url.startsWith('/en-gb') ||
-    (process.env.IS_FR_BE_LANGUAGE_LOCALE_AVAILABLE === 'true' &&
-      url.startsWith('/fr-be')) ||
-    url.startsWith('/fr-fr')
-  ) {
-    return url
-  }
+export function isCurrentLocaleURL(url, $i18n) {
+  if (!url.startsWith('/')) return false
+
+  const locale = getPathLocale(url, $i18n) ?? $i18n.defaultLocale
+  return locale === $i18n.locale
+}
+
+function getLocaleURL(url, $i18n, localePath) {
+  if (!url.startsWith('/') || getPathLocale(url, $i18n)) return url
   return localePath(url)
 }
 
-function getRelativeLinkPrefix(url) {
-  if (!url) {
-    return ''
+export function getPathLocale(path, $i18n) {
+  const localeCodesWithoutDefault = $i18n.localeCodes.filter(
+    (code) => code !== $i18n.defaultLocale
+  )
+
+  const rootMatch = new RegExp(
+    `^/(${localeCodesWithoutDefault.join('|')})$`
+  ).exec(path)
+  if (rootMatch != null) return rootMatch[1]
+
+  const pageMatch = new RegExp(
+    `^/(${localeCodesWithoutDefault.join('|')})/`
+  ).exec(path)
+  if (pageMatch != null) return pageMatch[1]
+
+  return undefined
+}
+
+export function removeHostIfCurrentSite(url, locale) {
+  try {
+    const parsedURL = new URL(url)
+
+    if (!isCurrentSiteURL(parsedURL, locale)) return url
+
+    return parsedURL.pathname + parsedURL.search + parsedURL.hash
+  } catch (e) {
+    // relative URL
+    return url
   }
-  const relativeLinkPrefixes =
-    process.env.SITE === SITES_PRISMIC_TAGS.PIX_PRO
-      ? ['https://pro.pix.fr']
-      : ['https://pix.org', 'https://pix.fr']
-  return relativeLinkPrefixes
-    .map((relativeLinkPrefix) =>
-      url.startsWith(relativeLinkPrefix) ? `${relativeLinkPrefix}/` : ''
-    )
-    .filter((relativeLinkPrefix) => relativeLinkPrefix !== '')[0]
+}
+
+function isCurrentSiteURL(url, locale) {
+  return url.host === getCurrentSiteHost(locale)
+}
+
+function getCurrentSiteHost(locale) {
+  if (process.env.SITE === SITES_PRISMIC_TAGS.PIX_PRO) return 'pro.pix.fr'
+  if (locale === 'fr-fr') return 'pix.fr'
+  return 'pix.org'
 }
 </script>

--- a/tests/components/PixLink.test.js
+++ b/tests/components/PixLink.test.js
@@ -1,0 +1,246 @@
+import {
+  removeHostIfCurrentSite,
+  getPathLocale,
+  isCurrentLocaleURL,
+} from '~/components/PixLink'
+import { SITES_PRISMIC_TAGS } from '~/services/available-sites'
+
+describe('Component: PixLink', () => {
+  describe('#removeHostIfCurrentSite', () => {
+    let locale
+
+    describe('when current site is pix.fr', () => {
+      beforeEach(() => {
+        process.env.SITE = SITES_PRISMIC_TAGS.PIX_SITE
+        locale = 'fr-fr'
+      })
+
+      it('should remove host from URLs for https://pix.fr', () => {
+        const urls = [
+          ['https://pix.fr/', '/'],
+          ['https://pix.fr/pourquoi', '/pourquoi'],
+          [
+            'https://pix.fr/la/totale?foo=bar#la-precision',
+            '/la/totale?foo=bar#la-precision',
+          ],
+        ]
+
+        for (const [url, expected] of urls) {
+          expect(removeHostIfCurrentSite(url, locale)).toBe(expected)
+        }
+      })
+
+      it('should not remove host from URLs outside of https://pix.fr', () => {
+        const urls = [
+          'https://pro.pix.fr/',
+          'https://pro.pix.fr/une-page-de-pro',
+          'https://pix.org/fr',
+          'https://pix.org/fr/une-page-si-t-es-pas-en-france',
+          'https://pix.org/fr-be',
+          'https://pix.org/fr-be/une-fois',
+          'https://pix.org/en-gb',
+          'https://pix.org/en-gb/tea-time',
+          'https://google.com/',
+        ]
+
+        for (const url of urls) {
+          expect(removeHostIfCurrentSite(url, locale)).toBe(url)
+        }
+      })
+    })
+
+    describe('when current site is pix.org', () => {
+      beforeEach(() => {
+        process.env.SITE = SITES_PRISMIC_TAGS.PIX_SITE
+        locale = 'fr'
+      })
+
+      it('should remove host from URLs for https://pix.org', () => {
+        const urls = [
+          ['https://pix.org/', '/'],
+          ['https://pix.org/fr', '/fr'],
+          ['https://pix.org/fr/pourquoi', '/fr/pourquoi'],
+          [
+            'https://pix.org/fr/la/totale?foo=bar#la-precision',
+            '/fr/la/totale?foo=bar#la-precision',
+          ],
+          ['https://pix.org/fr-be/une-fois', '/fr-be/une-fois'],
+          ['https://pix.org/en-gb/tea-time', '/en-gb/tea-time'],
+        ]
+
+        for (const [url, expected] of urls) {
+          expect(removeHostIfCurrentSite(url, locale)).toBe(expected)
+        }
+      })
+
+      it('should not remove host from URLs outside of https://pix.org', () => {
+        const urls = [
+          'https://pro.pix.fr/',
+          'https://pro.pix.fr/une-page-de-pro',
+          'https://pix.fr',
+          'https://pix.fr/une-page-de-la-france',
+          'https://google.com/',
+        ]
+
+        for (const url of urls) {
+          expect(removeHostIfCurrentSite(url, locale)).toBe(url)
+        }
+      })
+    })
+
+    describe('when current site is pro.pix.fr', () => {
+      beforeEach(() => {
+        process.env.SITE = SITES_PRISMIC_TAGS.PIX_PRO
+      })
+
+      it('should remove host from URLs under https://pro.pix.org', () => {
+        const urls = [
+          ['https://pro.pix.fr/', '/'],
+          ['https://pro.pix.fr/une-page-de-pro', '/une-page-de-pro'],
+        ]
+
+        for (const [url, expected] of urls) {
+          expect(removeHostIfCurrentSite(url, locale)).toBe(expected)
+        }
+      })
+
+      it('should not remove host from URLs outside of https://pro.pix.org', () => {
+        const urls = [
+          'https://pix.fr',
+          'https://pix.fr/une-page-de-la-france',
+          'https://pix.org/',
+          'https://pix.org/fr',
+          'https://pix.org/fr/pourquoi',
+          'https://pix.org/fr-be/une-fois',
+          'https://pix.org/en-gb/tea-time',
+          'https://google.com/',
+        ]
+
+        for (const url of urls) {
+          expect(removeHostIfCurrentSite(url, locale)).toBe(url)
+        }
+      })
+    })
+  })
+
+  describe('#getPathLocale', () => {
+    let $i18n
+
+    beforeEach(() => {
+      $i18n = {
+        localeCodes: ['fr-fr', 'fr', 'fr-be', 'en-gb'],
+        defaultLocale: 'fr-fr',
+      }
+    })
+
+    it('should extract the locale from the given path', () => {
+      const paths = [
+        ['/fr', 'fr'],
+        ['/fr-be', 'fr-be'],
+        ['/en-gb', 'en-gb'],
+        ['/fr/path', 'fr'],
+        ['/fr-be/path', 'fr-be'],
+        ['/en-gb/path', 'en-gb'],
+        ['/fr/path/subpath', 'fr'],
+        ['/fr-be/path/subpath', 'fr-be'],
+        ['/en-gb/path/subpath', 'en-gb'],
+      ]
+
+      for (const [path, expectedLocale] of paths) {
+        expect(getPathLocale(path, $i18n)).toBe(expectedLocale)
+      }
+    })
+
+    it("should return undefined if the given path doesn't contain a locale", () => {
+      const paths = ['/', '/path', '/en-us']
+
+      for (const path of paths) {
+        expect(getPathLocale(path, $i18n)).toBeUndefined()
+      }
+    })
+
+    it('should return undefined if the given path contains default locale', () => {
+      const paths = ['/fr-fr', '/fr-fr/path', '/fr-fr/path/subpath']
+
+      for (const path of paths) {
+        expect(getPathLocale(path, $i18n)).toBeUndefined()
+      }
+    })
+  })
+
+  describe('#isCurrentLocaleURL', () => {
+    let $i18n
+
+    beforeEach(() => {
+      $i18n = {
+        localeCodes: ['fr-fr', 'fr', 'fr-be', 'en-gb'],
+        defaultLocale: 'fr-fr',
+      }
+    })
+
+    it('should return false if the given URL is absolute', () => {
+      const urls = [
+        'https://pix.fr',
+        'https://pix.fr/une-page',
+        'https://pix.org/fr',
+        'https://google.com/',
+      ]
+
+      for (const url of urls) {
+        expect(isCurrentLocaleURL(url, $i18n)).toBe(false)
+      }
+    })
+
+    describe('when current locale is fr-fr', () => {
+      beforeEach(() => {
+        $i18n.locale = 'fr-fr'
+      })
+
+      it('should return true if the given URL is in fr-fr', () => {
+        const urls = ['/', '/une-page', '/path/subpath', '/fr-ca/tabernacle']
+
+        for (const url of urls) {
+          expect(isCurrentLocaleURL(url, $i18n)).toBe(true)
+        }
+      })
+
+      it('should return false if the given URL is outside of fr-fr', () => {
+        const urls = ['/fr', '/en-gb', '/fr/une-page', '/en-gb/path/subpath']
+
+        for (const url of urls) {
+          expect(isCurrentLocaleURL(url, $i18n)).toBe(false)
+        }
+      })
+    })
+
+    describe('when current locale is fr-be', () => {
+      beforeEach(() => {
+        $i18n.locale = 'fr-be'
+      })
+
+      it('should return true if the given URL is in fr-be', () => {
+        const urls = ['/fr-be', '/fr-be/une-fois', '/fr-be/path/subpath']
+
+        for (const url of urls) {
+          expect(isCurrentLocaleURL(url, $i18n)).toBe(true)
+        }
+      })
+
+      it('should return false if the given URL is outside of fr-be', () => {
+        const urls = [
+          '/',
+          '/une-page',
+          '/path/subpath',
+          '/fr',
+          '/en-gb',
+          '/fr/une-page',
+          '/en-gb/path/subpath',
+        ]
+
+        for (const url of urls) {
+          expect(isCurrentLocaleURL(url, $i18n)).toBe(false)
+        }
+      })
+    })
+  })
+})


### PR DESCRIPTION
## :unicorn: Problème

Les liens inter-locales ne fonctionnent pas correctement, nuxt ne prend pas vraiment en compte le changement de locale:
 - Les liens du menus pointent toujours vers l'ancienne locale
 - Le logo FWB n'apparait pas...

Exemple sur la page https://pix.org/fr/federation-wallonie-bruxelles, le bouton "Aller sur le site de Pix en FWB".

## :robot: Solution

Utiliser des liens classiques (`<a href>`) pour ces liens à la place du routeur nuxt/vue.

## :rainbow: Remarques

Suite aux refactorings effectués, on est plus strict sur les liens reçus de Prismic, quelques exemples de liens qui ne fonctionnent plus et qui ont du être corrigés dans Prismic :

 - Sur pix.org/fr
   - https://pix.fr/fr/score-et-niveaux
   - https://pix.org/contactez-nous
   - https://pix.org/actualites
- Sur pix.org/en-gb
   - https://pix.org/terms-and-conditions
   - https://pix.org/news
   - https://pix.org/legal-notice

## :100: Pour tester

Vérifier que le déploiement ne casse pas.

Se balader sur pix.fr - pix.org dans les différentes locales/