### PR TITLE
[FEATURE] Ajoute le Language Switcher sur pix.fr (PIX-4302)

### DIFF
--- a/components/LanguageSwitcher.vue
+++ b/components/LanguageSwitcher.vue
@@ -128,14 +128,11 @@ export default {
     const availableLocales = this.$i18n.locales.map((locale) => {
       return { code: locale.code, lang: locale.code }
     })
-    const languageLocales = availableLocales.filter(
-      (locale) => locale.lang !== 'fr-fr'
-    )
     const languages = language
     return {
       showMenu: false,
       showSubMenu: false,
-      languageLocales,
+      languageLocales: availableLocales,
       languages,
     }
   },

--- a/components/LanguageSwitcher.vue
+++ b/components/LanguageSwitcher.vue
@@ -11,7 +11,7 @@
       :aria-expanded="showMenu.toString()"
       @click.stop.prevent="toggleMenu()"
     >
-      {{ currentLanguage.name }}
+      {{ $t(currentLanguage.code) }}
       <fa v-if="showMenu" icon="angle-up" />
       <fa v-else icon="angle-down" />
     </button>
@@ -126,7 +126,7 @@ export default {
   },
   data() {
     const availableLocales = this.$i18n.locales.map((locale) => {
-      return { name: this.$t(locale.code), lang: locale.code }
+      return { code: locale.code, lang: locale.code }
     })
     const languageLocales = availableLocales.filter(
       (locale) => locale.lang !== 'fr-fr'

--- a/components/LanguageSwitcher.vue
+++ b/components/LanguageSwitcher.vue
@@ -41,7 +41,7 @@
           <a
             v-else-if="option.target"
             :href="
-              getAbsoluteUrlIfSwitchWebsite(option.target, option.isOnPixOrg)
+              useGetAbsoluteUrlIfSwitchWebsite(option.target, option.isOnPixOrg)
             "
           >
             <img
@@ -72,7 +72,10 @@
             <div class="language-switcher__lang">
               <a
                 :href="
-                  getAbsoluteUrlIfSwitchWebsite(child.target, child.isOnPixOrg)
+                  useGetAbsoluteUrlIfSwitchWebsite(
+                    child.target,
+                    child.isOnPixOrg
+                  )
                 "
               >
                 {{ $t(child.name) }}
@@ -113,7 +116,10 @@
           >
             <a
               :href="
-                getAbsoluteUrlIfSwitchWebsite(option.target, option.isOnPixOrg)
+                useGetAbsoluteUrlIfSwitchWebsite(
+                  option.target,
+                  option.isOnPixOrg
+                )
               "
             >
               {{ $t(option.name) }}
@@ -154,8 +160,7 @@ export default {
     },
     selectedMenu() {
       return this.languages.menu
-        .map((menuItem) => menuItem.children ?? menuItem)
-        .flat()
+        .flatMap((menuItem) => menuItem.children ?? menuItem)
         .find((locale) => locale.lang === this.currentLocaleCode)
     },
   },
@@ -178,27 +183,38 @@ export default {
       this.showMenu = false
       this.showSubMenu = false
     },
-    getAbsoluteUrlIfSwitchWebsite(relativeTarget, isTargetOnPixOrg) {
-      if (!this.selectedMenu.isOnPixOrg && isTargetOnPixOrg) {
-        const orgBaseUrl = getBaseUrl(process.env.DOMAIN_ORG)
-        return new URL(relativeTarget, orgBaseUrl)
-      }
-
-      if (this.selectedMenu.isOnPixOrg && !isTargetOnPixOrg) {
-        const frBaseUrl = getBaseUrl(process.env.DOMAIN_FR)
-        return new URL(relativeTarget, frBaseUrl)
-      }
-
-      return relativeTarget
+    useGetAbsoluteUrlIfSwitchWebsite(relativeTarget, isTargetOnPixOrg) {
+      return getAbsoluteUrlIfSwitchWebsite(
+        relativeTarget,
+        isTargetOnPixOrg,
+        this.selectedMenu.isOnPixOrg
+      )
     },
   },
 }
 
 /**
- * Add current URL scheme to a domain (http:// or https://)
+ * Adds current URL scheme to a domain (http:// or https://)
  */
 function getBaseUrl(domain) {
   return new URL(`//${domain}`, document.location)
+}
+export function getAbsoluteUrlIfSwitchWebsite(
+  relativeTarget,
+  isTargetOnPixOrg,
+  isOnPixOrg
+) {
+  if (!isOnPixOrg && isTargetOnPixOrg) {
+    const orgBaseUrl = getBaseUrl(process.env.DOMAIN_ORG)
+    return new URL(relativeTarget, orgBaseUrl).href
+  }
+
+  if (isOnPixOrg && !isTargetOnPixOrg) {
+    const frBaseUrl = getBaseUrl(process.env.DOMAIN_FR)
+    return new URL(relativeTarget, frBaseUrl).href
+  }
+
+  return relativeTarget
 }
 </script>
 

--- a/components/LanguageSwitcher.vue
+++ b/components/LanguageSwitcher.vue
@@ -141,11 +141,7 @@ export default {
   },
   computed: {
     showLanguageDropdown() {
-      return (
-        process.env.SITE === SITES_PRISMIC_TAGS.PIX_SITE &&
-        this.$config.languageSwitchEnabled &&
-        this.$i18n.locale !== 'fr-fr'
-      )
+      return process.env.SITE === SITES_PRISMIC_TAGS.PIX_SITE
     },
     currentLocale() {
       return this.$i18n.locale || this.$i18n.defaultLocale

--- a/components/LanguageSwitcher.vue
+++ b/components/LanguageSwitcher.vue
@@ -38,7 +38,12 @@
               class="language-switcher__icon"
             />
           </button>
-          <a v-else-if="option.target" :href="option.target">
+          <a
+            v-else-if="option.target"
+            :href="
+              getAbsoluteUrlIfSwitchWebsite(option.target, option.isOnPixOrg)
+            "
+          >
             <img
               class="language-switcher__img"
               :src="'/images/' + option.icon"
@@ -65,7 +70,11 @@
             }"
           >
             <div class="language-switcher__lang">
-              <a :href="child.target">
+              <a
+                :href="
+                  getAbsoluteUrlIfSwitchWebsite(child.target, child.isOnPixOrg)
+                "
+              >
                 {{ $t(child.name) }}
               </a>
             </div>
@@ -102,7 +111,11 @@
                 option.lang === currentLanguage.lang,
             }"
           >
-            <a :href="option.target">
+            <a
+              :href="
+                getAbsoluteUrlIfSwitchWebsite(option.target, option.isOnPixOrg)
+              "
+            >
               {{ $t(option.name) }}
             </a>
           </span>
@@ -115,6 +128,7 @@
 <script>
 import { SITES_PRISMIC_TAGS } from '~/services/available-sites'
 import { language } from '~/config/language'
+import { getCurrentSiteHost } from '~/services/get-current-site-host'
 
 export default {
   name: 'LanguageSwitcher',
@@ -167,6 +181,16 @@ export default {
     hideMenu() {
       this.showMenu = false
       this.showSubMenu = false
+    },
+    getAbsoluteUrlIfSwitchWebsite(target, isOnPixOrg) {
+      const currentSiteHost = getCurrentSiteHost(this.currentLocale)
+      if (currentSiteHost === 'pix.fr' && isOnPixOrg) {
+        return process.env.DOMAIN_ORG + target
+      } else if (currentSiteHost === 'pix.org' && !isOnPixOrg) {
+        return process.env.DOMAIN_FR + target
+      }
+
+      return target
     },
   },
 }

--- a/components/LanguageSwitcher.vue
+++ b/components/LanguageSwitcher.vue
@@ -11,7 +11,7 @@
       :aria-expanded="showMenu.toString()"
       @click.stop.prevent="toggleMenu()"
     >
-      {{ $t(currentLanguage.code) }}
+      {{ $t(currentLocale) }}
       <fa v-if="showMenu" icon="angle-up" />
       <fa v-else icon="angle-down" />
     </button>
@@ -21,7 +21,7 @@
         :key="option.key"
         :class="{
           'language-switcher__dropdown-menu--active':
-            option.lang === currentLanguage.lang,
+            option.lang === currentLocale,
         }"
       >
         <div class="language-switcher__lang">
@@ -66,7 +66,7 @@
             :key="child.key"
             :class="{
               'language-switcher__dropdown-menu--active':
-                child.lang === currentLanguage.lang,
+                child.lang === currentLocale,
             }"
           >
             <div class="language-switcher__lang">
@@ -94,7 +94,7 @@
             :class="{
               'language-switcher-burger-menu__lang': true,
               'language-switcher-burger-menu--active':
-                child.lang === currentLanguage.lang,
+                child.lang === currentLocale,
             }"
           >
             <a :href="child.target">
@@ -108,7 +108,7 @@
             :class="{
               'language-switcher-burger-menu__lang': true,
               'language-switcher-burger-menu--active':
-                option.lang === currentLanguage.lang,
+                option.lang === currentLocale,
             }"
           >
             <a
@@ -139,14 +139,10 @@ export default {
     },
   },
   data() {
-    const availableLocales = this.$i18n.locales.map((locale) => {
-      return { code: locale.code, lang: locale.code }
-    })
     const languages = language
     return {
       showMenu: false,
       showSubMenu: false,
-      languageLocales: availableLocales,
       languages,
     }
   },
@@ -156,11 +152,6 @@ export default {
     },
     currentLocale() {
       return this.$i18n.locale || this.$i18n.defaultLocale
-    },
-    currentLanguage() {
-      return this.languageLocales.find(
-        (locale) => locale.lang === this.currentLocale
-      )
     },
   },
   mounted() {

--- a/components/PixLink.vue
+++ b/components/PixLink.vue
@@ -6,7 +6,7 @@
 
 <script>
 import prismicDOM from 'prismic-dom'
-import { SITES_PRISMIC_TAGS } from '~/services/available-sites'
+import { getCurrentSiteHost } from '~/services/get-current-site-host'
 
 export default {
   name: 'PixLink',
@@ -100,11 +100,5 @@ export function removeHostIfCurrentSite(url, locale) {
 
 function isCurrentSiteURL(url, locale) {
   return url.host === getCurrentSiteHost(locale)
-}
-
-function getCurrentSiteHost(locale) {
-  if (process.env.SITE === SITES_PRISMIC_TAGS.PIX_PRO) return 'pro.pix.fr'
-  if (locale === 'fr-fr') return 'pix.fr'
-  return 'pix.org'
 }
 </script>

--- a/config/language.js
+++ b/config/language.js
@@ -13,6 +13,7 @@ export const language = {
           lang: 'fr',
           icon: 'icon',
           target: '/fr',
+          isOnPixOrg: true,
           sub: null,
         },
         {
@@ -20,6 +21,7 @@ export const language = {
           lang: 'en-gb',
           icon: 'icon',
           target: '/en-gb',
+          isOnPixOrg: true,
           sub: null,
         },
       ],
@@ -29,6 +31,7 @@ export const language = {
       lang: 'fr-fr',
       icon: 'flag-fr.svg',
       target: '/',
+      isOnPixOrg: false,
       sub: null,
     },
     {
@@ -36,6 +39,7 @@ export const language = {
       lang: 'fr-be',
       icon: 'flag-be.svg',
       target: '/fr-be',
+      isOnPixOrg: true,
       sub: 'fwb',
     },
   ],

--- a/config/language.js
+++ b/config/language.js
@@ -26,7 +26,7 @@ export const language = {
     },
     {
       name: 'france',
-      lang: '',
+      lang: 'fr-fr',
       icon: 'flag-fr.svg',
       target: 'https://www.pix.fr',
       sub: null,

--- a/config/language.js
+++ b/config/language.js
@@ -28,7 +28,7 @@ export const language = {
       name: 'france',
       lang: 'fr-fr',
       icon: 'flag-fr.svg',
-      target: 'https://www.pix.fr',
+      target: '/',
       sub: null,
     },
     {

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -1,6 +1,6 @@
 export default {
   fr: 'International FR',
-  'fr-fr': 'International FR',
+  'fr-fr': 'France',
   'en-gb': 'International EN',
   'fr-be': 'FWB',
   france: 'France',

--- a/lang/fr-be.js
+++ b/lang/fr-be.js
@@ -1,6 +1,6 @@
 export default {
-  fr: 'France',
-  'fr-fr': 'International FR',
+  fr: 'International FR',
+  'fr-fr': 'France',
   'en-gb': 'International EN',
   'fr-be': 'FWB',
   france: 'France',

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -1,6 +1,6 @@
 export default {
-  fr: 'France',
-  'fr-fr': 'International FR',
+  fr: 'International FR',
+  'fr-fr': 'France',
   'en-gb': 'International EN',
   'fr-be': 'FWB',
   france: 'France',

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -1,6 +1,6 @@
 export default {
   fr: 'International FR',
-  'fr-fr': 'International FR',
+  'fr-fr': 'France',
   'en-gb': 'International EN',
   'fr-be': 'FWB',
   france: 'France',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -8,7 +8,6 @@ const config = {
   generate: { routes, fallback: '404.html' },
   target: 'static',
   publicRuntimeConfig: {
-    orgDomain: process.env.DOMAIN_ORG || 'pix.org',
     formKeysToMap: process.env.FORM_KEYS_TO_MAP || {},
   },
   server: {
@@ -17,6 +16,8 @@ const config = {
   env: {
     // Nuxt env are required to be usable client-side (e.g.: PixLink)
     SITE: process.env.SITE,
+    DOMAIN_ORG: process.env.DOMAIN_ORG,
+    DOMAIN_FR: process.env.DOMAIN_FR,
   },
   dir: {
     pages: `pages/${process.env.SITE}`,
@@ -190,6 +191,14 @@ const config = {
       },
     },
   },
+}
+
+if (process.env.DOMAIN_ORG === undefined) {
+  throw new Error(`The DOMAIN_ORG environment variable must be provided`)
+}
+
+if (process.env.DOMAIN_FR === undefined) {
+  throw new Error(`The DOMAIN_FR environment variable must be provided`)
 }
 
 const availablesSites = Object.values(SITES_PRISMIC_TAGS)

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -8,7 +8,6 @@ const config = {
   generate: { routes, fallback: '404.html' },
   target: 'static',
   publicRuntimeConfig: {
-    languageSwitchEnabled: process.env.LANGUAGE_SWITCH_ENABLED === 'true',
     orgDomain: process.env.DOMAIN_ORG || 'pix.org',
     formKeysToMap: process.env.FORM_KEYS_TO_MAP || {},
   },

--- a/scalingo.json
+++ b/scalingo.json
@@ -4,10 +4,17 @@
     "REVIEW_APP": {
       "description": "Indicates that the application is a review app",
       "value": "true"
+    },
+    "DOMAIN_ORG": {
+      "generator": "template",
+      "template": "https://site-pr%PR_NUMBER%.review.pix.org"
+    },
+    "DOMAIN_FR": {
+      "generator": "template",
+      "template": "https://site-pr%PR_NUMBER%.review.pix.fr"
     }
   },
-  "addons": [
-  ],
+  "addons": [],
   "formation": {
     "web": {
       "amount": 1,
@@ -15,4 +22,3 @@
     }
   }
 }
-

--- a/scalingo.json
+++ b/scalingo.json
@@ -7,11 +7,11 @@
     },
     "DOMAIN_ORG": {
       "generator": "template",
-      "template": "https://site-pr%PR_NUMBER%.review.pix.org"
+      "template": "site-pr%PR_NUMBER%.review.pix.org"
     },
     "DOMAIN_FR": {
       "generator": "template",
-      "template": "https://site-pr%PR_NUMBER%.review.pix.fr"
+      "template": "site-pr%PR_NUMBER%.review.pix.fr"
     }
   },
   "addons": [],

--- a/services/get-current-site-host.js
+++ b/services/get-current-site-host.js
@@ -1,0 +1,7 @@
+import { SITES_PRISMIC_TAGS } from './available-sites'
+
+export function getCurrentSiteHost(locale) {
+  if (process.env.SITE === SITES_PRISMIC_TAGS.PIX_PRO) return 'pro.pix.fr'
+  if (locale === 'fr-fr') return 'pix.fr'
+  return 'pix.org'
+}

--- a/tests/components/LanguageSwitcher.test.js
+++ b/tests/components/LanguageSwitcher.test.js
@@ -1,0 +1,46 @@
+import { getAbsoluteUrlIfSwitchWebsite } from '~/components/LanguageSwitcher'
+
+describe('Component: LanguageSwitcher', () => {
+  describe('#getAbsoluteUrlIfSwitchWebsite', () => {
+    beforeEach(() => {
+      process.env.DOMAIN_FR = 'pix.fr'
+      process.env.DOMAIN_ORG = 'pix.org'
+    })
+    it('Should return relative url if target is in domain', () => {
+      const switchMenu = [
+        {
+          relativeTarget: '/',
+          isTargetOnPixOrg: false,
+          isOnPixOrg: false,
+          response: '/',
+        },
+        {
+          relativeTarget: '/fr-be',
+          isTargetOnPixOrg: true,
+          isOnPixOrg: false,
+          response: 'http://pix.org/fr-be',
+        },
+        {
+          relativeTarget: '/en-gb',
+          isTargetOnPixOrg: true,
+          isOnPixOrg: true,
+          response: '/en-gb',
+        },
+        {
+          relativeTarget: '/',
+          isTargetOnPixOrg: false,
+          isOnPixOrg: true,
+          response: 'http://pix.fr/',
+        },
+      ]
+      for (const item of switchMenu) {
+        const url = getAbsoluteUrlIfSwitchWebsite(
+          item.relativeTarget,
+          item.isTargetOnPixOrg,
+          item.isOnPixOrg
+        )
+        expect(url).toBe(item.response)
+      }
+    })
+  })
+})

--- a/tests/services/get-current-site-host.test.js
+++ b/tests/services/get-current-site-host.test.js
@@ -1,0 +1,27 @@
+const { getCurrentSiteHost } = require('~/services/get-current-site-host')
+
+describe('getCurrentSiteHost', () => {
+  let savedProcessEnvSite
+  beforeEach(() => {
+    savedProcessEnvSite = process.env.SITE
+  })
+
+  afterEach(() => {
+    process.env.SITE = savedProcessEnvSite
+  })
+
+  test('should return pix.fr if `SITE` env variable is `pix-site` and locale `fr-fr`', () => {
+    process.env.SITE = 'pix-site'
+    expect(getCurrentSiteHost('fr-fr')).toBe('pix.fr')
+  })
+
+  test('should return pix.org if `SITE` env variable is `pix-site` and locale not `fr-fr`', () => {
+    process.env.SITE = 'pix-site'
+    expect(getCurrentSiteHost('fr')).toBe('pix.org')
+  })
+
+  test('should return pro.pix.fr if `SITE` env variable is `pix-pro`', () => {
+    process.env.SITE = 'pix-pro'
+    expect(getCurrentSiteHost()).toBe('pro.pix.fr')
+  })
+})


### PR DESCRIPTION
## :unicorn: Problème
Le Language Switcher n'est disponible que sur pix.org.

## :robot: Solution
Ajouter le Language Switcher sur pix.fr.

## :rainbow: Remarques
### Variables d'environnement
- Suppression de la variable d'environnement `LANGUAGE_SWITCH_ENABLED`
- Déplacement de la variable d'environnement `DOMAIN_ORG` du `publicRuntimeConfig` au `env` (elle n'est pas nécessaire au runtime)
- Suppression de la valeur par défaut "pix.org" de cette variable
- Modification du format de la variable d'environnement `DOMAIN_ORG` : elle doit maintenant contenir le lien absolu sans slash à la fin
- Pareil pour `DOMAIN_FR`

### DX
Il est maintenant possible de naviguer en dev entre "pix.fr" et "pix.org". Comme en prod : les urls `/` correspondent à "fr-fr" (pix.fr) et les `/fr`/`fr-be`/`en-gb` correspondent à pix.org. On se base sur une nouvelle clé `isOnPixOrg` pour savoir si la redirection est nécessaire.

Sur les Review Apps, la navigation entre pix.fr et pix.org dans le Language Switcher nous envoyait en prod. On se base maintenant sur les valeurs de `DOMAIN_ORG` et `DOMAIN_FR`. Il est donc maintenant possible de naviguer entre "pix.fr" et "pix.org" tout en restant sur l'environnement courant (plus de bascule vers la prod !)

### Aller plus loin
Il serait intéressant de brancher le Language Switcher à `PixLink` pour ne pas avoir à recharger entièrement la page au changement de langue. À voir dans une prochaine PR.

## :100: Pour tester
En local, remettre à jour les variables d'environnement `DOMAIN_ORG` et `DOMAIN_FR` à `localhost:5000` pour permettre la navigation entre les deux sites. Tous les liens doivent pouvoir fonctionner.