### PR TITLE
[FEATURE] Ajoute de l'espacement en dessous du language switcher du burger menu

### DIFF
--- a/components/LanguageSwitcher.vue
+++ b/components/LanguageSwitcher.vue
@@ -381,7 +381,7 @@ export function getAbsoluteUrlIfSwitchWebsite(
 }
 
 .language-switcher-burger-menu {
-  margin: 0;
+  margin: 0 0 50px 0;
   font-size: 1rem;
   line-height: 1.5rem;
   color: $grey-30;


### PR DESCRIPTION
## :unicorn: Problème
Dans le burger menu, le language switcher est collé au bas de l'écran.

## :robot: Solution
Ajoute une marge pour éviter que ce soit collé au bas de l'écran.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que le burger menu est plus facile à utiliser comme ça.

