### PR TITLE
[BUGFIX] Permettre d'afficher 4 blocks dans les multiple blocks "process" quelque soit la résolution (PIX-4012)

### DIFF
--- a/assets/scss/components/slices/process.scss
+++ b/assets/scss/components/slices/process.scss
@@ -23,13 +23,11 @@
     padding: 48px 10%;
     display: flex;
     flex-direction: column;
-    align-items: center;
   }
 }
 
 .process-wrapper {
   &__item {
-    width: 293px;
     padding: 24px;
     box-shadow: 0 24px 32px 0 rgba($grey-200, 0.03),
       0 8px 32px 0 rgba($grey-200, 0.06);
@@ -79,14 +77,28 @@
 }
 
 @include device-is('large-screen') {
+  $gap: 56px;
+
   .process {
     &__wrapper {
       display: flex;
       flex-direction: row;
-      gap: 56px;
+      gap: $gap;
       flex-wrap: wrap;
-      justify-content: center;
+      justify-content: space-evenly;
       align-items: stretch;
+
+      &-5-items {
+        /* Si 5 items */
+        /* Afficher 3 items sur une ligne puis 2 items sur une autre */
+        padding: 60px 0;
+        max-width: 75%;
+        margin: 0 auto;
+
+        .process-wrapper__item {
+          flex-basis: calc((100% / 3) - $gap * 2 / 3);
+        }
+      }
     }
   }
 
@@ -96,6 +108,7 @@
       display: block;
       padding: 32px 24px 50px;
       margin-bottom: 40px;
+      flex-basis: calc((100% / 4) - $gap * 3 / 4);
     }
 
     &-item__image {


### PR DESCRIPTION
## :unicorn: Problème
Selon la résolution, les multiple blocks de type "process" pouvait contenir un nombre de blocks différent sur une même ligne (4, 3 ou 1 en mobile).

## :robot: Solution
De la même manière que les "features", affiche correctement :
- 4 blocks sur les large-screen si 4 éléments
- 3 puis 2 blocks sur les large-screen si 5 éléments
- 1 seul élément par ligne si < large-screen (étendu sur toute la largeur disponible)

## :rainbow: Remarques
RAS

## :100: Pour tester
Dupliquer un bloc dans les devtools (ex : Co-construit) et constater qu'on affiche toujours bien 4 élements jusqu'à ce qu'on ne soit plus en large-screen. Sur la page `/les-tests` on peut voir les 5 blocks.
