### PR TITLE
[BUGFIX] Suppression de liens vers pix.fr/fr et pix.fr/en-gb

### DIFF
--- a/components/LanguageSwitcher.vue
+++ b/components/LanguageSwitcher.vue
@@ -100,7 +100,11 @@
                 child.lang === currentLocaleCode,
             }"
           >
-            <a :href="child.target">
+            <a
+              :href="
+                useGetAbsoluteUrlIfSwitchWebsite(child.target, child.isOnPixOrg)
+              "
+            >
               {{ $t(option.name) }} - {{ $t(child.name) }}
             </a>
             <br />


### PR DESCRIPTION
## :unicorn: Problème
Sur pix.fr, dans le burger menu, les liens des pages internationales renvoient vers pix.fr alors qu'ils devraient renvoyer pix.org. On avait oublié de passer par la méthode permettant de construire le lien absolu dans ce cas ci.

## :robot: Solution
Utiliser la méthode `useGetAbsoluteUrlIfSwitchWebsite` pour construire les liens absolus vers pix.org si nécessaire.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier sur la RA en mobile que les liens du burger menu permettent de naviguer correctement entre pix.fr et pix.org.

