### PR TITLE
[BUGFIX] Redirige les pages localisées de pix.fr vers pix.org (PIX-4496)

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -40,10 +40,10 @@ server {
   }
 
   if ($host ~ \.org) {
-    rewrite ^/(?!404.html)(?!fr)(?!en-gb)(?!_assets)(?!_nuxt)(?!documents)(?!images)(?!scripts)(?!apple-touch-icon)(?!favicon)(?!robots\.txt) $scheme://$host/fr$request_uri redirect;
+    rewrite ^/(?!404.html)(?!fr-be)(?!fr)(?!en-gb)(?!_assets)(?!_nuxt)(?!documents)(?!images)(?!scripts)(?!apple-touch-icon)(?!favicon)(?!robots\.txt) $scheme://$host/fr$request_uri redirect;
   }
 
   if ($http_x_forwarded_host ~ \.org) {
-    rewrite ^/(?!404.html)(?!fr)(?!en-gb)(?!_assets)(?!_nuxt)(?!documents)(?!images)(?!scripts)(?!apple-touch-icon)(?!favicon)(?!robots\.txt) $http_x_forwarded_proto://$http_x_forwarded_host/fr$request_uri redirect;
+    rewrite ^/(?!404.html)(?!fr-be)(?!fr)(?!en-gb)(?!_assets)(?!_nuxt)(?!documents)(?!images)(?!scripts)(?!apple-touch-icon)(?!favicon)(?!robots\.txt) $http_x_forwarded_proto://$http_x_forwarded_host/fr$request_uri redirect;
   }
 }

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -29,7 +29,7 @@ server {
   root /app/dist/;
 
   rewrite ^/(aide|help)$ https://support.pix.org redirect;
-  rewrite ^/employeurs$ https://pro.pix.fr redirect;
+  rewrite ^/employeurs$ https://pro.<%= ENV['DOMAIN_FR'] %> redirect;
 
   error_page 400 401 403 404 418 500 502 503 504 /404.html;
 
@@ -41,15 +41,15 @@ server {
 
   # Redirect pix.fr localized pages to pix.org
   if ($host ~ \.fr) {
-    rewrite ^/fr-be $scheme://pix.org/$request_uri redirect;
-    rewrite ^/en-gb $scheme://pix.org/$request_uri redirect;
-    rewrite ^/fr $scheme://pix.org/$request_uri redirect;
+    rewrite ^/fr-be $scheme://<%= ENV['DOMAIN_ORG'] %>/$request_uri redirect;
+    rewrite ^/en-gb $scheme://<%= ENV['DOMAIN_ORG'] %>/$request_uri redirect;
+    rewrite ^/fr $scheme://<%= ENV['DOMAIN_ORG'] %>/$request_uri redirect;
   }
 
   if ($http_x_forwarded_host ~ \.fr) {
-    rewrite ^/fr-be $http_x_forwarded_proto://pix.org/$request_uri redirect;
-    rewrite ^/en-gb $http_x_forwarded_proto://pix.org/$request_uri redirect;
-    rewrite ^/fr $http_x_forwarded_proto://pix.org/$request_uri redirect;
+    rewrite ^/fr-be $http_x_forwarded_proto://<%= ENV['DOMAIN_ORG'] %>/$request_uri redirect;
+    rewrite ^/en-gb $http_x_forwarded_proto://<%= ENV['DOMAIN_ORG'] %>/$request_uri redirect;
+    rewrite ^/fr $http_x_forwarded_proto://<%= ENV['DOMAIN_ORG'] %>/$request_uri redirect;
   }
 
   if ($host ~ \.org) {

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -41,15 +41,15 @@ server {
 
   # Redirect pix.fr localized pages to pix.org
   if ($host ~ \.fr) {
-    rewrite ^/fr-be $scheme://<%= ENV['DOMAIN_ORG'] %>/$request_uri redirect;
-    rewrite ^/en-gb $scheme://<%= ENV['DOMAIN_ORG'] %>/$request_uri redirect;
-    rewrite ^/fr $scheme://<%= ENV['DOMAIN_ORG'] %>/$request_uri redirect;
+    rewrite ^/fr-be $scheme://<%= ENV['DOMAIN_ORG'] %>$request_uri redirect;
+    rewrite ^/en-gb $scheme://<%= ENV['DOMAIN_ORG'] %>$request_uri redirect;
+    rewrite ^/fr $scheme://<%= ENV['DOMAIN_ORG'] %>$request_uri redirect;
   }
 
   if ($http_x_forwarded_host ~ \.fr) {
-    rewrite ^/fr-be $http_x_forwarded_proto://<%= ENV['DOMAIN_ORG'] %>/$request_uri redirect;
-    rewrite ^/en-gb $http_x_forwarded_proto://<%= ENV['DOMAIN_ORG'] %>/$request_uri redirect;
-    rewrite ^/fr $http_x_forwarded_proto://<%= ENV['DOMAIN_ORG'] %>/$request_uri redirect;
+    rewrite ^/fr-be $http_x_forwarded_proto://<%= ENV['DOMAIN_ORG'] %>$request_uri redirect;
+    rewrite ^/en-gb $http_x_forwarded_proto://<%= ENV['DOMAIN_ORG'] %>$request_uri redirect;
+    rewrite ^/fr $http_x_forwarded_proto://<%= ENV['DOMAIN_ORG'] %>$request_uri redirect;
   }
 
   if ($host ~ \.org) {

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -39,6 +39,19 @@ server {
     add_header ETag "";
   }
 
+  # Redirect pix.fr localized pages to pix.org
+  if ($host ~ \.fr) {
+    rewrite ^/fr-be $scheme://pix.org/$request_uri redirect;
+    rewrite ^/en-gb $scheme://pix.org/$request_uri redirect;
+    rewrite ^/fr $scheme://pix.org/$request_uri redirect;
+  }
+
+  if ($http_x_forwarded_host ~ \.fr) {
+    rewrite ^/fr-be $http_x_forwarded_proto://pix.org/$request_uri redirect;
+    rewrite ^/en-gb $http_x_forwarded_proto://pix.org/$request_uri redirect;
+    rewrite ^/fr $http_x_forwarded_proto://pix.org/$request_uri redirect;
+  }
+
   if ($host ~ \.org) {
     rewrite ^/(?!404.html)(?!fr-be)(?!fr)(?!en-gb)(?!_assets)(?!_nuxt)(?!documents)(?!images)(?!scripts)(?!apple-touch-icon)(?!favicon)(?!robots\.txt) $scheme://$host/fr$request_uri redirect;
   }


### PR DESCRIPTION
## :unicorn: Problème
Les sources de pix.fr et pix.org sont sur le même serveur. Ainsi les pages localisées qui commencent par `/fr-be`, `/en-gb`, `/fr` sont accessibles sur pix.fr.

## :robot: Solution
Cette première PR redirige des pages localisées de pix.fr vers pix.org pour clarifier la situation.

Des liens externes pointent vers pix.fr/fr, on a contacté les personnes maintenant ces sites d'autre part pour qu'elles renvoient vers les bons liens.

## :rainbow: Remarques
Cette modif devrait également permettre de désindexer sur Google ces pages incorrectes.

La next step une fois qu'on aura le retour des mainteneurs d'autres sites sera de couper ces pages.

## :100: Pour tester
Vérifier sur la RA que les pages <RA.fr>/fr, <RA.fr>/fr-be, <RA.fr>/en-gb renvoient bien vers <RA.org> sur la même page.
