### PR TITLE
[BUGFIX] Bloquer l'indexation Google des liens dépréciés

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -41,15 +41,15 @@ server {
 
   # Redirect pix.fr localized pages to pix.org
   if ($host ~ \.fr) {
-    rewrite ^/fr-be $scheme://<%= ENV['DOMAIN_ORG'] %>$request_uri redirect;
-    rewrite ^/en-gb $scheme://<%= ENV['DOMAIN_ORG'] %>$request_uri redirect;
-    rewrite ^/fr $scheme://<%= ENV['DOMAIN_ORG'] %>$request_uri redirect;
+    rewrite ^/fr-be $scheme://<%= ENV['DOMAIN_ORG'] %>$request_uri permanent;
+    rewrite ^/en-gb $scheme://<%= ENV['DOMAIN_ORG'] %>$request_uri permanent;
+    rewrite ^/fr $scheme://<%= ENV['DOMAIN_ORG'] %>$request_uri permanent;
   }
 
   if ($http_x_forwarded_host ~ \.fr) {
-    rewrite ^/fr-be $http_x_forwarded_proto://<%= ENV['DOMAIN_ORG'] %>$request_uri redirect;
-    rewrite ^/en-gb $http_x_forwarded_proto://<%= ENV['DOMAIN_ORG'] %>$request_uri redirect;
-    rewrite ^/fr $http_x_forwarded_proto://<%= ENV['DOMAIN_ORG'] %>$request_uri redirect;
+    rewrite ^/fr-be $http_x_forwarded_proto://<%= ENV['DOMAIN_ORG'] %>$request_uri permanent;
+    rewrite ^/en-gb $http_x_forwarded_proto://<%= ENV['DOMAIN_ORG'] %>$request_uri permanent;
+    rewrite ^/fr $http_x_forwarded_proto://<%= ENV['DOMAIN_ORG'] %>$request_uri permanent;
   }
 
   if ($host ~ \.org) {


### PR DESCRIPTION
## :unicorn: Problème
Les pages avec des redirections 302 temporaires apparaissent toujours sur Google.

https://developers.google.com/search/docs/advanced/crawling/301-redirects?hl=fr

## :robot: Solution
Passer les redirections temporaires en redirections permanentes (301).

## :rainbow: Remarques
Next step : renvoyer des 404 sur ces pages.

## :100: Pour tester
Vérifier dans la RA que les redirections sont bien permanentes.

