### PR TITLE
[FEATURE] Ne cache pas la donnée au click sur la légende d'un graphique

### DIFF
--- a/components/LineChart.vue
+++ b/components/LineChart.vue
@@ -14,6 +14,7 @@ export default {
     this.renderChart(this.data, {
       legend: {
         position: 'bottom',
+        onClick: () => {},
       },
       scales: {
         yAxes: [


### PR DESCRIPTION
## :unicorn: Problème
Lors que l'on clique sur la légende d'un graphique Chart.js, la donnée disparait. Nos graphiques n'ayant toujours qu'une seule donnée affichée ça n'est pas un comportement qui nous intéresse.
![image](https://user-images.githubusercontent.com/5855339/157049726-6e5f4baa-ad1b-4e86-8cc1-3f8c38ac215d.png)


## :robot: Solution
Enlever le comportement par défaut du click sur la légende.

## :rainbow: Remarques
RAS

## :100: Pour tester
Sur la page `/statistiques`, Comparer le clic sur la légende de la RA avec les autres envs.

