### PR TITLE
[BUGFIX] Traduction page d'erreur et liens localisés

### DIFF
--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -54,11 +54,12 @@ export default {
     'pix-orga-registration': 'Request for information | Pix pro',
   },
   'preview-page-load': 'Preview page loading...',
+  'home-page-url': `https://${process.env.DOMAIN_ORG}/en-gb/`,
   'error-content':
-    '<p>Oups ! Un problème est survenu, mais pas de panix !</p>' +
-    '<p>Vous pouvez revenir sur la ' +
-    "<a href='https://pix.fr/'>page d'accueil</a>." +
-    '<br/>Si vous avez besoin d’aide, vous pouvez consulter le ' +
-    '<a href="https://support.pix.fr/">support</a>.' +
+    '<p>Oops! A problem has occurred, but do not panic!</p>' +
+    '<p>You can go back to the ' +
+    `<a href="https://${process.env.DOMAIN_ORG}/en-gb/">homepage</a>.` +
+    '<br/>If you need help, you can check out the ' +
+    '<a href="https://support.pix.org/en/support/home">support</a>.' +
     '</p>',
 }

--- a/lang/fr-be.js
+++ b/lang/fr-be.js
@@ -54,11 +54,12 @@ export default {
     'pix-orga-registration': "Demande d'information | Pix pro",
   },
   'preview-page-load': 'Chargement de la page de prévisualisation...',
+  'home-page-url': `https://${process.env.DOMAIN_ORG}/fr-be/`,
   'error-content':
     '<p>Oups ! Un problème est survenu, mais pas de panix !</p>' +
     '<p>Vous pouvez revenir sur la ' +
-    "<a href='https://pix.fr/'>page d'accueil</a>." +
+    `<a href="https://${process.env.DOMAIN_ORG}/fr-be/">page d'accueil</a>.` +
     '<br/>Si vous avez besoin d’aide, vous pouvez consulter le ' +
-    '<a href="https://support.pix.fr/">support</a>.' +
+    '<a href="https://support.pix.org/fr/support/home">support</a>.' +
     '</p>',
 }

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -54,11 +54,12 @@ export default {
     'pix-orga-registration': "Demande d'information | Pix pro",
   },
   'preview-page-load': 'Chargement de la page de prévisualisation...',
+  'home-page-url': `https://${process.env.DOMAIN_FR}/`,
   'error-content':
     '<p>Oups ! Un problème est survenu, mais pas de panix !</p>' +
     '<p>Vous pouvez revenir sur la ' +
-    "<a href='https://pix.fr/'>page d'accueil</a>." +
+    `<a href="https://${process.env.DOMAIN_FR}/">page d'accueil</a>.` +
     '<br/>Si vous avez besoin d’aide, vous pouvez consulter le ' +
-    '<a href="https://support.pix.fr/">support</a>.' +
+    '<a href="https://support.pix.org/fr/support/home">support</a>.' +
     '</p>',
 }

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -54,11 +54,12 @@ export default {
       "Votre navigateur ne supporte pas les iframes. Le formulaire de contact ne peut pas être affiché. Merci d'utiliser une autre méthode de contact (téléphone, fax, etc.)",
   },
   'preview-page-load': 'Chargement de la page de prévisualisation...',
+  'home-page-url': `https://${process.env.DOMAIN_ORG}/fr/`,
   'error-content':
     '<p>Oups ! Un problème est survenu, mais pas de panix !</p>' +
     '<p>Vous pouvez revenir sur la ' +
-    "<a href='https://pix.fr/'>page d'accueil</a>." +
+    `<a href="https://${process.env.DOMAIN_ORG}/fr/">page d'accueil</a>.` +
     '<br/>Si vous avez besoin d’aide, vous pouvez consulter le ' +
-    '<a href="https://support.pix.fr/">support</a>.' +
+    '<a href="https://support.pix.org/fr/support/home">support</a>.' +
     '</p>',
 }

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="error">
-    <nuxt-link to="/">
+    <a :href="$t('home-page-url')">
       <img
         class="logo"
         src="/images/pix-logo.svg"
         alt="Lien pour revenir à l'accueil"
       />
-    </nuxt-link>
+    </a>
     <!-- eslint-disable-next-line vue/no-v-html -->
     <div v-html="$t('error-content')" />
   </div>


### PR DESCRIPTION
## :unicorn: Problème
La page d'erreur n'était pas traduite et ses liens ramenaient toujours vers pix.fr

## :robot: Solution
- Traduire la page d'erreur
- Mettre des liens vers les bonnes pages d'accueil selon la locale

## :rainbow: Remarques
- J'ai utilisé un `<a href` pour ne pas avoir à s'embêter avec les liens pix.fr/pix.org. Tant pis pour le prefetch éventuel.
- Ne fonctionne pas en localhost à cause du `https`

## :100: Pour tester
Aller sur des pages inexistantes sur les RA .fr et .org (sur chaque locale)
