### PR TITLE
[BUGFIX] Utilise nuxt/image sur toute les images

### DIFF
--- a/components/NewsItemCard.vue
+++ b/components/NewsItemCard.vue
@@ -8,7 +8,7 @@
         <!-- /!\ We keep this line if we think that an image would be better -->
         <div
           class="news-item-card__illustration"
-          :style="`background-image: url(${slice.illustration.url})`"
+          :style="`background-image: url(${$img(slice.illustration.url)})`"
         ></div>
       </div>
 

--- a/components/slices/Article.vue
+++ b/components/slices/Article.vue
@@ -59,7 +59,7 @@
       <video
         v-if="isMediaLayout && containsVideo"
         class="article__secondary-content article-secondary-content__video"
-        :poster="content.article_video_poster.url"
+        :poster="$img(content.article_video_poster.url)"
         controls
       >
         <source :src="content.article_video.url" type="video/mp4" />

--- a/components/slices/Article.vue
+++ b/components/slices/Article.vue
@@ -89,7 +89,9 @@ export default {
       let style = {}
       if (this.isOnlyTextLayout && this.hasBackgroundImage) {
         style = {
-          background: `no-repeat url(${this.content.article_background.url})`,
+          background: `no-repeat url(${this.img(
+            this.content.article_background.url
+          )})`,
           backgroundSize: '100%',
           backgroundPosition: 'top right',
         }


### PR DESCRIPTION
## :unicorn: Problème
Des images sont récupérées via prismic en production alors qu'on est censé utiliser nuxt/image partout.

## :robot: Solution
Corriger les non utilisations de nuxt/image dans les styles `background-image` et l'utiisation de l'attribut `poster`. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
1. Sur la page d'accueil, constater que les images dans les actualités sont bien chargé localement
2. Sur https://site-pr381.review.pix.fr/enseignement-scolaire, vérifier que l'attribut poster a bien une image chargé localement
3. Sur https://site-pr381.review.pix.fr/trouver-une-session voir que l'image dans le dernier block est bien chargé localement 
4. Sur https://site-pr381.review.pix.fr/mentions-legales voir que les images sont chargé localement

