### PR TITLE
[TECH] Supprimer les types de document Prismic inutiles (PIX-4895).

### DIFF
--- a/app/prismic/link-resolver.js
+++ b/app/prismic/link-resolver.js
@@ -1,11 +1,7 @@
 import { DOCUMENTS } from '~/services/document-fetcher'
 
 export default function (doc) {
-  const staticRoute = [
-    DOCUMENTS.COMPETENCES,
-    DOCUMENTS.STATISTIQUES,
-    DOCUMENTS.SIMPLE_PAGE,
-  ]
+  const staticRoute = [DOCUMENTS.STATISTIQUES, DOCUMENTS.SIMPLE_PAGE]
 
   if (staticRoute.includes(doc.type)) {
     const locale = doc.lang !== 'fr-fr' ? `/${doc.lang}` : ''

--- a/services/document-fetcher.js
+++ b/services/document-fetcher.js
@@ -7,7 +7,6 @@ export const DOCUMENTS = {
   SIMPLE_PAGE: 'simple_page',
   FORM_PAGE: 'form_page',
   SLICES_PAGE: 'slices_page',
-  COMPETENCES: 'competences',
   STATISTIQUES: 'statistiques',
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Le type `COMPETENCES` n'existe plus dans Prismic, cependant le code le référence toujours. 

## :robot: Solution
- Supprimer le type dans le code.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Vérifier le bon fonctionnement de la page `/competences`.

