### PR TITLE
[FEATURE] Renvoyer vers les bonnes locales quand les pages de prismic référencent des liens vers d'autres pages (PIX-4903).

### DIFF
--- a/app/prismic/link-resolver.js
+++ b/app/prismic/link-resolver.js
@@ -7,15 +7,15 @@ export const STATIC_ROUTE = [
   DOCUMENTS.SLICES_PAGE,
 ]
 export function linkResolver(doc) {
+  const locale = doc.lang !== 'fr-fr' ? `/${doc.lang}` : ''
   if (STATIC_ROUTE.includes(doc.type)) {
-    const locale = doc.lang !== 'fr-fr' ? `/${doc.lang}` : ''
     return `${locale}/${doc.uid}`
   }
   if (doc.type === DOCUMENTS.NEWS_ITEM) {
-    return `/${translation[doc.lang]['news-page-prefix']}/${doc.uid}`
+    return `${locale}/${translation[doc.lang]['news-page-prefix']}/${doc.uid}`
   }
   if (doc.type === DOCUMENTS.INDEX) {
-    return `/`
+    return `${locale}/`
   }
 }
 

--- a/app/prismic/link-resolver.js
+++ b/app/prismic/link-resolver.js
@@ -1,9 +1,7 @@
 import { DOCUMENTS } from '~/services/document-fetcher'
-
-export default function (doc) {
-  const staticRoute = [DOCUMENTS.STATISTIQUES, DOCUMENTS.SIMPLE_PAGE]
-
-  if (staticRoute.includes(doc.type)) {
+export const STATIC_ROUTE = [DOCUMENTS.STATISTIQUES, DOCUMENTS.SIMPLE_PAGE]
+export function linkResolver(doc) {
+  if (STATIC_ROUTE.includes(doc.type)) {
     const locale = doc.lang !== 'fr-fr' ? `/${doc.lang}` : ''
     return `${locale}/${doc.uid}`
   }
@@ -14,3 +12,5 @@ export default function (doc) {
     return `/`
   }
 }
+
+export default linkResolver

--- a/app/prismic/link-resolver.js
+++ b/app/prismic/link-resolver.js
@@ -1,5 +1,9 @@
 import { DOCUMENTS } from '~/services/document-fetcher'
-export const STATIC_ROUTE = [DOCUMENTS.STATISTIQUES, DOCUMENTS.SIMPLE_PAGE]
+export const STATIC_ROUTE = [
+  DOCUMENTS.STATISTIQUES,
+  DOCUMENTS.SIMPLE_PAGE,
+  DOCUMENTS.SLICES_PAGE,
+]
 export function linkResolver(doc) {
   if (STATIC_ROUTE.includes(doc.type)) {
     const locale = doc.lang !== 'fr-fr' ? `/${doc.lang}` : ''

--- a/app/prismic/link-resolver.js
+++ b/app/prismic/link-resolver.js
@@ -1,22 +1,16 @@
 import { DOCUMENTS } from '~/services/document-fetcher'
 import { translation } from '~/lang'
 
-export const STATIC_ROUTE = [
-  DOCUMENTS.STATISTIQUES,
-  DOCUMENTS.SIMPLE_PAGE,
-  DOCUMENTS.SLICES_PAGE,
-]
 export function linkResolver(doc) {
   const locale = doc.lang !== 'fr-fr' ? `/${doc.lang}` : ''
-  if (STATIC_ROUTE.includes(doc.type)) {
-    return `${locale}/${doc.uid}`
-  }
+
   if (doc.type === DOCUMENTS.NEWS_ITEM) {
     return `${locale}/${translation[doc.lang]['news-page-prefix']}/${doc.uid}`
   }
   if (doc.type === DOCUMENTS.INDEX) {
     return `${locale}/`
   }
+  return `${locale}/${doc.uid}`
 }
 
 export default linkResolver

--- a/app/prismic/link-resolver.js
+++ b/app/prismic/link-resolver.js
@@ -1,4 +1,6 @@
 import { DOCUMENTS } from '~/services/document-fetcher'
+import { translation } from '~/lang'
+
 export const STATIC_ROUTE = [
   DOCUMENTS.STATISTIQUES,
   DOCUMENTS.SIMPLE_PAGE,
@@ -10,7 +12,7 @@ export function linkResolver(doc) {
     return `${locale}/${doc.uid}`
   }
   if (doc.type === DOCUMENTS.NEWS_ITEM) {
-    return `/actualites/${doc.uid}`
+    return `/${translation[doc.lang]['news-page-prefix']}/${doc.uid}`
   }
   if (doc.type === DOCUMENTS.INDEX) {
     return `/`

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -29,6 +29,7 @@ export default {
     'page-title': 'Finalize your Pix Orga workspace request',
     'form-id': '28772',
   },
+  'news-page-prefix': 'news',
   'news-page-title': 'News',
   'news-page-title-level-two': 'News List',
   'news-page-no-news': 'No news available for the moment.',

--- a/lang/fr-be.js
+++ b/lang/fr-be.js
@@ -29,6 +29,7 @@ export default {
     'page-title': "Finalisez votre demande d'espace Pix Orga",
     'form-id': '22797',
   },
+  'news-page-prefix': 'actualites',
   'news-page-title': 'Actualités',
   'news-page-title-level-two': 'Liste des actualités',
   'news-page-no-news': "Il n’y a pas encore d'actualités",

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -29,6 +29,7 @@ export default {
     'page-title': "Finalisez votre demande d'espace Pix Orga",
     'form-id': '22797',
   },
+  'news-page-prefix': 'actualites',
   'news-page-title': 'Actualités',
   'news-page-title-level-two': 'Liste des actualités',
   'news-page-no-news': "Il n’y a pas encore d'actualités",

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -29,6 +29,7 @@ export default {
     'page-title': "Finalisez votre demande d'espace Pix Orga",
     'form-id': '22797',
   },
+  'news-page-prefix': 'actualites',
   'news-page-title': 'Actualités',
   'news-page-title-level-two': 'Liste des actualités',
   'news-page-no-news': "Il n’y a pas encore d'actualités",

--- a/lang/index.js
+++ b/lang/index.js
@@ -1,0 +1,6 @@
+import fr from './fr'
+import frFr from './fr-fr'
+import frBe from './fr-be'
+import enGb from './en-gb'
+
+export const translation = { fr, 'fr-fr': frFr, 'fr-be': frBe, 'en-gb': enGb }

--- a/tests/app/prismic/link-resolver.test.js
+++ b/tests/app/prismic/link-resolver.test.js
@@ -49,7 +49,7 @@ describe('linkResolver', () => {
       {
         lang: 'en-gb',
         uid: 'test-uid',
-        expectedUrl: '/actualites/test-uid',
+        expectedUrl: '/news/test-uid',
       },
     ]
 

--- a/tests/app/prismic/link-resolver.test.js
+++ b/tests/app/prismic/link-resolver.test.js
@@ -1,0 +1,120 @@
+import { DOCUMENTS } from '~/services/document-fetcher'
+import { linkResolver, STATIC_ROUTE } from '~/app/prismic/link-resolver'
+
+describe('linkResolver', () => {
+  describe('when document is for root level', function () {
+    const testCases = [
+      {
+        lang: 'fr-fr',
+        uid: 'test-uid',
+        expectedUrl: '/test-uid',
+      },
+      {
+        lang: 'fr-be',
+        uid: 'test-uid',
+        expectedUrl: '/fr-be/test-uid',
+      },
+      {
+        lang: 'en-gb',
+        uid: 'test-uid',
+        expectedUrl: '/en-gb/test-uid',
+      },
+    ]
+
+    testCases.forEach(({ lang, uid, expectedUrl }) => {
+      STATIC_ROUTE.forEach((type) => {
+        test(`it should return ${expectedUrl} when type is ${type} and lang is ${lang}`, () => {
+          // when
+          const url = linkResolver({ type, lang, uid })
+
+          // then
+          expect(url).toEqual(expectedUrl)
+        })
+      })
+    })
+  })
+
+  describe('when document is a news item', () => {
+    const testCases = [
+      {
+        lang: 'fr-fr',
+        uid: 'test-uid',
+        expectedUrl: '/actualites/test-uid',
+      },
+      {
+        lang: 'fr-be',
+        uid: 'test-uid',
+        expectedUrl: '/actualites/test-uid',
+      },
+      {
+        lang: 'en-gb',
+        uid: 'test-uid',
+        expectedUrl: '/actualites/test-uid',
+      },
+    ]
+
+    testCases.forEach(({ lang, uid, expectedUrl }) => {
+      test(`it should add prefix for lang ${lang}`, () => {
+        // when
+        const result = linkResolver({ type: DOCUMENTS.NEWS_ITEM, lang, uid })
+
+        // then
+        expect(result).toEqual(expectedUrl)
+      })
+    })
+  })
+
+  describe('when document is an index', () => {
+    const testCases = [
+      {
+        lang: 'fr-fr',
+        expectedUrl: '/',
+      },
+      {
+        lang: 'fr-be',
+        expectedUrl: '/',
+      },
+      {
+        lang: 'en-gb',
+        expectedUrl: '/',
+      },
+    ]
+
+    testCases.forEach(({ lang, expectedUrl }) => {
+      test(`it should return root url for lang ${lang}`, () => {
+        // when
+        const result = linkResolver({ type: DOCUMENTS.INDEX, lang })
+
+        // then
+        expect(result).toEqual(expectedUrl)
+      })
+    })
+  })
+
+  describe('when document type is not specific', () => {
+    const testCases = [
+      {
+        lang: 'fr-fr',
+        expectedUrl: undefined,
+      },
+      {
+        lang: 'fr-be',
+        expectedUrl: undefined,
+      },
+      {
+        lang: 'en-gb',
+        expectedUrl: undefined,
+      },
+    ]
+
+    testCases.forEach(({ lang, expectedUrl }) => {
+      test(`it should return ${expectedUrl}`, () => {
+        // when
+        const result = linkResolver({ type: 'not-defined', lang })
+
+        // then
+        expect(result).toEqual(expectedUrl)
+      })
+    })
+  })
+})

--- a/tests/app/prismic/link-resolver.test.js
+++ b/tests/app/prismic/link-resolver.test.js
@@ -1,36 +1,32 @@
 import { DOCUMENTS } from '~/services/document-fetcher'
-import { linkResolver, STATIC_ROUTE } from '~/app/prismic/link-resolver'
+import { linkResolver } from '~/app/prismic/link-resolver'
 
 describe('linkResolver', () => {
-  describe('when document is for root level', function () {
-    const testCases = [
-      {
-        lang: 'fr-fr',
-        uid: 'test-uid',
-        expectedUrl: '/test-uid',
-      },
-      {
-        lang: 'fr-be',
-        uid: 'test-uid',
-        expectedUrl: '/fr-be/test-uid',
-      },
-      {
-        lang: 'en-gb',
-        uid: 'test-uid',
-        expectedUrl: '/en-gb/test-uid',
-      },
-    ]
+  const testCases = [
+    {
+      lang: 'fr-fr',
+      uid: 'test-uid',
+      expectedUrl: '/test-uid',
+    },
+    {
+      lang: 'fr-be',
+      uid: 'test-uid',
+      expectedUrl: '/fr-be/test-uid',
+    },
+    {
+      lang: 'en-gb',
+      uid: 'test-uid',
+      expectedUrl: '/en-gb/test-uid',
+    },
+  ]
 
-    testCases.forEach(({ lang, uid, expectedUrl }) => {
-      STATIC_ROUTE.forEach((type) => {
-        test(`it should return ${expectedUrl} when type is ${type} and lang is ${lang}`, () => {
-          // when
-          const url = linkResolver({ type, lang, uid })
+  testCases.forEach(({ lang, uid, expectedUrl }) => {
+    test(`it should return ${expectedUrl}`, () => {
+      // when
+      const result = linkResolver({ type: 'anything', lang, uid })
 
-          // then
-          expect(url).toEqual(expectedUrl)
-        })
-      })
+      // then
+      expect(result).toEqual(expectedUrl)
     })
   })
 
@@ -84,33 +80,6 @@ describe('linkResolver', () => {
       test(`it should return root url for lang ${lang}`, () => {
         // when
         const result = linkResolver({ type: DOCUMENTS.INDEX, lang })
-
-        // then
-        expect(result).toEqual(expectedUrl)
-      })
-    })
-  })
-
-  describe('when document type is not specific', () => {
-    const testCases = [
-      {
-        lang: 'fr-fr',
-        expectedUrl: undefined,
-      },
-      {
-        lang: 'fr-be',
-        expectedUrl: undefined,
-      },
-      {
-        lang: 'en-gb',
-        expectedUrl: undefined,
-      },
-    ]
-
-    testCases.forEach(({ lang, expectedUrl }) => {
-      test(`it should return ${expectedUrl}`, () => {
-        // when
-        const result = linkResolver({ type: 'not-defined', lang })
 
         // then
         expect(result).toEqual(expectedUrl)

--- a/tests/app/prismic/link-resolver.test.js
+++ b/tests/app/prismic/link-resolver.test.js
@@ -44,12 +44,12 @@ describe('linkResolver', () => {
       {
         lang: 'fr-be',
         uid: 'test-uid',
-        expectedUrl: '/actualites/test-uid',
+        expectedUrl: '/fr-be/actualites/test-uid',
       },
       {
         lang: 'en-gb',
         uid: 'test-uid',
-        expectedUrl: '/news/test-uid',
+        expectedUrl: '/en-gb/news/test-uid',
       },
     ]
 
@@ -72,11 +72,11 @@ describe('linkResolver', () => {
       },
       {
         lang: 'fr-be',
-        expectedUrl: '/',
+        expectedUrl: '/fr-be/',
       },
       {
         lang: 'en-gb',
-        expectedUrl: '/',
+        expectedUrl: '/en-gb/',
       },
     ]
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, si une `slices pages` est référencée dans une page Prismic, la redirection ne fonctionnera pas correctement. Il en est de même avec les actualités (type: `NEWS_ITEM`) où on ne rajoute que le préfix `actualites` mais pas forcément `news` pour la locale `en-gb` par exemple.  

## :robot: Solution
- Ajouter des tests sur le link-resolver
- Gérer les locales dans le link-resolver
- Gérer les préfix pour les pages NEWS_ITEM

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Créer une page qui a un lien vers un autre document 
- Vérifier que le lien renvoie bien vers la locale