### PR TITLE
[TECH] Utilisation du tag index dans le link-resolver.

### DIFF
--- a/app/prismic/link-resolver.js
+++ b/app/prismic/link-resolver.js
@@ -7,7 +7,7 @@ export function linkResolver(doc) {
   if (doc.type === DOCUMENTS.NEWS_ITEM) {
     return `${locale}/${translation[doc.lang]['news-page-prefix']}/${doc.uid}`
   }
-  if (doc.type === DOCUMENTS.INDEX) {
+  if (doc.tags?.includes('index')) {
     return `${locale}/`
   }
   return `${locale}/${doc.uid}`

--- a/app/prismic/link-resolver.js
+++ b/app/prismic/link-resolver.js
@@ -1,4 +1,4 @@
-import { DOCUMENTS } from '~/services/document-fetcher'
+import { DOCUMENTS, TAGS } from '~/services/document-fetcher'
 import { translation } from '~/lang'
 
 export function linkResolver(doc) {
@@ -7,7 +7,7 @@ export function linkResolver(doc) {
   if (doc.type === DOCUMENTS.NEWS_ITEM) {
     return `${locale}/${translation[doc.lang]['news-page-prefix']}/${doc.uid}`
   }
-  if (doc.tags?.includes('index')) {
+  if (doc.tags?.includes(TAGS.INDEX)) {
     return `${locale}/`
   }
   return `${locale}/${doc.uid}`

--- a/services/document-fetcher.js
+++ b/services/document-fetcher.js
@@ -1,6 +1,5 @@
 export const DOCUMENTS = {
   HOT_NEWS: 'hot_news',
-  INDEX: 'index',
   MAIN_FOOTER: 'main_footer',
   MAIN_NAVIGATION: 'main_navigation',
   NEWS_ITEM: 'news_item',
@@ -8,6 +7,10 @@ export const DOCUMENTS = {
   FORM_PAGE: 'form_page',
   SLICES_PAGE: 'slices_page',
   STATISTIQUES: 'statistiques',
+}
+
+export const TAGS = {
+  INDEX: 'index',
 }
 
 export function documentFetcher(

--- a/tests/app/prismic/link-resolver.test.js
+++ b/tests/app/prismic/link-resolver.test.js
@@ -1,4 +1,4 @@
-import { DOCUMENTS } from '~/services/document-fetcher'
+import { DOCUMENTS, TAGS } from '~/services/document-fetcher'
 import { linkResolver } from '~/app/prismic/link-resolver'
 
 describe('linkResolver', () => {
@@ -63,17 +63,17 @@ describe('linkResolver', () => {
   describe('when document is an index', () => {
     const testCases = [
       {
-        tags: ['index', 'another-tag'],
+        tags: [TAGS.INDEX, 'another-tag'],
         lang: 'fr-fr',
         expectedUrl: '/',
       },
       {
-        tags: ['index'],
+        tags: [TAGS.INDEX],
         lang: 'fr-be',
         expectedUrl: '/fr-be/',
       },
       {
-        tags: ['index'],
+        tags: [TAGS.INDEX],
         lang: 'en-gb',
         expectedUrl: '/en-gb/',
       },

--- a/tests/app/prismic/link-resolver.test.js
+++ b/tests/app/prismic/link-resolver.test.js
@@ -63,23 +63,26 @@ describe('linkResolver', () => {
   describe('when document is an index', () => {
     const testCases = [
       {
+        tags: ['index', 'another-tag'],
         lang: 'fr-fr',
         expectedUrl: '/',
       },
       {
+        tags: ['index'],
         lang: 'fr-be',
         expectedUrl: '/fr-be/',
       },
       {
+        tags: ['index'],
         lang: 'en-gb',
         expectedUrl: '/en-gb/',
       },
     ]
 
-    testCases.forEach(({ lang, expectedUrl }) => {
-      test(`it should return root url for lang ${lang}`, () => {
+    testCases.forEach(({ tags, lang, expectedUrl }) => {
+      test(`it should return root url for lang ${lang} when one of tag is index`, () => {
         // when
-        const result = linkResolver({ type: DOCUMENTS.INDEX, lang })
+        const result = linkResolver({ tags, lang })
 
         // then
         expect(result).toEqual(expectedUrl)

--- a/tests/pages/pix-site/index.test.js
+++ b/tests/pages/pix-site/index.test.js
@@ -1,6 +1,6 @@
 import VueMeta from 'vue-meta'
 import { getInitialised, createLocalVue } from './utils'
-import { documentFetcher, DOCUMENTS } from '~/services/document-fetcher'
+import { documentFetcher, TAGS } from '~/services/document-fetcher'
 import getMeta, { fallbackDescription } from '~/services/meta-builder'
 
 const localVue = createLocalVue()
@@ -41,7 +41,7 @@ describe('Index Page', () => {
           },
         }),
     })
-    wrapper = await getInitialised(DOCUMENTS.INDEX, {
+    wrapper = await getInitialised(TAGS.INDEX, {
       localVue,
       computed: {
         $prismic() {
@@ -77,7 +77,7 @@ describe('Index Page', () => {
   })
 
   test('uses the fallback meta description when not filled in Prismic', async () => {
-    wrapper = await getInitialised(DOCUMENTS.INDEX, {
+    wrapper = await getInitialised(TAGS.INDEX, {
       localVue,
       computed: {
         $prismic() {


### PR DESCRIPTION
## :unicorn: Problème

Le type de page index n'existe plus. On ne créé donc pas d'URL  en `/` dans le `link-resolver.js`

## :robot: Solution

On ajoute un tag `index` à la page sur lequel nous nous basons dans le `link-resolver.js` à la place du type de document.

## :rainbow: Remarques
N/A

## :100: Pour tester
N/A

