### PR TITLE
[FEATURE] Générer les pages des sites en fonctions des tags Prismic (PIX-4905).

### DIFF
--- a/app/prismic/link-resolver.js
+++ b/app/prismic/link-resolver.js
@@ -1,16 +1,2 @@
-import { DOCUMENTS, TAGS } from '~/services/document-fetcher'
-import { translation } from '~/lang'
-
-export function linkResolver(doc) {
-  const locale = doc.lang !== 'fr-fr' ? `/${doc.lang}` : ''
-
-  if (doc.type === DOCUMENTS.NEWS_ITEM) {
-    return `${locale}/${translation[doc.lang]['news-page-prefix']}/${doc.uid}`
-  }
-  if (doc.tags?.includes(TAGS.INDEX)) {
-    return `${locale}/`
-  }
-  return `${locale}/${doc.uid}`
-}
-
+import { linkResolver } from '~/services/link-resolver'
 export default linkResolver

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,10 +9,6 @@ module.exports = {
     '^.+\\.js$': 'babel-jest',
     '.*\\.(vue)$': 'vue-jest',
   },
-  collectCoverage: true,
-  collectCoverageFrom: [
-    '<rootDir>/components/**/*.vue',
-    '<rootDir>/pages/**/*.vue',
-  ],
   testEnvironment: 'jsdom',
+  setupFiles: ['<rootDir>/setEnvVars.js'],
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  clearMocks: true,
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
     '^~/(.*)$': '<rootDir>/$1',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -9,6 +9,7 @@ const config = {
     routes,
     dir: `dist/${process.env.SITE_DOMAIN}`,
     fallback: '404.html',
+    crawler: false,
   },
   target: 'static',
   publicRuntimeConfig: {

--- a/services/get-routes-to-generate.js
+++ b/services/get-routes-to-generate.js
@@ -2,7 +2,6 @@ import Prismic from '@prismicio/client'
 import { language } from '../config/language'
 import { linkResolver } from '../services/link-resolver'
 import { SITES_PRISMIC_TAGS } from './available-sites'
-import { DOCUMENTS } from './document-fetcher'
 
 export default async function () {
   const api = await Prismic.getApi(process.env.PRISMIC_API_ENDPOINT)
@@ -20,10 +19,10 @@ export default async function () {
 
 async function getRoutesInPage(api, page) {
   const { results, total_pages: totalPages } = await api.query(
-    Prismic.Predicates.any('document.type', [
-      DOCUMENTS.SIMPLE_PAGE,
-      DOCUMENTS.FORM_PAGE,
-    ]),
+    [
+      Prismic.Predicates.at('document.tags', [process.env.SITE]),
+      Prismic.Predicates.not('document.tags', ['fragment']),
+    ],
     {
       pageSize: 100,
       page,

--- a/services/get-routes-to-generate.js
+++ b/services/get-routes-to-generate.js
@@ -1,5 +1,6 @@
 import Prismic from '@prismicio/client'
 import { language } from '../config/language'
+import { linkResolver } from '../services/link-resolver'
 import { SITES_PRISMIC_TAGS } from './available-sites'
 import { DOCUMENTS } from './document-fetcher'
 
@@ -34,10 +35,7 @@ async function getRoutesInPage(api, page) {
   const routes = results
     .filter(({ uid }) => Boolean(uid))
     .filter(({ lang }) => availableLangs.includes(lang))
-    .map(({ uid, lang }) => {
-      if (lang === 'fr-fr') return `/${uid}`
-      return `/${lang}/${uid}`
-    })
+    .map(linkResolver)
 
   return { totalPages, routes }
 }

--- a/services/link-resolver.js
+++ b/services/link-resolver.js
@@ -1,0 +1,16 @@
+import { translation } from '../lang'
+import { DOCUMENTS, TAGS } from './document-fetcher'
+
+export function linkResolver(doc) {
+  const locale = doc.lang !== 'fr-fr' ? `/${doc.lang}` : ''
+
+  if (doc.type === DOCUMENTS.NEWS_ITEM) {
+    return `${locale}/${translation[doc.lang]['news-page-prefix']}/${doc.uid}`
+  }
+  if (doc.tags?.includes(TAGS.INDEX)) {
+    return `${locale}/`
+  }
+  return `${locale}/${doc.uid}`
+}
+
+export default linkResolver

--- a/setEnvVars.js
+++ b/setEnvVars.js
@@ -1,0 +1,4 @@
+process.env.SITE = 'pix-site'
+process.env.METABASE_API_URL = 'https://test.metabase.fr'
+process.env.METABASE_USERNAME = 'username'
+process.env.METABASE_PASSWORD = 'password'

--- a/tests/services/get-routes-to-generate.test.js
+++ b/tests/services/get-routes-to-generate.test.js
@@ -4,10 +4,17 @@ import { DOCUMENTS } from '~/services/document-fetcher'
 jest.mock('@prismicio/client')
 
 describe('#getRoutesToGenerate', () => {
-  const prismicDocPredicates = prismic.Predicates.any('document.type', [
-    DOCUMENTS.SIMPLE_PAGE,
-    DOCUMENTS.FORM_PAGE,
-  ])
+  let prismicDocPredicates
+
+  beforeEach(() => {
+    prismic.Predicates.any = jest
+      .fn()
+      .mockReturnValue(Symbol('prismic-predicates'))
+    prismicDocPredicates = prismic.Predicates.any('document.type', [
+      DOCUMENTS.SIMPLE_PAGE,
+      DOCUMENTS.FORM_PAGE,
+    ])
+  })
 
   test('it should fetch routes to generate document for each lang', async () => {
     // Given
@@ -36,6 +43,10 @@ describe('#getRoutesToGenerate', () => {
       pageSize: 100,
       page: 1,
     })
+    expect(prismic.Predicates.any).lastCalledWith('document.type', [
+      DOCUMENTS.SIMPLE_PAGE,
+      DOCUMENTS.FORM_PAGE,
+    ])
     expect(result).toEqual(expected)
   })
 

--- a/tests/services/get-routes-to-generate.test.js
+++ b/tests/services/get-routes-to-generate.test.js
@@ -1,19 +1,20 @@
 import prismic from '@prismicio/client'
 import getRoutesToGenerate from '@/services/get-routes-to-generate'
-import { DOCUMENTS } from '~/services/document-fetcher'
 jest.mock('@prismicio/client')
 
 describe('#getRoutesToGenerate', () => {
-  let prismicDocPredicates
+  let prismicDocPredicatesAt
+  let prismicDocPredicatesNot
 
   beforeEach(() => {
-    prismic.Predicates.any = jest
+    prismic.Predicates.at = jest
       .fn()
-      .mockReturnValue(Symbol('prismic-predicates'))
-    prismicDocPredicates = prismic.Predicates.any('document.type', [
-      DOCUMENTS.SIMPLE_PAGE,
-      DOCUMENTS.FORM_PAGE,
-    ])
+      .mockReturnValue(Symbol('prismic-predicates-at'))
+    prismic.Predicates.not = jest
+      .fn()
+      .mockReturnValue(Symbol('prismic-predicates-not'))
+    prismicDocPredicatesAt = prismic.Predicates.at()
+    prismicDocPredicatesNot = prismic.Predicates.not()
   })
 
   test('it should fetch routes to generate document for each lang', async () => {
@@ -38,15 +39,18 @@ describe('#getRoutesToGenerate', () => {
     const result = await getRoutesToGenerate(prismic)
 
     // Then
-    expect(prismicApi.query).toBeCalledWith(prismicDocPredicates, {
-      lang: '*',
-      pageSize: 100,
-      page: 1,
-    })
-    expect(prismic.Predicates.any).lastCalledWith('document.type', [
-      DOCUMENTS.SIMPLE_PAGE,
-      DOCUMENTS.FORM_PAGE,
+    expect(prismicApi.query).toBeCalledWith(
+      [prismicDocPredicatesAt, prismicDocPredicatesNot],
+      {
+        lang: '*',
+        pageSize: 100,
+        page: 1,
+      }
+    )
+    expect(prismic.Predicates.at).lastCalledWith('document.tags', [
+      process.env.SITE,
     ])
+    expect(prismic.Predicates.not).lastCalledWith('document.tags', ['fragment'])
     expect(result).toEqual(expected)
   })
 
@@ -73,11 +77,14 @@ describe('#getRoutesToGenerate', () => {
     const result = await getRoutesToGenerate(prismic)
 
     // Then
-    expect(prismicApi.query).toBeCalledWith(prismicDocPredicates, {
-      lang: '*',
-      pageSize: 100,
-      page: 1,
-    })
+    expect(prismicApi.query).toBeCalledWith(
+      [prismicDocPredicatesAt, prismicDocPredicatesNot],
+      {
+        lang: '*',
+        pageSize: 100,
+        page: 1,
+      }
+    )
     expect(result).toEqual(expected)
   })
 
@@ -99,11 +106,14 @@ describe('#getRoutesToGenerate', () => {
     const result = await getRoutesToGenerate(prismic)
 
     // Then
-    expect(prismicApi.query).toBeCalledWith(prismicDocPredicates, {
-      lang: '*',
-      pageSize: 100,
-      page: 1,
-    })
+    expect(prismicApi.query).toBeCalledWith(
+      [prismicDocPredicatesAt, prismicDocPredicatesNot],
+      {
+        lang: '*',
+        pageSize: 100,
+        page: 1,
+      }
+    )
     expect(result).toEqual(expected)
   })
 
@@ -135,16 +145,22 @@ describe('#getRoutesToGenerate', () => {
     const result = await getRoutesToGenerate(prismic)
 
     // Then
-    expect(prismicApi.query).toBeCalledWith(prismicDocPredicates, {
-      lang: '*',
-      pageSize: 100,
-      page: 1,
-    })
-    expect(prismicApi.query).toBeCalledWith(prismicDocPredicates, {
-      lang: '*',
-      pageSize: 100,
-      page: 2,
-    })
+    expect(prismicApi.query).toBeCalledWith(
+      [prismicDocPredicatesAt, prismicDocPredicatesNot],
+      {
+        lang: '*',
+        pageSize: 100,
+        page: 1,
+      }
+    )
+    expect(prismicApi.query).toBeCalledWith(
+      [prismicDocPredicatesAt, prismicDocPredicatesNot],
+      {
+        lang: '*',
+        pageSize: 100,
+        page: 2,
+      }
+    )
     expect(result).toEqual(expected)
   })
 })

--- a/tests/services/link-resolver.test.js
+++ b/tests/services/link-resolver.test.js
@@ -1,5 +1,5 @@
 import { DOCUMENTS, TAGS } from '~/services/document-fetcher'
-import { linkResolver } from '~/app/prismic/link-resolver'
+import { linkResolver } from '~/services/link-resolver'
 
 describe('linkResolver', () => {
   const testCases = [

--- a/tests/services/metabase-fetcher.test.js
+++ b/tests/services/metabase-fetcher.test.js
@@ -14,9 +14,6 @@ describe('MetabaseFetcher', () => {
     global.fetch = jest
       .fn()
       .mockReturnValue(fetchResponse({ id: 'session-id' }))
-    process.env.METABASE_API_URL = 'https://test.metabase.fr'
-    process.env.METABASE_USERNAME = 'username'
-    process.env.METABASE_PASSWORD = 'password'
 
     // when
     await metabaseFetcher()
@@ -42,7 +39,6 @@ describe('MetabaseFetcher', () => {
         .mockReturnValueOnce(fetchResponse({ id: 'session-id' }))
         .mockReturnValueOnce(fetchResponse([]))
       const cardId = 1234
-      process.env.METABASE_API_URL = 'https://test.metabase.fr'
 
       // when
       const fetcher = await metabaseFetcher()


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous buildons les pages de Pix Pro dans le build de Pix Site et inversement. 
Les inconvénients de ça sont que : 
- les utilisateurs peuvent accéder à des pages qui ne doivent pas être présentes pour ce site
- les build sont plus lourds 
- Et nous n'avons pas le contrôle des pages générées.

## :robot: Solution
Pour identifier la destination d'une page, nous avons opté sur l'utilisation de tag sur Prismic : `pix-site` et `pix-pro`.
Les avantages des tags sont que : 
- Une unique page peut contenir les 2 tags si elle doit aller dans les 2 sites 
- l'API Prismic nous permet facilement de remonter toutes les pages ayant un certain tag.

Pour faire cela, nous utilisons la méthode `getRoutesToGenerate` que nous avons modifié pour chercher les pages par tag. 

De plus, nous retirons le mécanisme de crawler proposé par Nuxt pour générer les pages, afin d'avoir l'arbitrage complet sur les pages générées. 

## :rainbow: Remarques
Nous avons aussi ajouté un tag `fragment` qui permet d'identifie un document Prismic qui correspond à une partie du site mais pas une page entière. Cela correspond par exemple : aux navigations ou footer.

## :100: Pour tester

### Vérifier que toutes les pages ont un tag `pix-site` ou `pix-pro`: 
On peut utiliser la commande : 

```bash
ref=$(curl -s https://<repo-name>.prismic.io/api/v2 | jq -r '.refs[0].ref') \ 
curl -sG "https://<repo-name>.prismic.io/api/v2/documents/search"  \ 
--data-urlencode "ref=${ref}" \
--data-urlencode 'q=[[not(document.tags,["pix-pro"])]]' \
--data-urlencode 'q=[[not(document.tags,["pix-site"])]]#format=json' | jq '.results | map(.uid)'
```

- `ref=$(curl -s https://<repo-name>.prismic.io/api/v2 | jq -r '.refs[0].ref')` Permet de récupérer la dernière référence qui correspond aux dernières modifications faites sur Prismic 
- `curl -sG "https://<repo-name>.prismic.io/api/v2/documents/search"  \ 
--data-urlencode "ref=${ref}" \
--data-urlencode 'q=[[not(document.tags,["pix-pro"])]]' \
--data-urlencode 'q=[[not(document.tags,["pix-site"])]]#format=json' ` Permet d'obtenir le même résultat que si nous utilisions la page `https://<repo-name>.prismic.io/api/v2` auquel on ajoute des prédicats. L'option `-s` pour silent et l'option `-G | --get` permet d'ajouter les data en query params et l'option `--data-urlencode` permet d'encoder les caractères spéciaux comme : `[](),`.
- `| jq '.results | map(.uid)` Permet de filtrer le json donnée par le curl pour n'avoir que les uid des pages 


### Comparer les build avant et après les modifications
- Lancer le build du site avant et après la modification dans 2 dossiers distincts.
- Pour comparer les pages générées, nous pouvons utiliser : 

```shell
comm <(find dist -not -path '*/_nuxt/*' | sed 's/dist//g' | sort) <(find dist.prod -not -path '*/_nuxt/*' | sed 's/dist.prod//g' | sort) | expand -t30
```
 
- La commande `comm` permet de comparer les lignes de 2 fichiers différents
- `find dist -not -path '*/_nuxt/*' | sed 's/dist//g' | sort` Permet de lister tous les fichiers et répertoires de façon récursive dans le répertoire `dist` auquel on ne prend pas en compte les répertoires `*/_nuxt/*` car les fichiers dedans ont des identifiants uniques à chaque build. Ensuite le `| sed 's/dist//g` permet de retirer le nom de répertoire pour pouvoir comparer le résultat de l'autre build.
- `<()` Permet de faire du [Process Substitution](https://www.gnu.org/software/bash/manual/html_node/Process-Substitution.html#Process-Substitution), ça permet d'éviter l'utilisation un fichier temporaire pour le résultat de la commande qui se trouve dedans. 
- `expand -t30` permet d'élargir la taille des tabs pour mieux visualiser les différentes colonnes. 

La commande retourne 3 colonnes : 
- 1 : les lignes que dans le premier ficher
- 2 : les lignes que dans le second fichier
- 3 : les lignes en commun 



