### PR TITLE
[TECH] Ajouter un commentaire avec les liens des RA et de la PR GitHub directement sur le ticket Jira associée (PIX-4918).

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "pix-site",
-      "version": "3.28.2",
+      "version": "3.28.3",
       "license": "AGPL-3.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
@@ -35,6 +35,7 @@
         "@nuxtjs/style-resources": "^1.2.1",
         "@vue/test-utils": "^1.2.2",
         "autoprefixer": "^10.4.0",
+        "axios": "^0.27.2",
         "babel-core": "7.0.0-bridge.0",
         "babel-jest": "^27.3.1",
         "eslint": "^8.1.0",
@@ -4927,6 +4928,30 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -9805,6 +9830,26 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-in": {
       "version": "1.0.2",
@@ -27513,6 +27558,29 @@
         "postcss-value-parser": "^4.2.0"
       }
     },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -31255,6 +31323,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
+    "follow-redirects": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -39661,6 +39735,11 @@
         "yallist": "^4.0.0"
       },
       "dependencies": {
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,6 @@
     "start:pro": "SITE=pix-pro SITE_DOMAIN=pix.fr npm run start",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "test": "SITE=pix-site jest --no-coverage",
-    "release": "npm run release:minor",
-    "release:patch": "npm version patch -m \"Release v%s\"",
-    "release:minor": "npm version minor -m \"Release v%s\"",
-    "release:major": "npm version major -m \"Release v%s\"",
     "signal-github": "./scripts/signal_deploy_to_pr.sh"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules .nuxt",
-    "build": "SITE_DOMAIN=pix.fr nuxt generate --fail-on-error && SITE_DOMAIN=pix.org nuxt generate --fail-on-error && npm run signal-github",
+    "build": "SITE_DOMAIN=pix.fr nuxt generate --fail-on-error && SITE_DOMAIN=pix.org nuxt generate --fail-on-error && npm run signal-github && npm run signal-jira",
     "start": "nuxt start",
     "dev:site": "SITE=pix-site SITE_DOMAIN=pix.fr nuxt",
     "build:site": "SITE=pix-site SITE_DOMAIN=pix.fr nuxt generate --fail-on-error",
@@ -28,7 +28,8 @@
     "start:pro": "SITE=pix-pro SITE_DOMAIN=pix.fr npm run start",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "test": "SITE=pix-site jest --no-coverage",
-    "signal-github": "./scripts/signal_deploy_to_pr.sh"
+    "signal-github": "./scripts/signal_deploy_to_pr.sh",
+    "signal-jira": "node ./scripts/jira/comment-with-review-app-url.js"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
@@ -57,6 +58,7 @@
     "@nuxtjs/style-resources": "^1.2.1",
     "@vue/test-utils": "^1.2.2",
     "autoprefixer": "^10.4.0",
+    "axios": "^0.27.2",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^27.3.1",
     "eslint": "^8.1.0",

--- a/scripts/jira/comment-with-review-app-url.js
+++ b/scripts/jira/comment-with-review-app-url.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+const axios = require('axios')
+const JIRA_API_VERSION = '2'
+const JIRA_API_URL = `https://1024pix.atlassian.net/rest/api/${JIRA_API_VERSION}`
+
+async function main() {
+  // eslint-disable-next-line eqeqeq
+  const isReviewApp = process.env.REVIEW_APP == 'true'
+
+  if (!isReviewApp) {
+    console.log(
+      '$REVIEW_APP is not true. I will not post a message to Jira. Bye !'
+    )
+    return
+  }
+
+  const appName = process.env.APP
+
+  const prNumber = extractPRNumberFromAppName(appName)
+
+  console.log(`Getting branch name from pull request: ${prNumber}`)
+  const branchName = await getBranchNameFromPRNumber(prNumber)
+
+  const issueCode = extractIssueCodeFromBranchName(branchName)
+
+  console.log(`Generating Review apps urls for pull request: ${prNumber}`)
+
+  const raSiteFrURL = `https://site-pr${prNumber}.review.pix.fr`
+  const raSiteOrgURL = `https://site-pr${prNumber}.review.pix.org`
+  const raProURL = `https://pro-pr${prNumber}.review.pix.fr`
+  const prGithubURL = `https://github.com/1024pix/pix-site/pull/${prNumber}`
+
+  const scalingoCommentRegex = new RegExp(raSiteFrURL, 'i')
+
+  console.log(`Getting existing comments on JIRA issue: ${issueCode}`)
+
+  const commentsResponse = await axios({
+    method: 'get',
+    url: `${JIRA_API_URL}/issue/${issueCode}/comment`,
+    auth: {
+      username: process.env.JIRA_NOTIFICATION_ACCOUNT_EMAIL,
+      password: process.env.JIRA_NOTIFICATION_ACCOUNT_TOKEN,
+    },
+  })
+
+  const commentContents = commentsResponse.data.comments.map(
+    (comment) => comment.body
+  )
+
+  console.log(
+    `Checking comment has not already been posted for PR number: ${prNumber}`
+  )
+
+  const hasAlreadyScalingoComment = commentContents.some((comment) =>
+    comment.match(scalingoCommentRegex)
+  )
+
+  if (hasAlreadyScalingoComment) {
+    console.log(
+      'Review apps urls already found in issue comments. No need to add it again'
+    )
+  } else {
+    const text =
+      'Je viens de déployer la Review App. Elle sera consultable sur les URL suivantes :\n' +
+      `- Site FR : ${raSiteFrURL}\n` +
+      `- Site ORG : ${raSiteOrgURL}\n` +
+      `- Pro : ${raProURL}\n` +
+      `Le lien Github de la PR : ${prGithubURL}`
+
+    console.log(
+      `Posting Review apps urls for PR number: ${prNumber} to JIRA issue: ${issueCode}`
+    )
+
+    await axios({
+      method: 'post',
+      url: `${JIRA_API_URL}/issue/${issueCode}/comment`,
+      headers: { 'Content-Type': 'application/json' },
+      auth: {
+        username: process.env.JIRA_NOTIFICATION_ACCOUNT_EMAIL,
+        password: process.env.JIRA_NOTIFICATION_ACCOUNT_TOKEN,
+      },
+      data: {
+        body: text,
+      },
+    })
+  }
+}
+
+function extractIssueCodeFromBranchName(branchName) {
+  // eslint-disable-next-line prefer-regex-literals
+  const jiraIssueNameRegex = new RegExp(/^\w+-\d+/, 'i')
+  const regexMatches = branchName.match(jiraIssueNameRegex)
+
+  if (regexMatches) {
+    return regexMatches[0]
+  } else {
+    throw new Error('The id of the Jira issue could not be found.')
+  }
+}
+
+function extractPRNumberFromAppName(appName) {
+  // eslint-disable-next-line prefer-regex-literals
+  const PRnumberRegex = new RegExp(/-pr(\d+)/)
+  const regexMatches = appName.match(PRnumberRegex)
+
+  if (regexMatches) {
+    return regexMatches[1]
+  } else {
+    throw new Error('The PR number could not be found.')
+  }
+}
+
+async function getBranchNameFromPRNumber(prNumber) {
+  const { data } = await axios(
+    `https://api.github.com/repos/1024pix/pix-site/pulls/${prNumber}`
+  )
+
+  if (data && data.head && data.head.ref) {
+    return data.head.ref
+  } else {
+    throw new Error(
+      `Could not find branch name in GitHub API output : ${JSON.stringify(
+        data
+      )}`
+    )
+  }
+}
+
+main().then(
+  () => {
+    console.log('Script done.')
+    process.exit()
+  },
+  (error) => {
+    console.error(error.message)
+    console.log('Stopping here.')
+    console.log('Script failed.')
+    process.exit()
+  }
+)


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous mettons manuellement le lien de la PR sur les tickets Jira, c'est une tâche qui est automatisée sur le repo `pix`.

## :robot: Solution
- Utiliser le script présent sur le repo `1024pix/pix.`

## :rainbow: Remarques
- Au passage, les scripts concernant les releases ont été supprimé étant inutiles car c'est Pix Bot qui s'en occupe.

## :100: Pour tester
- Vérifier dans le déploiement que le script a été lancé, il ne marche pas dans cette PR car le ref pour github est l'ancien nom de branche :/ 
