### PR TITLE
[TECH] Accéder au domaine .org sur les RA (PIX-4963).

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -28,6 +28,10 @@ server {
     set $extension 'fr';
   }
 
+  if ($http_x_forwarded_host ~ \.org) {
+    set $extension 'org';
+  }
+
   charset utf-8;
 
   # Disable compression that is performed by the Scalingo router anyway

--- a/tests.sh
+++ b/tests.sh
@@ -35,3 +35,4 @@ checkRedirect pix.org /_assets/ "" "" 404
 checkRedirect review.scalingo.io /_assets/ "review.pix.org" "https" 404
 checkRedirect pix.org /favicon.ico "" "" 200
 checkRedirect pix.org /favicon.ico "review.pix.org" "" 200
+checkRedirect review.scalingo.io /en-gb/the-tests/ "review.pix.org" "" 200


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il n'est plus possible d'accéder au domaine `.org` car le dossier servi est le `.fr`. 
En effet, contrairement à la production, sur les RA nous ne pouvons pas nous baser sur l'host pour servir les fichiers, nous pouvons par contre nous baser sur le header `X-Forwarded-Host`

## :robot: Solution
Se servir du header `X-forwarded-host` pour servir les fichiers du bon dossier.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._

