### PR TITLE
[TECH] Supprimer les appels inutiles à /undefined (PIX-4966).

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,6 @@ Domain name for `.org` extension.
 - type: String
 - default: none
 
-`MATOMO_URL`
-If not present, nuxt-matomo will not be loaded and analytics will not be active
-
-- presence: optional
-- type: Url
-- default: none
-
 `MATOMO_CONTAINER`
 If not present, nuxt-matomo will not be loaded and tag managers will not be active
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -48,19 +48,7 @@ const nuxtConfig = {
       isSeoIndexingEnabled() ? {} : { name: 'robots', content: 'noindex' },
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
-    script: [
-      {
-        type: 'text/javascript',
-        src: config.matomo.containerUrl,
-        async: true,
-        defer: true,
-      },
-      {
-        type: 'text/javascript',
-        src: '/scripts/start-matomo-event.js',
-        'data-matomo-debug-mode': config.matomo.debug,
-      },
-    ],
+    script: [],
   },
   /*
    ** Customize the progress-bar color
@@ -218,6 +206,22 @@ const availableSites = Object.values(SITES_PRISMIC_TAGS)
 if (!availableSites.includes(process.env.SITE)) {
   throw new Error(
     `The SITE environment variable must have one of these values: (${availableSites})`
+  )
+}
+
+if (config.matomo.containerUrl) {
+  nuxtConfig.head.script.push(
+    {
+      type: 'text/javascript',
+      src: config.matomo.containerUrl,
+      async: true,
+      defer: true,
+    },
+    {
+      type: 'text/javascript',
+      src: '/scripts/start-matomo-event.js',
+      'data-matomo-debug-mode': config.matomo.debug,
+    }
   )
 }
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -221,18 +221,4 @@ if (!availableSites.includes(process.env.SITE)) {
   )
 }
 
-if (process.env.MATOMO_URL && process.env.MATOMO_SITE_ID) {
-  config.modules.push([
-    'nuxt-matomo',
-    {
-      matomoUrl: process.env.MATOMO_URL,
-      siteId: process.env.MATOMO_SITE_ID,
-    },
-  ])
-} else {
-  console.warn(
-    'Both MATOMO_URL and MATOMO_SITE_ID environment variables must be provided'
-  )
-}
-
 export default nuxtConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "chart.js": "^2.9.4",
         "nuxt": "^2.15.1",
         "nuxt-fontawesome": "0.4.0",
-        "nuxt-matomo": "^1.2.4",
         "nuxt-winston-log": "^1.2.0",
         "postcss-cli": "^9.0.1",
         "vue-burger-menu": "2.0.5",
@@ -14902,11 +14901,6 @@
         "@fortawesome/fontawesome-svg-core": ">= 1.2.0 < 1.3",
         "vue": "~2"
       }
-    },
-    "node_modules/nuxt-matomo": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/nuxt-matomo/-/nuxt-matomo-1.2.4.tgz",
-      "integrity": "sha512-09cIWnj6v58CMbEDS+mVTnJ97BaO/fJaQDPk31sa27jejcD80bIvNowkAJMj4OcVWMeeIVTljClMHE6249cFtw=="
     },
     "node_modules/nuxt-winston-log": {
       "version": "1.2.0",
@@ -35132,11 +35126,6 @@
           "requires": {}
         }
       }
-    },
-    "nuxt-matomo": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/nuxt-matomo/-/nuxt-matomo-1.2.4.tgz",
-      "integrity": "sha512-09cIWnj6v58CMbEDS+mVTnJ97BaO/fJaQDPk31sa27jejcD80bIvNowkAJMj4OcVWMeeIVTljClMHE6249cFtw=="
     },
     "nuxt-winston-log": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "chart.js": "^2.9.4",
     "nuxt": "^2.15.1",
     "nuxt-fontawesome": "0.4.0",
-    "nuxt-matomo": "^1.2.4",
     "nuxt-winston-log": "^1.2.0",
     "postcss-cli": "^9.0.1",
     "vue-burger-menu": "2.0.5",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lorsqu'on ne fournit pas la variable d'environnement : `MATOMO_CONTAINER_URL`, la balise script pour Matomo Tag Manager est quand même ajouté et provoque des appels à `/undefined`.

## :robot: Solution
- Supprimer `nuxt-matomo` qui sert à Matomo Analytics seulement nous utilisons Matomo Tag Manager
- Conditionner l'ajout des balises script pour Matomo Tag Manager uniquement si la variable d'environnement est présente

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Vérifier que dans la RA il n'y a plus d'appel à `/undefined` .

