### PR TITLE
[FEATURE] - Builder pix site et pix pro pour tous les contextes (PIX-4980).

### DIFF
--- a/components/LanguageSwitcher/LanguageSwitcher.vue
+++ b/components/LanguageSwitcher/LanguageSwitcher.vue
@@ -12,8 +12,12 @@
       @click.stop.prevent="toggleMenu()"
     >
       {{ $t(currentLocaleCode) }}
-      <fa v-if="showMenu" icon="angle-up" />
-      <fa v-else icon="angle-down" />
+      <fa
+        v-if="showMenu"
+        icon="angle-up"
+        class="language-switcher-button__angle"
+      />
+      <fa v-else icon="angle-down" class="language-switcher-button__angle" />
     </button>
     <ul v-if="showMenu" class="language-switcher__dropdown-menu">
       <li
@@ -39,7 +43,7 @@
             <fa
               v-if="!option.target"
               icon="angle-right"
-              class="language-switcher__icon"
+              class="language-switcher__icon language-switcher-button__angle"
             />
           </button>
           <a
@@ -218,7 +222,7 @@ export default {
       background-position: 5% 50%;
       padding: 2px 3px 0 30px;
       cursor: pointer;
-      background: url('/images/globe.svg') no-repeat;
+      background: url('/images/globe.svg') no-repeat left;
       &:hover {
         color: $blue;
       }
@@ -345,6 +349,11 @@ export default {
       margin-right: 10px;
       height: 23px;
       width: 23px;
+    }
+  }
+  .language-switcher-button {
+    &__angle {
+      margin-left: 8px;
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules .nuxt",
-    "build": "SITE_DOMAIN=pix.fr nuxt generate --fail-on-error && if [ $SITE = \"pix-site\" ]; then SITE_DOMAIN=pix.org nuxt generate --fail-on-error; fi && npm run signal-github && npm run signal-jira",
+    "build": "SITE_DOMAIN=pix.fr nuxt generate --fail-on-error && SITE_DOMAIN=pix.org nuxt generate --fail-on-error && npm run signal-github && npm run signal-jira",
     "start": "nuxt start",
     "dev:site": "SITE=pix-site SITE_DOMAIN=pix.fr nuxt",
     "build:site": "SITE=pix-site SITE_DOMAIN=pix.fr nuxt generate --fail-on-error",
@@ -26,6 +26,9 @@
     "dev:pro": "SITE=pix-pro SITE_DOMAIN=pix.fr nuxt",
     "build:pro": "SITE=pix-pro SITE_DOMAIN=pix.fr nuxt generate --fail-on-error",
     "start:pro": "SITE=pix-pro SITE_DOMAIN=pix.fr npm run start",
+    "dev:pro:org":"SITE=pix-pro SITE_DOMAIN=pix.org nuxt",
+    "build:pro:org": "SITE=pix-pro SITE_DOMAIN=pix.org nuxt generate --fail-on-error",
+    "start:pro:org": "SITE=pix-pro SITE_DOMAIN=pix.org npm run start",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "test": "SITE=pix-site jest --no-coverage",
     "signal-github": "./scripts/signal_deploy_to_pr.sh",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lors du build de pix-pro, on ne prend pas en compte le build de pro.pix.org

## :robot: Solution
Modifier le script du package.json

## :rainbow: Remarques
Cette PR embarque des sr sur le style du language switcher.

## :100: Pour tester
Se rendre sur la RA, et constater qu'on a accès à pro.pix.org
