### PR TITLE
[TECH] Supprimer les redirections pix.fr (PIX-4497).

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -50,17 +50,4 @@ server {
     add_header Cache-Control public;
     add_header ETag "";
   }
-
-  # Redirect pix.fr localized pages to pix.org
-  if ($host ~ \.fr) {
-    rewrite ^/fr-be $scheme://<%= ENV['DOMAIN_ORG'] %>$request_uri permanent;
-    rewrite ^/en-gb $scheme://<%= ENV['DOMAIN_ORG'] %>$request_uri permanent;
-    rewrite ^/fr $scheme://<%= ENV['DOMAIN_ORG'] %>$request_uri permanent;
-  }
-
-  if ($http_x_forwarded_host ~ \.fr) {
-    rewrite ^/fr-be $http_x_forwarded_proto://<%= ENV['DOMAIN_ORG'] %>$request_uri permanent;
-    rewrite ^/en-gb $http_x_forwarded_proto://<%= ENV['DOMAIN_ORG'] %>$request_uri permanent;
-    rewrite ^/fr $http_x_forwarded_proto://<%= ENV['DOMAIN_ORG'] %>$request_uri permanent;
-  }
 }


### PR DESCRIPTION
## :unicorn: Problème

On ne souhaite plus avoir accès aux pages http://pix.fr/fr , http://pix.fr/fr-be , pix.fr/en-gb

## :robot: Solution

Suppression des redirections dans la conf Nginx

## :rainbow: Remarques
N/A

## :100: Pour tester
Tenter d'accéder aux pages mentionnées.

