### PR TITLE
[BUGFIX] Affichage burger menu sur pro.pix.fr (PIX-5051)

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -24,6 +24,9 @@ const nuxtConfig = {
     SITE: process.env.SITE,
     DOMAIN_ORG: process.env.DOMAIN_ORG,
     DOMAIN_FR: process.env.DOMAIN_FR,
+    FT_DISABLE_PIX_PRO_LANGUAGE_SWITCHER:
+      process.env.FT_DISABLE_PIX_PRO_LANGUAGE_SWITCHER,
+    SITE_DOMAIN: process.env.SITE_DOMAIN,
   },
   dir: {
     pages: `pages/${process.env.SITE}`,


### PR DESCRIPTION
## :unicorn: Problème
Le burger menu ne s'affiche pas en mode mobile sur le site pro.pix.fr.

## :robot: Solution
Ajouter les variables d'environnement dans le fichier `nuxt.config.js`.
En affichage côté client, il est nécessaire de déclarer la clé `env` pour que Nuxt soit capable de les lire ([voir commentaire](https://github.com/1024pix/pix-site/blob/dev/nuxt.config.js#L23)).

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier le bon comportement du menu sur les 4 sites en review-app, en mode mobile et desktop.

