### PR TITLE
[BUGFIX] Rétablir l'affichage du lien actif dans la barre de navigation du site Pro.pix.org (PIX-5026).

### DIFF
--- a/middleware/current-page-path.js
+++ b/middleware/current-page-path.js
@@ -1,15 +1,8 @@
-import { SITES_PRISMIC_TAGS } from '~/services/available-sites'
+import { getCurrentSiteHost } from '~/services/get-current-site-host'
 
 // Middleware computes og:url for meta tags (SEO)
 export default function (context) {
   const { app, route } = context
-  const host = getHost(app.i18n.locale)
+  const host = getCurrentSiteHost(app.i18n.locale, true)
   context.currentPagePath = `${host}${route.path}`
-}
-
-function getHost(locale) {
-  if (process.env.SITE === SITES_PRISMIC_TAGS.PIX_SITE) {
-    return locale === 'fr-fr' ? 'https://pix.fr' : 'https://pix.org'
-  }
-  return 'https://pro.pix.fr'
 }

--- a/services/get-current-site-host.js
+++ b/services/get-current-site-host.js
@@ -1,12 +1,13 @@
 import { SITES_PRISMIC_TAGS } from './available-sites'
 
-export function getCurrentSiteHost(locale) {
+export function getCurrentSiteHost(locale, withProtocol = false) {
+  const protocol = withProtocol ? 'https://' : ''
   const subDomain =
     process.env.SITE === SITES_PRISMIC_TAGS.PIX_PRO ? 'pro.' : ''
 
   if (locale === 'fr-fr') {
-    return `${subDomain}pix.fr`
+    return `${protocol}${subDomain}pix.fr`
   }
 
-  return `${subDomain}pix.org`
+  return `${protocol}${subDomain}pix.org`
 }

--- a/services/get-current-site-host.js
+++ b/services/get-current-site-host.js
@@ -1,7 +1,12 @@
 import { SITES_PRISMIC_TAGS } from './available-sites'
 
 export function getCurrentSiteHost(locale) {
-  if (process.env.SITE === SITES_PRISMIC_TAGS.PIX_PRO) return 'pro.pix.fr'
-  if (locale === 'fr-fr') return 'pix.fr'
-  return 'pix.org'
+  const subDomain =
+    process.env.SITE === SITES_PRISMIC_TAGS.PIX_PRO ? 'pro.' : ''
+
+  if (locale === 'fr-fr') {
+    return `${subDomain}pix.fr`
+  }
+
+  return `${subDomain}pix.org`
 }

--- a/tests/components/PixLink.test.js
+++ b/tests/components/PixLink.test.js
@@ -91,12 +91,48 @@ describe('Component: PixLink', () => {
     describe('when current site is pro.pix.fr', () => {
       beforeEach(() => {
         process.env.SITE = SITES_PRISMIC_TAGS.PIX_PRO
+        locale = 'fr-fr'
+      })
+
+      it('should remove host from URLs under https://pro.pix.fr', () => {
+        const urls = [
+          ['https://pro.pix.fr/', '/'],
+          ['https://pro.pix.fr/une-page-de-pro', '/une-page-de-pro'],
+        ]
+
+        for (const [url, expected] of urls) {
+          expect(removeHostIfCurrentSite(url, locale)).toBe(expected)
+        }
+      })
+
+      it('should not remove host from URLs outside of https://pro.pix.fr', () => {
+        const urls = [
+          'https://pix.fr',
+          'https://pix.fr/une-page-de-la-france',
+          'https://pix.org/',
+          'https://pix.org/fr',
+          'https://pix.org/fr/pourquoi',
+          'https://pix.org/fr-be/une-fois',
+          'https://pix.org/en-gb/tea-time',
+          'https://google.com/',
+        ]
+
+        for (const url of urls) {
+          expect(removeHostIfCurrentSite(url, locale)).toBe(url)
+        }
+      })
+    })
+
+    describe('when current site is pro.pix.org', () => {
+      beforeEach(() => {
+        process.env.SITE = SITES_PRISMIC_TAGS.PIX_PRO
+        locale = 'fr'
       })
 
       it('should remove host from URLs under https://pro.pix.org', () => {
         const urls = [
-          ['https://pro.pix.fr/', '/'],
-          ['https://pro.pix.fr/une-page-de-pro', '/une-page-de-pro'],
+          ['https://pro.pix.org/', '/'],
+          ['https://pro.pix.org/une-page-de-pro', '/une-page-de-pro'],
         ]
 
         for (const [url, expected] of urls) {

--- a/tests/middlewares/current-page-path.test.js
+++ b/tests/middlewares/current-page-path.test.js
@@ -1,0 +1,62 @@
+import currentPagePath from '~/middleware/current-page-path'
+
+describe('Middlewares | current-page-path', () => {
+  let oldProcessEnv
+
+  beforeEach(() => {
+    oldProcessEnv = { ...process.env }
+  })
+
+  afterEach(() => {
+    process.env = oldProcessEnv
+  })
+
+  const cases = [
+    {
+      locale: 'fr-fr',
+      site: 'pix-site',
+      path: '/test',
+      expectedResult: 'https://pix.fr/test',
+    },
+    {
+      locale: 'fr',
+      site: 'pix-site',
+      path: '/fr/test',
+      expectedResult: 'https://pix.org/fr/test',
+    },
+    {
+      locale: 'fr-fr',
+      site: 'pix-pro',
+      path: '/test',
+      expectedResult: 'https://pro.pix.fr/test',
+    },
+    {
+      locale: 'fr',
+      site: 'pix-pro',
+      path: '/fr/test',
+      expectedResult: 'https://pro.pix.fr/fr/test',
+    },
+  ]
+
+  cases.forEach(({ locale, site, path, expectedResult }) => {
+    it(`should return ${expectedResult} when locale is ${locale} and site is ${site}`, () => {
+      // given
+      const context = {
+        app: {
+          i18n: {
+            locale,
+          },
+        },
+        route: { path },
+        currentPagePath: null,
+      }
+      process.env.SITE = site
+
+      // when
+      currentPagePath(context)
+
+      // then
+      expect(context.currentPagePath).toEqual(expectedResult)
+    })
+  })
+})

--- a/tests/middlewares/current-page-path.test.js
+++ b/tests/middlewares/current-page-path.test.js
@@ -34,7 +34,7 @@ describe('Middlewares | current-page-path', () => {
       locale: 'fr',
       site: 'pix-pro',
       path: '/fr/test',
-      expectedResult: 'https://pro.pix.fr/fr/test',
+      expectedResult: 'https://pro.pix.org/fr/test',
     },
   ]
 

--- a/tests/services/get-current-site-host.test.js
+++ b/tests/services/get-current-site-host.test.js
@@ -29,4 +29,26 @@ describe('getCurrentSiteHost', () => {
     process.env.SITE = 'pix-pro'
     expect(getCurrentSiteHost('fr')).toBe('pro.pix.org')
   })
+
+  describe('when withPrefix is true', () => {
+    test('should return pix.fr if `SITE` env variable is `pix-site` and locale `fr-fr`', () => {
+      process.env.SITE = 'pix-site'
+      expect(getCurrentSiteHost('fr-fr', true)).toBe('https://pix.fr')
+    })
+
+    test('should return pix.org if `SITE` env variable is `pix-site` and locale not `fr-fr`', () => {
+      process.env.SITE = 'pix-site'
+      expect(getCurrentSiteHost('fr', true)).toBe('https://pix.org')
+    })
+
+    test('should return pro.pix.fr if `SITE` env variable is `pix-pro`', () => {
+      process.env.SITE = 'pix-pro'
+      expect(getCurrentSiteHost('fr-fr', true)).toBe('https://pro.pix.fr')
+    })
+
+    test('should return pro.pix.org if `SITE` env variable is `pix-pro` and locale is not `fr-fr`', () => {
+      process.env.SITE = 'pix-pro'
+      expect(getCurrentSiteHost('fr', true)).toBe('https://pro.pix.org')
+    })
+  })
 })

--- a/tests/services/get-current-site-host.test.js
+++ b/tests/services/get-current-site-host.test.js
@@ -3,7 +3,7 @@ const { getCurrentSiteHost } = require('~/services/get-current-site-host')
 describe('getCurrentSiteHost', () => {
   let savedProcessEnvSite
   beforeEach(() => {
-    savedProcessEnvSite = process.env.SITE
+    savedProcessEnvSite = { ...process.env.SITE }
   })
 
   afterEach(() => {
@@ -22,6 +22,11 @@ describe('getCurrentSiteHost', () => {
 
   test('should return pro.pix.fr if `SITE` env variable is `pix-pro`', () => {
     process.env.SITE = 'pix-pro'
-    expect(getCurrentSiteHost()).toBe('pro.pix.fr')
+    expect(getCurrentSiteHost('fr-fr')).toBe('pro.pix.fr')
+  })
+
+  test('should return pro.pix.org if `SITE` env variable is `pix-pro` and locale is not `fr-fr`', () => {
+    process.env.SITE = 'pix-pro'
+    expect(getCurrentSiteHost('fr')).toBe('pro.pix.org')
   })
 })


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, sur pro.pix.org, le soulignage de la page active dans la barre de navigation ne fonctionne pas. 

## :robot: Solution
Rétablir le lien

## :rainbow: Remarques
Nous avons factorisé la création des hosts. 

## :100: Pour tester
Se rendre sur https://pro-pr411.review.pix.org/fr/ et constater le soulignage du premier élément de la barre de navigation.

