### PR TITLE
[TECH] Ajouter le lien pro org dans les commentaires (PIX-5133).

### DIFF
--- a/scripts/jira/comment-with-review-app-url.js
+++ b/scripts/jira/comment-with-review-app-url.js
@@ -27,7 +27,8 @@ async function main() {
 
   const raSiteFrURL = `https://site-pr${prNumber}.review.pix.fr`
   const raSiteOrgURL = `https://site-pr${prNumber}.review.pix.org`
-  const raProURL = `https://pro-pr${prNumber}.review.pix.fr`
+  const raProFrURL = `https://pro-pr${prNumber}.review.pix.fr`
+  const raProOrgURL = `https://pro-pr${prNumber}.review.pix.org`
   const prGithubURL = `https://github.com/1024pix/pix-site/pull/${prNumber}`
 
   const scalingoCommentRegex = new RegExp(raSiteFrURL, 'i')
@@ -64,7 +65,8 @@ async function main() {
       'Je viens de déployer la Review App. Elle sera consultable sur les URL suivantes :\n' +
       `- Site FR : ${raSiteFrURL}\n` +
       `- Site ORG : ${raSiteOrgURL}\n` +
-      `- Pro : ${raProURL}\n` +
+      `- Pro FR : ${raProFrURL}\n` +
+      `- Pro ORG : ${raProOrgURL}\n` +
       `Le lien Github de la PR : ${prGithubURL}`
 
     console.log(

--- a/scripts/signal_deploy_to_pr.sh
+++ b/scripts/signal_deploy_to_pr.sh
@@ -24,6 +24,7 @@ PR_NUMBER=$(echo $APP | grep -Po '(?<=-pr)\d+')
 RA_SITE_URL_FR="https://site-pr$PR_NUMBER.review.pix.fr"
 RA_SITE_URL_ORG="https://site-pr$PR_NUMBER.review.pix.org"
 RA_PRO_URL_FR="https://pro-pr$PR_NUMBER.review.pix.fr"
+RA_PRO_URL_ORG="https://pro-pr$PR_NUMBER.review.pix.org"
 
 MESSAGE_PREFIX="I'm deploying this PR to these urls:"
 
@@ -35,5 +36,5 @@ if [[ $existing_comments == *"${MESSAGE_PREFIX}"* ]]; then
 else
 	curl -Ssf -u $GITHUB_USER:$GITHUB_USER_TOKEN \
 		-X POST "https://api.github.com/repos/1024pix/pix-site/issues/${PR_NUMBER}/comments" \
-    --data "{\"body\":\"$MESSAGE_PREFIX\n\n- Pix Site (fr): $RA_SITE_URL_FR\n- Pix Site (org): $RA_SITE_URL_ORG\n- Pix Pro (fr): $RA_PRO_URL_FR\n\n Please check it out!\"}"
+    --data "{\"body\":\"$MESSAGE_PREFIX\n\n- Pix Site (fr): $RA_SITE_URL_FR\n- Pix Site (org): $RA_SITE_URL_ORG\n- Pix Pro (fr): $RA_PRO_URL_FR\n- Pix Pro (org): $RA_PRO_URL_ORG\n\n Please check it out!\"}"
 fi


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le commentaire GitHub et le commentaire sur le ticket Jira ne contiennent pas le lien vers l'environnement pro org.

## :robot: Solution
Ajouter le lien vers pro org dans les 2 commentaires

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Constater le commentaire dans le ticket Jira et dans la PR

