### PR TITLE
[BUGFIX] Mettre les dates des graphiques dans un format plus lisible (PIX-5188).

### DIFF
--- a/components/LineChart.vue
+++ b/components/LineChart.vue
@@ -22,6 +22,14 @@ export default {
             ticks: { beginAtZero: true },
           },
         ],
+        xAxes: [
+          {
+            type: 'time',
+            time: {
+              tooltipFormat: 'L',
+            },
+          },
+        ],
       },
     })
   },


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, les dates des graphiques sont au format ISO, ce qui ne rend pas très bien et n'est pas très lisible.
<img width="1157" alt="Screenshot 2022-07-01 at 14 45 45@2x" src="https://user-images.githubusercontent.com/26384707/176897174-e3483437-26f6-4c7f-bc0c-f86b759cf418.png">


## :robot: Solution
Indiquer à ChartJs qu'il s'agit de date et choisir un format de date pour la tooltip qui a le même problème 
<img width="1166" alt="Screenshot 2022-07-01 at 14 46 56@2x" src="https://user-images.githubusercontent.com/26384707/176897375-d0050928-f25e-4691-aeb9-67107ec315c2.png">

## :rainbow: Remarques
La page statistiques n'existent pas dans d'autre langue nous pouvons donc pas tester l'i18n mais cela ne devrait pas poser de problème puisque ChartJs utilise Moment.

## :100: Pour tester
- Se rendre sur `/statistiques`
