### PR TITLE
[BUGFIX] Générer toutes les langues pour Pix Pro (PIX-5367).

### DIFF
--- a/services/get-routes-to-generate.js
+++ b/services/get-routes-to-generate.js
@@ -26,7 +26,7 @@ async function getRoutesInPage(api, page) {
     {
       pageSize: 100,
       page,
-      lang: config.isPixSite ? '*' : 'fr-fr',
+      lang: '*',
     }
   )
 

--- a/tests/services/get-routes-to-generate.test.js
+++ b/tests/services/get-routes-to-generate.test.js
@@ -32,13 +32,13 @@ describe('#getRoutesToGenerate', () => {
       .mockReturnValue(Symbol('prismic-predicates-not'))
     prismicDocPredicatesAt = prismic.Predicates.at()
     prismicDocPredicatesNot = prismic.Predicates.not()
+    global.console = { info: jest.fn() }
   })
 
   describe('When fetching Pix Pro pages', () => {
     beforeEach(() => {
       config.site = 'pix-pro'
       config.siteDomain = 'pix.fr'
-      config.isPixSite = false
     })
 
     test('it should fetch routes to generate document for each lang', async () => {
@@ -62,7 +62,7 @@ describe('#getRoutesToGenerate', () => {
       expect(prismicApi.query).toBeCalledWith(
         [prismicDocPredicatesAt, prismicDocPredicatesNot],
         {
-          lang: 'fr-fr',
+          lang: '*',
           pageSize: 100,
           page: 1,
         }
@@ -79,7 +79,7 @@ describe('#getRoutesToGenerate', () => {
 
   describe('When fetching Pix Site pages', () => {
     beforeEach(() => {
-      config.isPixSite = true
+      config.site = 'pix-site'
     })
     test('it should fetch routes to generate document for each lang', async () => {
       // Given


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, les pages autres que `fr-fr` ne sont pas générées statiquement. Cela engendre donc une preview au moment de l'accès à la page. La preview lors d'un accès directe ne fonctionne pas correctement pour la navigation et on obtient donc une page sans navigation. 

## :robot: Solution
Générer les pages de toutes les langues. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se rendre sur la page [`/entreprises`.](https://pro-pr418.review.pix.org/fr/entreprises/)

