### PR TITLE
Bump automerge action

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,6 +12,6 @@ jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-      - uses: 1024pix/pix-actions/auto-merge@v0.1.2
+      - uses: 1024pix/pix-actions/auto-merge@v0.1.3
         with:
           auto_merge_token: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"


### PR DESCRIPTION
## :unicorn: Problème
L'automerge n'était plus à jour ce qui pouvait causer des soucis demandant d'enlever/remettre un label.

## :robot: Solution
Remettre à jour l'automerge.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que l'automerge fonctionne toujours sur cette PR.

