### PR TITLE
[CLEANUP] Met à jour l'action commune d'automerge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,14 +4,18 @@ on:
   pull_request:
     types:
       - labeled
+      - unlabeled
   check_suite:
     types:
       - completed
+  status:
+    types:
+      - success
 
 jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-      - uses: 1024pix/pix-actions/auto-merge@v0.1.3
+      - uses: 1024pix/pix-actions/auto-merge@v0
         with:
           auto_merge_token: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"


### PR DESCRIPTION
## :unicorn: Problème
On utilise une version spécifique de l'action commune d'automerge, et on n'utilise pas la dernière version dispo.

## :robot: Solution
Mettre à jour l'action d'automerge.