### PR TITLE
[TECH] Migrer de moment à dayjs

### DIFF
--- a/components/NewsItemCard.vue
+++ b/components/NewsItemCard.vue
@@ -55,7 +55,7 @@ export default {
       return this.slice.category.toLowerCase()
     },
     date() {
-      return this.$moment(this.slice.date)
+      return this.$dayjs(this.slice.date)
         .locale(this.$i18n.locale.split('-')[0])
         .format('LL')
     },

--- a/components/NewsItemPost.vue
+++ b/components/NewsItemPost.vue
@@ -44,7 +44,7 @@ export default {
       if (!this.newsItem.first_publication_date) {
         return 'Preview'
       }
-      return this.$moment(this.newsItem.data.date)
+      return this.$dayjs(this.newsItem.data.date)
         .locale(this.$i18n.locale.split('-')[0])
         .format('LL')
     },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -94,7 +94,7 @@ const nuxtConfig = {
    */
   modules: [
     '@nuxtjs/style-resources',
-    '@nuxtjs/moment',
+    '@nuxtjs/dayjs',
     '@nuxtjs/robots',
     [
       'nuxt-fontawesome',
@@ -130,8 +130,9 @@ const nuxtConfig = {
       },
     ],
   ],
-  moment: {
-    locales: ['fr'],
+  dayjs: {
+    locales: ['fr', 'en'],
+    plugins: ['localizedFormat'],
   },
   styleResources: {
     scss: ['assets/scss/globals.scss'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,9 @@
       "devDependencies": {
         "@babel/eslint-parser": "^7.16.0",
         "@nuxt/image": "^0.6.0",
+        "@nuxtjs/dayjs": "^1.4.1",
         "@nuxtjs/eslint-config": "^7.0.0",
         "@nuxtjs/eslint-module": "^3.0.2",
-        "@nuxtjs/moment": "1.6.1",
         "@nuxtjs/robots": "^2.5.0",
         "@nuxtjs/style-resources": "^1.2.1",
         "@vue/test-utils": "^1.2.2",
@@ -3585,6 +3585,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@nuxtjs/dayjs": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/dayjs/-/dayjs-1.4.1.tgz",
+      "integrity": "sha512-FgZoFqXxwRPoNJwcN3Up8jvxKnwalIZJF4rX5MWmMpJej75Rl/ShPKkkNxgf3x3gUopOyRjTCLRq/LAVFwY0Pg==",
+      "dev": true,
+      "dependencies": {
+        "consola": "^2.10.1",
+        "dayjs": "^1.10.4"
+      }
+    },
     "node_modules/@nuxtjs/eslint-config": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@nuxtjs/eslint-config/-/eslint-config-7.0.0.tgz",
@@ -3634,18 +3644,6 @@
         "lodash.merge": "^4.6.2",
         "ufo": "^0.7.9",
         "vue-i18n": "^8.26.7"
-      }
-    },
-    "node_modules/@nuxtjs/moment": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/moment/-/moment-1.6.1.tgz",
-      "integrity": "sha512-Mo2/3NQB0XryMQuNCTVnAclrDvt9I9sr6dwVm56KhYCoiWTKgQ78tDV9tmrxw7lahw1IBwyPGhw+3pwkM4phAA==",
-      "dev": true,
-      "dependencies": {
-        "moment": "^2.25.3",
-        "moment-locales-webpack-plugin": "^1.2.0",
-        "moment-timezone": "^0.5.28",
-        "moment-timezone-data-webpack-plugin": "^1.3.0"
       }
     },
     "node_modules/@nuxtjs/prismic": {
@@ -7551,6 +7549,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
+      "dev": true
     },
     "node_modules/de-indent": {
       "version": "1.0.2",
@@ -13708,12 +13712,6 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
-    "node_modules/lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-      "dev": true
-    },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -14172,45 +14170,6 @@
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/moment-locales-webpack-plugin": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.2.0.tgz",
-      "integrity": "sha512-QAi5v0OlPUP7GXviKMtxnpBAo8WmTHrUNN7iciAhNOEAd9evCOvuN0g1N7ThIg3q11GLCkjY1zQ2saRcf/43nQ==",
-      "dev": true,
-      "dependencies": {
-        "lodash.difference": "^4.5.0"
-      },
-      "peerDependencies": {
-        "moment": "^2.8.0",
-        "webpack": "^1 || ^2 || ^3 || ^4 || ^5"
-      }
-    },
-    "node_modules/moment-timezone": {
-      "version": "0.5.39",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.39.tgz",
-      "integrity": "sha512-hoB6suq4ISDj7BDgctiOy6zljBsdYT0++0ZzZm9rtxIvJhIbQ3nmbgSWe7dNFGurl6/7b1OUkHlmN9JWgXVz7w==",
-      "dev": true,
-      "dependencies": {
-        "moment": ">= 2.9.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment-timezone-data-webpack-plugin": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/moment-timezone-data-webpack-plugin/-/moment-timezone-data-webpack-plugin-1.5.0.tgz",
-      "integrity": "sha512-eidUVGn6Fc8jR0tBf8xAhBR1C3jqknFJe0rfzThnglnJjmzqTXRYVTOeobUzWvlEfgTSu+b0W7GgOdqAWvGbYA==",
-      "dev": true,
-      "dependencies": {
-        "find-cache-dir": "^3.0.0",
-        "make-dir": "^3.0.0"
-      },
-      "peerDependencies": {
-        "moment-timezone": ">= 0.1.0",
-        "webpack": "4.x.x || 5.x.x"
       }
     },
     "node_modules/move-concurrently": {
@@ -26206,6 +26165,16 @@
         }
       }
     },
+    "@nuxtjs/dayjs": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/dayjs/-/dayjs-1.4.1.tgz",
+      "integrity": "sha512-FgZoFqXxwRPoNJwcN3Up8jvxKnwalIZJF4rX5MWmMpJej75Rl/ShPKkkNxgf3x3gUopOyRjTCLRq/LAVFwY0Pg==",
+      "dev": true,
+      "requires": {
+        "consola": "^2.10.1",
+        "dayjs": "^1.10.4"
+      }
+    },
     "@nuxtjs/eslint-config": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@nuxtjs/eslint-config/-/eslint-config-7.0.0.tgz",
@@ -26249,18 +26218,6 @@
         "lodash.merge": "^4.6.2",
         "ufo": "^0.7.9",
         "vue-i18n": "^8.26.7"
-      }
-    },
-    "@nuxtjs/moment": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/moment/-/moment-1.6.1.tgz",
-      "integrity": "sha512-Mo2/3NQB0XryMQuNCTVnAclrDvt9I9sr6dwVm56KhYCoiWTKgQ78tDV9tmrxw7lahw1IBwyPGhw+3pwkM4phAA==",
-      "dev": true,
-      "requires": {
-        "moment": "^2.25.3",
-        "moment-locales-webpack-plugin": "^1.2.0",
-        "moment-timezone": "^0.5.28",
-        "moment-timezone-data-webpack-plugin": "^1.3.0"
       }
     },
     "@nuxtjs/prismic": {
@@ -29370,6 +29327,12 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "dayjs": {
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
+      "dev": true
     },
     "de-indent": {
       "version": "1.0.2",
@@ -33925,12 +33888,6 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
-    "lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-      "dev": true
-    },
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -34293,34 +34250,6 @@
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
-    },
-    "moment-locales-webpack-plugin": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.2.0.tgz",
-      "integrity": "sha512-QAi5v0OlPUP7GXviKMtxnpBAo8WmTHrUNN7iciAhNOEAd9evCOvuN0g1N7ThIg3q11GLCkjY1zQ2saRcf/43nQ==",
-      "dev": true,
-      "requires": {
-        "lodash.difference": "^4.5.0"
-      }
-    },
-    "moment-timezone": {
-      "version": "0.5.39",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.39.tgz",
-      "integrity": "sha512-hoB6suq4ISDj7BDgctiOy6zljBsdYT0++0ZzZm9rtxIvJhIbQ3nmbgSWe7dNFGurl6/7b1OUkHlmN9JWgXVz7w==",
-      "dev": true,
-      "requires": {
-        "moment": ">= 2.9.0"
-      }
-    },
-    "moment-timezone-data-webpack-plugin": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/moment-timezone-data-webpack-plugin/-/moment-timezone-data-webpack-plugin-1.5.0.tgz",
-      "integrity": "sha512-eidUVGn6Fc8jR0tBf8xAhBR1C3jqknFJe0rfzThnglnJjmzqTXRYVTOeobUzWvlEfgTSu+b0W7GgOdqAWvGbYA==",
-      "dev": true,
-      "requires": {
-        "find-cache-dir": "^3.0.0",
-        "make-dir": "^3.0.0"
-      }
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7.16.0",
     "@nuxt/image": "^0.6.0",
+    "@nuxtjs/dayjs": "^1.4.1",
     "@nuxtjs/eslint-config": "^7.0.0",
     "@nuxtjs/eslint-module": "^3.0.2",
-    "@nuxtjs/moment": "1.6.1",
     "@nuxtjs/robots": "^2.5.0",
     "@nuxtjs/style-resources": "^1.2.1",
     "@vue/test-utils": "^1.2.2",


### PR DESCRIPTION
## :unicorn: Problème
[Moment.js n'est plus mis à jour](https://momentjs.com/docs/#/-project-status/).

## :robot: Solution
En lien avec [cet ADR](https://github.com/1024pix/pix/blob/dev/docs/adr/0030-revoir-le-choix-d-une-librairie-de-gestion-des-dates.md), on remplace par [dayjs](https://www.npmjs.com/package/@nuxtjs/dayjs). C'est d'ailleurs le plus simple à mettre en place.

## :rainbow: Remarques
Dayjs ne fournit pas de traductions `fr-fr` ou `fr-be`. J'ai enregistré `fr` et `en` qui sont suffisamment génériques pour notre besoin. On se base sur la partie "langue" de la locale pour choisir la bonne langue.

Le plugin `localizedFormat` permet d'afficher les dates en toutes lettres. (visiblement la traduction ne fonctionne pas du tout sans ce plugin...)

On devrait y gagner sur le poids du bundle.

## :100: Pour tester
Vérifier qu'on trouve toujours les dates sur les actualités, qu'elles sont formatées au format "français" sur les locales françaises et en en "anglais" sur `en-gb`. C'était déjà le cas auparavant donc il n'y est pas sensé avoir d'impact mais je ne comprend pas comment ça fonctionnait...

