### PR TITLE
[FEATURE] Utiliser la bonne valeur d'attribut `lang` sur la balise `html` (PIX-6520)

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -9,6 +9,18 @@
   </div>
 </template>
 
+<script>
+export default {
+  head() {
+    return {
+      htmlAttrs: {
+        lang: this.$i18n.locale,
+      },
+    }
+  },
+}
+</script>
+
 <style lang="scss">
 html {
   font-size: 16px;

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -23,6 +23,9 @@ export default {
   head() {
     return {
       title: 'Error | Pix',
+      htmlAttrs: {
+        lang: this.$i18n.locale,
+      },
     }
   },
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -33,9 +33,6 @@ const nuxtConfig = {
    ** Headers of the page
    */
   head: {
-    htmlAttrs: {
-      lang: 'fr',
-    },
     title: 'Pix - Cultivez vos compétences numériques',
     meta: [
       { charset: 'utf-8' },

--- a/tests/layouts/default.test.js
+++ b/tests/layouts/default.test.js
@@ -1,0 +1,63 @@
+import { shallowMount } from '@vue/test-utils'
+import VueMeta from 'vue-meta'
+import { createLocalVue } from '../pages/pix-site/utils'
+import DefaultLayout from '~/layouts/default.vue'
+
+const localVue = createLocalVue()
+localVue.use(VueMeta, { keyName: 'head' })
+
+describe.only('Default layout', () => {
+  let $i18n, wrapper
+  const stubs = {
+    HotNewsBanner: true,
+    NavigationSliceZone: true,
+    Nuxt: true,
+    FooterSliceZone: true,
+  }
+
+  beforeEach(() => {
+    $i18n = { locale: 'fr-be' }
+  })
+
+  it('should render the #app element', () => {
+    // given
+    wrapper = shallowMount(DefaultLayout, {
+      localVue,
+      stubs,
+      mocks: { $i18n },
+    })
+
+    // then
+    expect(wrapper.find('#app').exists()).toBe(true)
+  })
+
+  it('should define the current locale as html lang', () => {
+    // given
+    wrapper = shallowMount(DefaultLayout, {
+      localVue,
+      stubs,
+      mocks: { $i18n },
+    })
+
+    // then
+    expect(wrapper.vm.$metaInfo.htmlAttrs).toHaveProperty('lang', $i18n.locale)
+  })
+
+  describe('when using another locale', () => {
+    it('should define this other locale as html lang', () => {
+      // given
+      $i18n = { locale: 'en' }
+      wrapper = shallowMount(DefaultLayout, {
+        localVue,
+        stubs,
+        mocks: { $i18n },
+      })
+
+      // then
+      expect(wrapper.vm.$metaInfo.htmlAttrs).toHaveProperty(
+        'lang',
+        $i18n.locale
+      )
+    })
+  })
+})

--- a/tests/layouts/error.test.js
+++ b/tests/layouts/error.test.js
@@ -1,0 +1,64 @@
+import { shallowMount } from '@vue/test-utils'
+import VueMeta from 'vue-meta'
+import { createLocalVue } from '../pages/pix-site/utils'
+import ErrorLayout from '~/layouts/error.vue'
+
+const localVue = createLocalVue()
+localVue.use(VueMeta, { keyName: 'head' })
+
+describe.only('Error layout', () => {
+  let $i18n, $t, wrapper
+  const stubs = {
+    HotNewsBanner: true,
+    NavigationSliceZone: true,
+    Nuxt: true,
+    FooterSliceZone: true,
+  }
+
+  beforeEach(() => {
+    $i18n = { locale: 'fr-be' }
+    $t = () => {}
+  })
+
+  it('should render the .error element', () => {
+    // given
+    wrapper = shallowMount(ErrorLayout, {
+      localVue,
+      stubs,
+      mocks: { $i18n, $t },
+    })
+
+    // then
+    expect(wrapper.find('.error').exists()).toBe(true)
+  })
+
+  it('should define the current locale as html lang', () => {
+    // given
+    wrapper = shallowMount(ErrorLayout, {
+      localVue,
+      stubs,
+      mocks: { $i18n, $t },
+    })
+
+    // then
+    expect(wrapper.vm.$metaInfo.htmlAttrs).toHaveProperty('lang', $i18n.locale)
+  })
+
+  describe('when using another locale', () => {
+    it('should define this other locale as html lang', () => {
+      // given
+      $i18n = { locale: 'en' }
+      wrapper = shallowMount(ErrorLayout, {
+        localVue,
+        stubs,
+        mocks: { $i18n, $t },
+      })
+
+      // then
+      expect(wrapper.vm.$metaInfo.htmlAttrs).toHaveProperty(
+        'lang',
+        $i18n.locale
+      )
+    })
+  })
+})


### PR DESCRIPTION
## :unicorn: Problème
Pour l'instant, l'attribut `lang` de la balise `html` est toujours setté à `fr`. En réalité, la langue utilisée n'est pas la même sur les différentes versions du site.

## :robot: Solution
Dans nos layouts, remplir la valeur de `lang` en fonction de la locale sélectionnée.

## :rainbow: Remarques
Ce manquement a des impacts assez important comme [listé sur ce site](https://www.matuzo.at/blog/lang-attribute/).

Pour aller plus loin, notamment en termes de SEO, il faudra peut être étudier la méthode [this.$nuxtI18nHead](https://i18n.nuxtjs.org/seo/).

## :100: Pour tester
Vérifier sur chaque locale, que l'attribut `lang` correspond à la locale : 
- sur la homepage
- sur la page d'erreur (par exemple si la page n'existe pas)

