### PR TITLE
[TECH] Simplifier la lecture des configurations i18n en fonction du domaine.

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -5,6 +5,7 @@ export const config = {
   siteDomain: process.env.SITE_DOMAIN,
   isFrenchDomain: process.env.SITE_DOMAIN === 'pix.fr',
   isPixSite: process.env.SITE === SITES_PRISMIC_TAGS.PIX_SITE,
+  isSeoIndexingEnabled: process.env.SEO_ENABLE_INDEXING === 'true',
   prismic: {
     apiEndpoint: process.env.PRISMIC_API_ENDPOINT,
   },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -5,6 +5,22 @@ import { language } from './config/language'
 import { config } from './config/environment'
 import { SITES_PRISMIC_TAGS } from './services/available-sites'
 
+const i18nConfigurationForFrenchDomain = {
+  defaultLocale: 'fr-fr',
+  strategy: 'prefix_except_default',
+  vueI18n: {
+    fallbackLocale: 'fr-fr',
+  },
+}
+
+const i18nConfigurationForInternationalDomain = {
+  defaultLocale: 'fr',
+  strategy: 'prefix',
+  vueI18n: {
+    fallbackLocale: 'fr',
+  },
+}
+
 const nuxtConfig = {
   generate: {
     routes,
@@ -85,14 +101,12 @@ const nuxtConfig = {
 
   i18n: {
     detectBrowserLanguage: false,
-    defaultLocale: config.isFrenchDomain ? 'fr-fr' : 'fr',
-    strategy: config.isFrenchDomain ? 'prefix_except_default' : 'prefix',
     locales: language.locales,
     lazy: true,
     langDir: 'lang/',
-    vueI18n: {
-      fallbackLocale: config.isFrenchDomain ? 'fr-fr' : 'fr',
-    },
+    ...(config.isFrenchDomain
+      ? i18nConfigurationForFrenchDomain
+      : i18nConfigurationForInternationalDomain),
   },
 
   prismic: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,6 +1,5 @@
 import { transports } from 'winston'
 import routes from './services/get-routes-to-generate'
-import isSeoIndexingEnabled from './services/is-seo-indexing-enabled'
 import { language } from './config/language'
 import { config } from './config/environment'
 import { SITES_PRISMIC_TAGS } from './services/available-sites'
@@ -59,7 +58,7 @@ const nuxtConfig = {
         content:
           'Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques tout au long de la vie.',
       },
-      isSeoIndexingEnabled() ? {} : { name: 'robots', content: 'noindex' },
+      config.isSeoIndexingEnabled ? {} : { name: 'robots', content: 'noindex' },
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
     script: [],
@@ -147,7 +146,7 @@ const nuxtConfig = {
   robots: () => {
     return {
       UserAgent: '*',
-      Disallow: isSeoIndexingEnabled() ? '' : '/',
+      Disallow: config.isSeoIndexingEnabled ? '' : '/',
     }
   },
 

--- a/services/is-seo-indexing-enabled.js
+++ b/services/is-seo-indexing-enabled.js
@@ -1,3 +1,0 @@
-export default function isSeoIndexingEnabled() {
-  return process.env.SEO_ENABLE_INDEXING === 'true'
-}


### PR DESCRIPTION
## :unicorn: Problème
Lire la configuration i18n en fonction du domaine sur lequel on se trouve peut être complexe.

## :robot: Solution
Exporter les configurations liées au domaine dans des constantes dédiées pour faciliter la lecture

## :rainbow: Remarques
On peut se demander si on souhaite pas extraire même la configuration en commun dans chaque nouvelle variable.

Au passage, j'ai remis dans la config le service is-seo-indexing-enabled qui est l'endroit le plus adapté

## :100: Pour tester
- Vérifier le bon fonctionnement des 4 RA 