### PR TITLE
[TECH] Améliorer la lisibilité des configurations des modules 

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -147,12 +147,14 @@ const nuxtConfig = {
       },
     ],
   ],
+
+  styleResources: {
+    scss: ['assets/scss/globals.scss'],
+  },
+
   dayjs: {
     locales: ['fr', 'en'],
     plugins: ['localizedFormat'],
-  },
-  styleResources: {
-    scss: ['assets/scss/globals.scss'],
   },
 
   router: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -113,30 +113,7 @@ const nuxtConfig = {
     '@nuxtjs/style-resources',
     '@nuxtjs/dayjs',
     '@nuxtjs/robots',
-    [
-      'nuxt-fontawesome',
-      {
-        component: 'fa',
-        imports: [
-          {
-            set: '@fortawesome/free-solid-svg-icons',
-            icons: [
-              'faAngleDown',
-              'faAngleUp',
-              'faAngleRight',
-              'faArrowRight',
-              'faCalendar',
-              'faCheck',
-              'faCircle',
-              'faCog',
-              'faExclamationTriangle',
-              'faHome',
-              'faPlayCircle',
-            ],
-          },
-        ],
-      },
-    ],
+    'nuxt-fontawesome',
     [
       'nuxt-winston-log',
       {
@@ -162,6 +139,28 @@ const nuxtConfig = {
       UserAgent: '*',
       Disallow: isSeoIndexingEnabled() ? '' : '/',
     }
+  },
+
+  fontAwesome: {
+    component: 'fa',
+    imports: [
+      {
+        set: '@fortawesome/free-solid-svg-icons',
+        icons: [
+          'faAngleDown',
+          'faAngleUp',
+          'faAngleRight',
+          'faArrowRight',
+          'faCalendar',
+          'faCheck',
+          'faCircle',
+          'faCog',
+          'faExclamationTriangle',
+          'faHome',
+          'faPlayCircle',
+        ],
+      },
+    ],
   },
 
   router: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -91,6 +91,11 @@ const nuxtConfig = {
     },
   },
 
+  prismic: {
+    endpoint: config.prismic.apiEndpoint,
+    modern: true,
+  },
+
   image: {
     provider: 'static',
     domains: [
@@ -150,10 +155,6 @@ const nuxtConfig = {
     scss: ['assets/scss/globals.scss'],
   },
 
-  prismic: {
-    endpoint: config.prismic.apiEndpoint,
-    modern: true,
-  },
   router: {
     middleware: 'current-page-path',
     linkExactActiveClass: 'current-active-link',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -157,16 +157,18 @@ const nuxtConfig = {
     plugins: ['localizedFormat'],
   },
 
-  router: {
-    middleware: 'current-page-path',
-    linkExactActiveClass: 'current-active-link',
-  },
   robots: () => {
     return {
       UserAgent: '*',
       Disallow: isSeoIndexingEnabled() ? '' : '/',
     }
   },
+
+  router: {
+    middleware: 'current-page-path',
+    linkExactActiveClass: 'current-active-link',
+  },
+
   /*
    ** Build configuration
    */

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -114,15 +114,7 @@ const nuxtConfig = {
     '@nuxtjs/dayjs',
     '@nuxtjs/robots',
     'nuxt-fontawesome',
-    [
-      'nuxt-winston-log',
-      {
-        loggerOptions: {
-          level: 'debug',
-          transports: [new transports.Console()],
-        },
-      },
-    ],
+    'nuxt-winston-log',
   ],
 
   styleResources: {
@@ -161,6 +153,13 @@ const nuxtConfig = {
         ],
       },
     ],
+  },
+
+  winstonLog: {
+    loggerOptions: {
+      level: 'debug',
+      transports: [new transports.Console()],
+    },
   },
 
   router: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -72,12 +72,16 @@ const nuxtConfig = {
    */
   buildModules: [
     // Doc: https://github.com/nuxt-community/eslint-module
-    ['@nuxtjs/eslint-module', { fix: true }],
+    '@nuxtjs/eslint-module',
     '~/modules/propagate-fetch-error-during-generation',
     '@nuxtjs/i18n',
     '@nuxtjs/prismic',
     '@nuxt/image',
   ],
+
+  eslint: {
+    fix: true,
+  },
 
   i18n: {
     detectBrowserLanguage: false,

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -79,6 +79,18 @@ const nuxtConfig = {
     '@nuxt/image',
   ],
 
+  i18n: {
+    detectBrowserLanguage: false,
+    defaultLocale: config.isFrenchDomain ? 'fr-fr' : 'fr',
+    strategy: config.isFrenchDomain ? 'prefix_except_default' : 'prefix',
+    locales: language.locales,
+    lazy: true,
+    langDir: 'lang/',
+    vueI18n: {
+      fallbackLocale: config.isFrenchDomain ? 'fr-fr' : 'fr',
+    },
+  },
+
   image: {
     provider: 'static',
     domains: [
@@ -137,17 +149,7 @@ const nuxtConfig = {
   styleResources: {
     scss: ['assets/scss/globals.scss'],
   },
-  i18n: {
-    detectBrowserLanguage: false,
-    defaultLocale: config.isFrenchDomain ? 'fr-fr' : 'fr',
-    strategy: config.isFrenchDomain ? 'prefix_except_default' : 'prefix',
-    locales: language.locales,
-    lazy: true,
-    langDir: 'lang/',
-    vueI18n: {
-      fallbackLocale: config.isFrenchDomain ? 'fr-fr' : 'fr',
-    },
-  },
+
   prismic: {
     endpoint: config.prismic.apiEndpoint,
     modern: true,


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous configurons les modules que nous utilisons de 2 manières différentes, ce qui créé de la complexité à la lecture et de la confusion lors de l'ajout d'un nouveau module

## :robot: Solution
- Configurer un module en utilisant sa clé de configuration dédiée

## :rainbow: Remarques
- Certaines clés ont été mises en dessous de là où le module a été déclaré

## :100: Pour tester
- Vérifier le bon fonctionnement des RA