### PR TITLE
[TECH] Ajouter des tests sur le language switcher

### DIFF
--- a/tests/components/LanguageSwitcher.test.js
+++ b/tests/components/LanguageSwitcher.test.js
@@ -1,66 +1,103 @@
-import { shallowMount } from '@vue/test-utils'
+import { shallowMount, mount } from '@vue/test-utils'
 import LanguageSwitcher from '~/components/LanguageSwitcher/LanguageSwitcher'
+import LanguageSwitcherSubMenu from '~/components/LanguageSwitcher/LanguageSwitcherSubMenu.vue'
 
 describe('Component: LanguageSwitcher', () => {
-  it('should render the language switcher if site is pix-pro.fr', () => {
-    // given
-    const $t = () => {}
-    const $i18n = { locale: 'fr-fr' }
+  let oldDomainFr
+  let oldDomainOrg
 
-    // when
-    const wrapper = shallowMount(LanguageSwitcher, {
-      stubs: {
-        LanguageSwitcherSubMenu: true,
-        fa: true,
-      },
-      propsData: {
-        type: 'with-dropdown',
-      },
-      data: LanguageSwitcher.data,
-      computed: LanguageSwitcher.computed,
-      mocks: { $t, $i18n },
-    })
-
-    // then
-    expect(wrapper.find('.language-switcher__button').exists()).toBe(true)
+  beforeEach(() => {
+    oldDomainFr = process.env.DOMAIN_FR
+    oldDomainOrg = process.env.DOMAIN_ORG
+    process.env.DOMAIN_FR = 'example.fr'
+    process.env.DOMAIN_ORG = 'example.org'
   })
 
-  it('should render the language switcher if site is pix-pro.org', async () => {
-    // given
-    const $t = () => {}
-    const $i18n = { locale: 'fr' }
+  afterEach(() => {
+    process.env.DOMAIN_FR = oldDomainFr
+    process.env.DOMAIN_ORG = oldDomainOrg
+  })
 
-    const LanguageSwitcherSubMenuStub = {
-      name: 'language-switcher-burger-menu',
-      template: '<div class="language-switcher__dropdown-menu child"/>',
-    }
-
-    const wrapper = shallowMount(LanguageSwitcher, {
-      stubs: {
-        LanguageSwitcherSubMenu: LanguageSwitcherSubMenuStub,
-        fa: true,
-      },
-      propsData: {
-        type: 'with-dropdown',
-      },
-      data: LanguageSwitcher.data,
-      computed: LanguageSwitcher.computed,
-      mocks: { $t, $i18n },
+  describe('when site is pix-pro', () => {
+    let oldSite
+    beforeEach(() => {
+      oldSite = process.env.SITE
+      process.env.SITE = 'pix-pro'
     })
 
-    const languageSwitcher = wrapper.find('.language-switcher__button')
+    afterEach(() => {
+      process.env.SITE = oldSite
+    })
 
-    // when
-    await languageSwitcher.trigger('click')
-    const languageChildrenSubMenuButton = wrapper.find(
-      '.language-switcher-sub-menu-button'
-    )
-    await languageChildrenSubMenuButton.trigger('click')
-    const languageChildrenSubMenu = wrapper.find(
-      '.language-switcher__dropdown-menu.child'
-    )
+    it('should render the language switcher', () => {
+      // given
+      const $t = () => {}
+      const $i18n = { locale: 'fr-fr' }
 
-    // then
-    expect(languageChildrenSubMenu.exists()).toBe(true)
+      // when
+      const wrapper = shallowMount(LanguageSwitcher, {
+        stubs: {
+          LanguageSwitcherSubMenu: true,
+          fa: true,
+        },
+        propsData: {
+          type: 'with-dropdown',
+        },
+        data: LanguageSwitcher.data,
+        computed: LanguageSwitcher.computed,
+        mocks: { $t, $i18n },
+      })
+
+      // then
+      expect(wrapper.find('.language-switcher__button').exists()).toBe(true)
+    })
+
+    it('should render the language switcher correctly for pix-pro', async () => {
+      // given
+      const $t = () => {}
+      const $i18n = { locale: 'fr-fr' }
+
+      // when
+      const wrapper = mount(LanguageSwitcher, {
+        components: { LanguageSwitcherSubMenu },
+        mocks: { $t, $i18n },
+        stubs: { fa: true },
+      })
+      await wrapper.find('button').trigger('click')
+      await wrapper.find('.language-switcher-sub-menu-button').trigger('click')
+
+      // then
+      expect(wrapper.element).toMatchSnapshot()
+    })
+  })
+
+  describe('when site is pix-site', () => {
+    let oldSite
+    beforeEach(() => {
+      oldSite = process.env.SITE
+      process.env.SITE = 'pix-site'
+    })
+
+    afterEach(() => {
+      process.env.SITE = oldSite
+    })
+
+    it('should render the language switcher correctly for pix-site', async () => {
+      // given
+      const $t = () => {}
+      const $i18n = { locale: 'fr-fr' }
+
+      // when
+      const wrapper = mount(LanguageSwitcher, {
+        components: { LanguageSwitcherSubMenu },
+        mocks: { $t, $i18n },
+        stubs: { fa: true },
+      })
+      await wrapper.find('button').trigger('click')
+      await wrapper.find('.language-switcher-sub-menu-button').trigger('click')
+
+      // then
+      expect(wrapper.element).toMatchSnapshot()
+    })
   })
 })

--- a/tests/components/__snapshots__/LanguageSwitcher.test.js.snap
+++ b/tests/components/__snapshots__/LanguageSwitcher.test.js.snap
@@ -1,0 +1,313 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: LanguageSwitcher when site is pix-pro should render the language switcher correctly for pix-pro 1`] = `
+<div
+  class="language-switcher"
+>
+  <button
+    aria-expanded="true"
+    aria-haspopup="true"
+    class="language-switcher__button"
+  >
+    
+    
+    
+    <fa-stub
+      class="language-switcher-button__angle"
+      icon="angle-up"
+    />
+  </button>
+   
+  <ul
+    class="language-switcher__dropdown-menu"
+  >
+    <li
+      class=""
+    >
+      <div
+        class="language-switcher__lang"
+      >
+        <button
+          class="language-switcher-sub-menu-button"
+        >
+          <img
+            alt=""
+            class="language-switcher__img"
+            src="/images/globe-europe.svg"
+          />
+           
+          <div
+            class="lang__text"
+          >
+            
+          </div>
+           
+          <fa-stub
+            class="language-switcher__icon language-switcher-button__angle"
+            icon="angle-right"
+          />
+        </button>
+      </div>
+       
+      <ul
+        class="language-switcher__dropdown-menu child"
+      >
+        <li
+          class=""
+        >
+          <div
+            class="language-switcher__lang"
+          >
+            <a
+              href="http://example.org/fr"
+            >
+              
+        
+      
+            </a>
+          </div>
+        </li>
+        <li
+          class=""
+        >
+          <div
+            class="language-switcher__lang"
+          >
+            <a
+              href="http://example.org/en-gb"
+            >
+              
+        
+      
+            </a>
+          </div>
+        </li>
+      </ul>
+    </li>
+    <li
+      class="language-switcher__dropdown-menu--active"
+    >
+      <div
+        class="language-switcher__lang"
+      >
+        <a
+          href="/"
+        >
+          <img
+            alt=""
+            class="language-switcher__img"
+            src="/images/flag-fr.svg"
+          />
+           
+          <div
+            class="lang__text"
+          >
+            <div>
+              
+            </div>
+             
+            <!---->
+          </div>
+        </a>
+      </div>
+       
+      <!---->
+    </li>
+    <li
+      class=""
+    >
+      <div
+        class="language-switcher__lang"
+      >
+        <a
+          href="http://example.org/fr-be"
+        >
+          <img
+            alt=""
+            class="language-switcher__img"
+            src="/images/flag-be.svg"
+          />
+           
+          <div
+            class="lang__text"
+          >
+            <div>
+              
+            </div>
+             
+            <div
+              class="language-switcher__subtitle"
+            >
+              
+              
+            
+            </div>
+          </div>
+        </a>
+      </div>
+       
+      <!---->
+    </li>
+  </ul>
+   
+  <span
+    class="separator"
+  />
+</div>
+`;
+
+exports[`Component: LanguageSwitcher when site is pix-site should render the language switcher correctly for pix-site 1`] = `
+<div
+  class="language-switcher"
+>
+  <button
+    aria-expanded="true"
+    aria-haspopup="true"
+    class="language-switcher__button"
+  >
+    
+    
+    
+    <fa-stub
+      class="language-switcher-button__angle"
+      icon="angle-up"
+    />
+  </button>
+   
+  <ul
+    class="language-switcher__dropdown-menu"
+  >
+    <li
+      class=""
+    >
+      <div
+        class="language-switcher__lang"
+      >
+        <button
+          class="language-switcher-sub-menu-button"
+        >
+          <img
+            alt=""
+            class="language-switcher__img"
+            src="/images/globe-europe.svg"
+          />
+           
+          <div
+            class="lang__text"
+          >
+            
+          </div>
+           
+          <fa-stub
+            class="language-switcher__icon language-switcher-button__angle"
+            icon="angle-right"
+          />
+        </button>
+      </div>
+       
+      <ul
+        class="language-switcher__dropdown-menu child"
+      >
+        <li
+          class=""
+        >
+          <div
+            class="language-switcher__lang"
+          >
+            <a
+              href="http://example.org/fr"
+            >
+              
+        
+      
+            </a>
+          </div>
+        </li>
+        <li
+          class=""
+        >
+          <div
+            class="language-switcher__lang"
+          >
+            <a
+              href="http://example.org/en-gb"
+            >
+              
+        
+      
+            </a>
+          </div>
+        </li>
+      </ul>
+    </li>
+    <li
+      class="language-switcher__dropdown-menu--active"
+    >
+      <div
+        class="language-switcher__lang"
+      >
+        <a
+          href="/"
+        >
+          <img
+            alt=""
+            class="language-switcher__img"
+            src="/images/flag-fr.svg"
+          />
+           
+          <div
+            class="lang__text"
+          >
+            <div>
+              
+            </div>
+             
+            <!---->
+          </div>
+        </a>
+      </div>
+       
+      <!---->
+    </li>
+    <li
+      class=""
+    >
+      <div
+        class="language-switcher__lang"
+      >
+        <a
+          href="http://example.org/fr-be"
+        >
+          <img
+            alt=""
+            class="language-switcher__img"
+            src="/images/flag-be.svg"
+          />
+           
+          <div
+            class="lang__text"
+          >
+            <div>
+              
+            </div>
+             
+            <div
+              class="language-switcher__subtitle"
+            >
+              
+              
+            
+            </div>
+          </div>
+        </a>
+      </div>
+       
+      <!---->
+    </li>
+  </ul>
+   
+  <span
+    class="separator"
+  />
+</div>
+`;


### PR DESCRIPTION
## :unicorn: Problème
Le language switcher est à mon gout pas suffisament tester pour que je puisse le refactorer en toute aisance

## :robot: Solution
Ajouter des tests snapshots pour couvrir l'affichage actuelle

## :rainbow: Remarques
On peut relever qu'un test a été supprimé car il ne servait plus, n'ayant plus de différence entre pro.pix.org et pro.pix.fr

## :100: Pour tester
- Constater le bon fonctionnement de la CI
