### PR TITLE
[TECH] Améliorer la lisibilité de la configuration des locales.

### DIFF
--- a/config/language/pix-pro.js
+++ b/config/language/pix-pro.js
@@ -1,5 +1,19 @@
 import { config } from '../environment'
 
+export const availableLocales = [
+  {
+    code: 'fr',
+    file: 'fr.js',
+  },
+  {
+    code: 'en-gb',
+    file: 'en-gb.js',
+  },
+  {
+    code: 'fr-fr',
+    file: 'fr-fr.js',
+  },
+]
 export const language = {
   menu: [
     {
@@ -35,27 +49,14 @@ export const language = {
       sub: null,
     },
   ],
-  locales: availableLocale(),
+  locales: availableLocales,
+  localesForCurrentSite: getLocalesForCurrentSite(),
 }
 
-export function availableLocale() {
-  if (!config.isFrenchDomain) {
-    return [
-      {
-        code: 'fr',
-        file: 'fr.js',
-      },
-      {
-        code: 'en-gb',
-        file: 'en-gb.js',
-      },
-    ]
+export function getLocalesForCurrentSite() {
+  if (config.isFrenchDomain) {
+    return [{ code: 'fr-fr', file: 'fr-fr.js' }]
   }
 
-  return [
-    {
-      code: 'fr-fr',
-      file: 'fr-fr.js',
-    },
-  ]
+  return availableLocales.filter((locale) => locale.code !== 'fr-fr')
 }

--- a/config/language/pix-site.js
+++ b/config/language/pix-site.js
@@ -1,5 +1,24 @@
 import { config } from '../environment'
 
+export const availableLocales = [
+  {
+    code: 'fr',
+    file: 'fr.js',
+  },
+  {
+    code: 'en-gb',
+    file: 'en-gb.js',
+  },
+  {
+    code: 'fr-be',
+    file: 'fr-be.js',
+  },
+  {
+    code: 'fr-fr',
+    file: 'fr-fr.js',
+  },
+]
+
 export const language = {
   menu: [
     {
@@ -43,31 +62,14 @@ export const language = {
       sub: 'fwb',
     },
   ],
-  locales: availableLocale(),
+  locales: availableLocales,
+  localesForCurrentSite: getLocalesForCurrentSite(),
 }
 
-export function availableLocale() {
-  if (!config.isFrenchDomain) {
-    return [
-      {
-        code: 'fr',
-        file: 'fr.js',
-      },
-      {
-        code: 'en-gb',
-        file: 'en-gb.js',
-      },
-      {
-        code: 'fr-be',
-        file: 'fr-be.js',
-      },
-    ]
+export function getLocalesForCurrentSite() {
+  if (config.isFrenchDomain) {
+    return [{ code: 'fr-fr', file: 'fr-fr.js' }]
   }
 
-  return [
-    {
-      code: 'fr-fr',
-      file: 'fr-fr.js',
-    },
-  ]
+  return availableLocales.filter((locale) => locale.code !== 'fr-fr')
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -100,7 +100,7 @@ const nuxtConfig = {
 
   i18n: {
     detectBrowserLanguage: false,
-    locales: language.locales,
+    locales: language.localesForCurrentSite,
     lazy: true,
     langDir: 'lang/',
     ...(config.isFrenchDomain

--- a/services/get-routes-to-generate.js
+++ b/services/get-routes-to-generate.js
@@ -30,10 +30,10 @@ async function getRoutesInPage(api, page) {
     }
   )
 
-  const availableLangs = language.locales.map((locale) => locale.code)
+  const localesToBuild = language.localesForCurrentSite.map(({ code }) => code)
   const routes = results
     .filter(({ uid }) => Boolean(uid))
-    .filter(({ lang }) => availableLangs.includes(lang))
+    .filter(({ lang }) => localesToBuild.includes(lang))
     .map(linkResolver)
 
   return { totalPages, routes }

--- a/tests/config/language/pix-pro.test.js
+++ b/tests/config/language/pix-pro.test.js
@@ -1,4 +1,4 @@
-import { availableLocale, language } from '~/config/language/pix-pro'
+import { getLocalesForCurrentSite, language } from '~/config/language/pix-pro'
 import { config } from '~/config/environment'
 
 jest.mock('~/config/environment', () => {
@@ -9,7 +9,7 @@ jest.mock('~/config/environment', () => {
   }
 })
 
-describe('#availableLocale', () => {
+describe('#getLocalesForCurrentSite', () => {
   it(`should return only fr-fr when siteDomain is pix.fr`, () => {
     config.isFrenchDomain = true
 
@@ -20,7 +20,7 @@ describe('#availableLocale', () => {
       },
     ]
 
-    expect(availableLocale()).toEqual(expectedLocales)
+    expect(getLocalesForCurrentSite()).toEqual(expectedLocales)
   })
 
   it(`should return all locales except fr-fr when siteDomain is pix.org`, () => {
@@ -37,7 +37,7 @@ describe('#availableLocale', () => {
       },
     ]
 
-    expect(availableLocale()).toEqual(expectedLocales)
+    expect(getLocalesForCurrentSite()).toEqual(expectedLocales)
   })
 })
 

--- a/tests/config/language/pix-site.test.js
+++ b/tests/config/language/pix-site.test.js
@@ -1,4 +1,4 @@
-import { availableLocale, language } from '~/config/language/pix-site'
+import { getLocalesForCurrentSite, language } from '~/config/language/pix-site'
 import { config } from '~/config/environment'
 
 jest.mock('~/config/environment', () => {
@@ -9,18 +9,13 @@ jest.mock('~/config/environment', () => {
   }
 })
 
-describe('#availableLocale', () => {
+describe('#getLocalesForCurrentSite', () => {
   it(`should return only fr-fr when siteDomain is pix.fr`, () => {
     config.isFrenchDomain = true
 
-    const expectedLocales = [
-      {
-        code: 'fr-fr',
-        file: 'fr-fr.js',
-      },
-    ]
+    const expectedLocales = [{ code: 'fr-fr', file: 'fr-fr.js' }]
 
-    expect(availableLocale()).toEqual(expectedLocales)
+    expect(getLocalesForCurrentSite()).toEqual(expectedLocales)
   })
 
   it(`should return all locales except fr-fr when siteDomain is pix.org`, () => {
@@ -41,7 +36,7 @@ describe('#availableLocale', () => {
       },
     ]
 
-    expect(availableLocale()).toEqual(expectedLocales)
+    expect(getLocalesForCurrentSite()).toEqual(expectedLocales)
   })
 })
 

--- a/tests/services/get-routes-to-generate.test.js
+++ b/tests/services/get-routes-to-generate.test.js
@@ -14,7 +14,7 @@ jest.mock('~/config/environment', () => {
 jest.mock('~/config/language', () => {
   return {
     language: {
-      locales: [{ code: 'fr-fr' }],
+      localesForCurrentSite: [{ code: 'fr-fr' }],
     },
   }
 })


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous confondons dans la configuration 2 principes différents : 
- les locales que nous proposons aux utilisateurs
- les locales que nous souhaitons pour un site en particulier

Nous mettons à disposions plusieurs locales, certaines uniquement sur le domain .fr (`fr-fr`) d'autres sur le domaine .org (`fr`, `fr-be`, `en-gb`). 
Pour éviter, que l'utilisateur visite des pages d'un site sur l'autre, nous avons décidé de générer uniquement les pages des locales dédiées au domaine et configurer notre serveur pour servir le bon dossier en fonction du domaine. 

Bien qu'un site ait un échantillon réduit de locale par rapport à ce que nous proposons, l'utilisateur lui peut se balader sur toutes les locales et c'est "transparent" pour lui. 

Le problème engendré par cette uniformisation de la configuration, c'est que nous nous retrouvons avec un échantillon réduit de locales quand nous souhaitons les manipuler.

## :robot: Proposition
Expliciter la différence entre les locales qu'on souhaite pour le site en particulier et les locales que nous gérons dans la globalité.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Vérifier le bon fonctionnement des 4 sites : 
- Pix site : 
	- .fr : contient que les pages `fr-fr`
	- .org : les pages sont préfixées par la langue et contient `fr`, `en-gb` et `fr-be`
- Pix Pro : 
	- .fr : contient que les pages `fr-fr`
	- .org : les pages sont préfixées par la langue et contient `fr` et `en-gb` 

Ou 
- Se connecter via un one-off  sur pix site et constater : 
	- que le répertoire : `dist/pix.fr`, contient toutes les pages 
	- que le répertoire : `dist/pix.org` contient un dossier : `fr-be`, `en-gb`, `fr`
- Se connecter via un one-off  sur pix pro et constater : 
	- que le répertoire : `dist/pix.fr`, contient toutes les pages 
	- que le répertoire : `dist/pix.org` contient un dossier : `en-gb`, `fr`	



### Comparer les build avant et après les modifications
- Lancer le build du site avant et après la modification dans 2 dossiers distincts. (`dist` et `dist.prod` sont utilisés ensuite)
- Pour comparer les pages générées, nous pouvons utiliser : 

```shell
comm <(find dist -not -path '*/_nuxt/*' | sed 's/dist//g' | sort) <(find dist.prod -not -path '*/_nuxt/*' | sed 's/dist.prod//g' | sort) | expand -t30
```
 
- La commande `comm` permet de comparer les lignes de 2 fichiers différents
- `find dist -not -path '*/_nuxt/*' | sed 's/dist//g' | sort` Permet de lister tous les fichiers et répertoires de façon récursive dans le répertoire `dist` auquel on ne prend pas en compte les répertoires `*/_nuxt/*` car les fichiers dedans ont des identifiants uniques à chaque build. Ensuite le `| sed 's/dist//g` permet de retirer le nom de répertoire pour pouvoir comparer le résultat de l'autre build.
- `<()` Permet de faire du [Process Substitution](https://www.gnu.org/software/bash/manual/html_node/Process-Substitution.html#Process-Substitution), ça permet d'éviter l'utilisation un fichier temporaire pour le résultat de la commande qui se trouve dedans. 
- `expand -t30` permet d'élargir la taille des tabs pour mieux visualiser les différentes colonnes. 

La commande retourne 3 colonnes : 
- 1 : les lignes que dans le premier ficher
- 2 : les lignes que dans le second fichier
- 3 : les lignes en commun 
