### PR TITLE
[BUGFIX] Corriger l'affichage des icônes (PIX-6602).

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -150,7 +150,7 @@ const nuxtConfig = {
     }
   },
 
-  fontAwesome: {
+  fontawesome: {
     component: 'fa',
     imports: [
       {


### PR DESCRIPTION
## :unicorn: Problème
Les icônes ne sont plus affichés.

## :robot: Solution
Corriger la clé de configuration de `fontawesome` dans le fichier `nuxt.config.js`

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se rendre sur les sites et constater le bon affichage des icônes comme par exemple dans le languageswitcher