### PR TITLE
[TECH] Migrer de nuxt-fontawesome à @nuxtjs/fontawesome

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -91,6 +91,7 @@ const nuxtConfig = {
     '~/modules/propagate-fetch-error-during-generation',
     '@nuxtjs/i18n',
     '@nuxtjs/prismic',
+    '@nuxtjs/fontawesome',
     '@nuxt/image',
   ],
 
@@ -113,6 +114,25 @@ const nuxtConfig = {
     modern: true,
   },
 
+  fontawesome: {
+    component: 'fa',
+    icons: {
+      solid: [
+        'faAngleDown',
+        'faAngleUp',
+        'faAngleRight',
+        'faArrowRight',
+        'faCalendar',
+        'faCheck',
+        'faCircle',
+        'faCog',
+        'faExclamationTriangle',
+        'faHome',
+        'faPlayCircle',
+      ],
+    },
+  },
+
   image: {
     provider: 'static',
     domains: [
@@ -130,7 +150,6 @@ const nuxtConfig = {
     '@nuxtjs/style-resources',
     '@nuxtjs/dayjs',
     '@nuxtjs/robots',
-    'nuxt-fontawesome',
     'nuxt-winston-log',
   ],
 
@@ -148,28 +167,6 @@ const nuxtConfig = {
       UserAgent: '*',
       Disallow: config.isSeoIndexingEnabled ? '' : '/',
     }
-  },
-
-  fontawesome: {
-    component: 'fa',
-    imports: [
-      {
-        set: '@fortawesome/free-solid-svg-icons',
-        icons: [
-          'faAngleDown',
-          'faAngleUp',
-          'faAngleRight',
-          'faArrowRight',
-          'faCalendar',
-          'faCheck',
-          'faCircle',
-          'faCog',
-          'faExclamationTriangle',
-          'faHome',
-          'faPlayCircle',
-        ],
-      },
-    ],
   },
 
   winstonLog: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,11 @@
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/free-solid-svg-icons": "^5.15.4",
-        "@fortawesome/vue-fontawesome": "^2.0.6",
+        "@nuxtjs/fontawesome": "^1.1.2",
         "@nuxtjs/i18n": "^7.1.0",
         "@nuxtjs/prismic": "^1.4.2",
         "chart.js": "^2.9.4",
         "nuxt": "^2.15.1",
-        "nuxt-fontawesome": "0.4.0",
         "nuxt-winston-log": "^1.2.0",
         "postcss-cli": "^9.0.1",
         "vue-burger-menu": "2.0.5",
@@ -1783,11 +1782,11 @@
       }
     },
     "node_modules/@fortawesome/vue-fontawesome": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-2.0.6.tgz",
-      "integrity": "sha512-V3vT3flY15AKbUS31aZOP12awQI3aAzkr2B1KnqcHLmwrmy51DW3pwyBczKdypV8QxBZ8U68Hl2XxK2nudTxpg==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.10.tgz",
+      "integrity": "sha512-b2+SLF31h32LSepVcXe+BQ63yvbq5qmTCy4KfFogCYm2bn68H5sDWUnX+U7MBqnM2aeEk9M7xSoqGnu+wSdY6w==",
       "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1 || >=1.3.0-beta1",
+        "@fortawesome/fontawesome-svg-core": ">= 1.2.0 < 1.3",
         "vue": "~2"
       }
     },
@@ -3625,6 +3624,15 @@
       },
       "peerDependencies": {
         "eslint": ">=7"
+      }
+    },
+    "node_modules/@nuxtjs/fontawesome": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/fontawesome/-/fontawesome-1.1.2.tgz",
+      "integrity": "sha512-QAfo7hdc6hiCOohdR861oNQ+riKW/kD22bYyvaC++xXiiC1hBQcrRQ6xXd5gln+6SKCwT09+C4kGjzTgrwtr7w==",
+      "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^1.2.27",
+        "@fortawesome/vue-fontawesome": "^0.1.9"
       }
     },
     "node_modules/@nuxtjs/i18n": {
@@ -14689,24 +14697,6 @@
         "nuxt": "bin/nuxt.js"
       }
     },
-    "node_modules/nuxt-fontawesome": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/nuxt-fontawesome/-/nuxt-fontawesome-0.4.0.tgz",
-      "integrity": "sha512-4oHIot/WLUBFM7o944EQks7WmntD/YsLxZ+g9mJjY9pHw1FJZBaD7Bd+cDsXvl3h/0/f87QwIXf/AA+vOIY0Ag==",
-      "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^1.2.12",
-        "@fortawesome/vue-fontawesome": "^0.1.4"
-      }
-    },
-    "node_modules/nuxt-fontawesome/node_modules/@fortawesome/vue-fontawesome": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.10.tgz",
-      "integrity": "sha512-b2+SLF31h32LSepVcXe+BQ63yvbq5qmTCy4KfFogCYm2bn68H5sDWUnX+U7MBqnM2aeEk9M7xSoqGnu+wSdY6w==",
-      "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": ">= 1.2.0 < 1.3",
-        "vue": "~2"
-      }
-    },
     "node_modules/nuxt-winston-log": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/nuxt-winston-log/-/nuxt-winston-log-1.2.0.tgz",
@@ -24756,9 +24746,9 @@
       }
     },
     "@fortawesome/vue-fontawesome": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-2.0.6.tgz",
-      "integrity": "sha512-V3vT3flY15AKbUS31aZOP12awQI3aAzkr2B1KnqcHLmwrmy51DW3pwyBczKdypV8QxBZ8U68Hl2XxK2nudTxpg==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.10.tgz",
+      "integrity": "sha512-b2+SLF31h32LSepVcXe+BQ63yvbq5qmTCy4KfFogCYm2bn68H5sDWUnX+U7MBqnM2aeEk9M7xSoqGnu+wSdY6w==",
       "requires": {}
     },
     "@gar/promisify": {
@@ -26199,6 +26189,15 @@
       "requires": {
         "consola": "^2.15.0",
         "eslint-webpack-plugin": "^2.4.1"
+      }
+    },
+    "@nuxtjs/fontawesome": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/fontawesome/-/fontawesome-1.1.2.tgz",
+      "integrity": "sha512-QAfo7hdc6hiCOohdR861oNQ+riKW/kD22bYyvaC++xXiiC1hBQcrRQ6xXd5gln+6SKCwT09+C4kGjzTgrwtr7w==",
+      "requires": {
+        "@fortawesome/fontawesome-svg-core": "^1.2.27",
+        "@fortawesome/vue-fontawesome": "^0.1.9"
       }
     },
     "@nuxtjs/i18n": {
@@ -34676,23 +34675,6 @@
         "@nuxt/vue-app": "2.15.8",
         "@nuxt/vue-renderer": "2.15.8",
         "@nuxt/webpack": "2.15.8"
-      }
-    },
-    "nuxt-fontawesome": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/nuxt-fontawesome/-/nuxt-fontawesome-0.4.0.tgz",
-      "integrity": "sha512-4oHIot/WLUBFM7o944EQks7WmntD/YsLxZ+g9mJjY9pHw1FJZBaD7Bd+cDsXvl3h/0/f87QwIXf/AA+vOIY0Ag==",
-      "requires": {
-        "@fortawesome/fontawesome-svg-core": "^1.2.12",
-        "@fortawesome/vue-fontawesome": "^0.1.4"
-      },
-      "dependencies": {
-        "@fortawesome/vue-fontawesome": {
-          "version": "0.1.10",
-          "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.10.tgz",
-          "integrity": "sha512-b2+SLF31h32LSepVcXe+BQ63yvbq5qmTCy4KfFogCYm2bn68H5sDWUnX+U7MBqnM2aeEk9M7xSoqGnu+wSdY6w==",
-          "requires": {}
-        }
       }
     },
     "nuxt-winston-log": {

--- a/package.json
+++ b/package.json
@@ -37,12 +37,11 @@
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
-    "@fortawesome/vue-fontawesome": "^2.0.6",
+    "@nuxtjs/fontawesome": "^1.1.2",
     "@nuxtjs/i18n": "^7.1.0",
     "@nuxtjs/prismic": "^1.4.2",
     "chart.js": "^2.9.4",
     "nuxt": "^2.15.1",
-    "nuxt-fontawesome": "0.4.0",
     "nuxt-winston-log": "^1.2.0",
     "postcss-cli": "^9.0.1",
     "vue-burger-menu": "2.0.5",


### PR DESCRIPTION
## :unicorn: Problème
On utilise la dépendance [nuxt-fontawesome](https://www.npmjs.com/package/nuxt-fontawesome) pour intégrer nos icônes fontawesome. Il est recommandé de migrer vers la version de l'organisation officielle nuxt : [@nuxtjs/fontawesome](https://www.npmjs.com/package/@nuxtjs/fontawesome).

## :robot: Solution
Utiliser la nouvelle dépendance `@nuxtjs/fontawesome`.

## :rainbow: Remarques
`@nuxtjs/fontawesome` est maintenant un `buildModule` et plus un `module`.

Je ne suis pas sûr de si cela doit être une `dependency` ou une `devDependency`, j'ai gardé ce que l'on avait jusqu'à présent.

## :100: Pour tester
Vérifier que les icônes s'affichent toujours.
