### PR TITLE
[FEATURE] Enregistrer et utiliser la préférence de locale de l'utilisateur (PIX-6506).

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -78,9 +78,9 @@ const nuxtConfig = {
   plugins: [
     '~/plugins/components.js',
     '~/plugins/meta.js',
-    { src: '~plugins/slide-menu', ssr: false },
+    { src: '~plugins/slide-menu', mode: 'client' },
     '~plugins/vue-js-modal',
-    { src: '~/plugins/prismicLinks', ssr: false },
+    { src: '~/plugins/prismicLinks', mode: 'client' },
   ],
   components: true,
   /*

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,5 +1,6 @@
 import { transports } from 'winston'
 import routes from './services/get-routes-to-generate'
+import { filterNuxtPages } from './services/filter-nuxt-pages'
 import { language } from './config/language'
 import { config } from './config/environment'
 import { SITES_PRISMIC_TAGS } from './services/available-sites'
@@ -180,6 +181,9 @@ const nuxtConfig = {
   router: {
     middleware: ['current-page-path'],
     linkExactActiveClass: 'current-active-link',
+    extendRoutes(routes) {
+      return filterNuxtPages(routes, config)
+    },
   },
 
   /*

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -178,7 +178,7 @@ const nuxtConfig = {
   },
 
   router: {
-    middleware: 'current-page-path',
+    middleware: ['current-page-path'],
     linkExactActiveClass: 'current-active-link',
   },
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -81,6 +81,7 @@ const nuxtConfig = {
     { src: '~plugins/slide-menu', mode: 'client' },
     '~plugins/vue-js-modal',
     { src: '~/plugins/prismicLinks', mode: 'client' },
+    { src: '~/plugins/locale-observer', mode: 'client' },
   ],
   components: true,
   /*

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -18,7 +18,6 @@ const i18nConfigurationForInternationalDomain = {
   vueI18n: {
     fallbackLocale: 'fr',
   },
-  rootRedirect: config.isPixSite && !config.isFrenchDomain && 'locale-choice',
 }
 
 const nuxtConfig = {

--- a/pages/pix-pro/locale-home.vue
+++ b/pages/pix-pro/locale-home.vue
@@ -16,7 +16,7 @@
 import { documentFetcher, DOCUMENTS } from '~/services/document-fetcher'
 
 export default {
-  name: 'Index',
+  name: 'LocaleHome',
   nuxtI18n: {
     paths: {
       fr: '/',

--- a/pages/pix-site/index.vue
+++ b/pages/pix-site/index.vue
@@ -1,63 +1,31 @@
-<template>
-  <div class="index">
-    <prismic-custom-slice-zone :slices="slices" />
-  </div>
-</template>
+<template><div></div></template>
 
 <script>
-import { documentFetcher } from '~/services/document-fetcher'
+import { language } from '~/config/language'
 
 export default {
-  name: 'Index',
-  nuxtI18n: {
-    paths: {
-      fr: '/',
-      'fr-fr': '/',
-      'en-gb': '/',
-      'fr-be': '/',
-    },
+  nuxtI18n: false,
+  layout: 'simple',
+  mounted() {
+    const chosenLocale = this.getLocaleFromCookie()
+    const url = chosenLocale ? `/${chosenLocale}/` : '/locale-choice'
+    this.$router.push(url)
   },
-  async asyncData({ app, req, error, currentPagePath }) {
-    try {
-      const document = await documentFetcher(
-        app.$prismic,
-        app.i18n,
-        req
-      ).getPageByUid('index-pix-site')
+  methods: {
+    getLocaleFromCookie() {
+      const localeCookie = document.cookie
+        .split('; ')
+        .find((item) => item.startsWith('locale'))
+      if (!localeCookie) return null
 
-      const latestNewsItems = await documentFetcher(
-        app.$prismic,
-        app.i18n,
-        req
-      ).findNewsItems({ page: 1, pageSize: 3 })
+      const chosenLocale = localeCookie.split('=')[1]
 
-      return {
-        currentPagePath,
-        meta: document.data.meta,
-        document: document.data.body,
-        title: document.data.title[0].text,
-        latestNewsItems,
-      }
-    } catch (e) {
-      console.error({ e })
-      error({ statusCode: 404, message: 'Page not found' })
-    }
-  },
-  head() {
-    const meta = this.$getMeta(this.meta, this.currentPagePath, this.$prismic)
-    return {
-      title: `${this.title} | Pix`,
-      meta,
-    }
-  },
-  computed: {
-    slices() {
-      return this.document.map((slice, index) => {
-        if (slice.slice_type === 'latest_news') {
-          slice.primary.latest_news_items = this.latestNewsItems
-        }
-        return slice
-      })
+      const currentLocales = language.localesForCurrentSite.map(
+        ({ code }) => code
+      )
+      if (!currentLocales.includes(chosenLocale)) return null
+
+      return chosenLocale
     },
   },
 }

--- a/pages/pix-site/locale-home.vue
+++ b/pages/pix-site/locale-home.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="index">
+    <prismic-custom-slice-zone :slices="slices" />
+  </div>
+</template>
+
+<script>
+import { documentFetcher } from '~/services/document-fetcher'
+
+export default {
+  name: 'LocaleHome',
+  nuxtI18n: {
+    paths: {
+      fr: '/',
+      'fr-fr': '/',
+      'en-gb': '/',
+      'fr-be': '/',
+    },
+  },
+  async asyncData({ app, req, error, currentPagePath }) {
+    try {
+      const document = await documentFetcher(
+        app.$prismic,
+        app.i18n,
+        req
+      ).getPageByUid('index-pix-site')
+
+      const latestNewsItems = await documentFetcher(
+        app.$prismic,
+        app.i18n,
+        req
+      ).findNewsItems({ page: 1, pageSize: 3 })
+
+      return {
+        currentPagePath,
+        meta: document.data.meta,
+        document: document.data.body,
+        title: document.data.title[0].text,
+        latestNewsItems,
+      }
+    } catch (e) {
+      console.error({ e })
+      error({ statusCode: 404, message: 'Page not found' })
+    }
+  },
+  head() {
+    const meta = this.$getMeta(this.meta, this.currentPagePath, this.$prismic)
+    return {
+      title: `${this.title} | Pix`,
+      meta,
+    }
+  },
+  computed: {
+    slices() {
+      return this.document.map((slice, index) => {
+        if (slice.slice_type === 'latest_news') {
+          slice.primary.latest_news_items = this.latestNewsItems
+        }
+        return slice
+      })
+    },
+  },
+}
+</script>

--- a/plugins/locale-observer.js
+++ b/plugins/locale-observer.js
@@ -1,0 +1,9 @@
+export default function ({ app }) {
+  app.i18n.onBeforeLanguageSwitch = (oldLocale, newLocale) => {
+    _setLocaleCookie(newLocale)
+  }
+}
+
+function _setLocaleCookie(locale) {
+  document.cookie = `locale=${locale}; path=/; max-age=31536000`
+}

--- a/services/filter-nuxt-pages.js
+++ b/services/filter-nuxt-pages.js
@@ -1,0 +1,9 @@
+export function filterNuxtPages(routes, config) {
+  if (config.isPixSite && config.isFrenchDomain) {
+    return routes.filter(
+      (route) => !(route.name === 'index' && route.path === '/')
+    )
+  }
+
+  return routes
+}

--- a/tests/pages/pix-site/__snapshots__/locale-home.test.js.snap
+++ b/tests/pages/pix-site/__snapshots__/locale-home.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Index Page renders properly 1`] = `
+exports[`LocaleHome Page renders properly 1`] = `
 "<div class=\\"index\\">
   <prismic-custom-slice-zone-stub slices=\\"[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]\\"></prismic-custom-slice-zone-stub>
 </div>"

--- a/tests/pages/pix-site/locale-home.test.js
+++ b/tests/pages/pix-site/locale-home.test.js
@@ -1,0 +1,101 @@
+import VueMeta from 'vue-meta'
+import { getInitialised, createLocalVue } from './utils'
+import { documentFetcher } from '~/services/document-fetcher'
+import getMeta, { fallbackDescription } from '~/services/meta-builder'
+
+const localVue = createLocalVue()
+localVue.prototype.$getMeta = getMeta
+
+localVue.use(VueMeta, { keyName: 'head' })
+
+jest.mock('~/services/document-fetcher')
+
+describe('LocaleHome Page', () => {
+  let wrapper
+  const PRISMIC_META = 'meta info'
+  const PRISMIC_TITLE = 'title'
+
+  beforeEach(async () => {
+    documentFetcher.mockReturnValue({
+      getPageByUid: () =>
+        Promise.resolve({
+          data: {
+            id: '',
+            meta: [
+              {
+                slice_type: 'general_card',
+                primary: { description: '', image: {} },
+              },
+            ],
+            type: 'slice_page',
+            body: [{}, {}, {}, {}, {}, {}, {}, {}],
+            title: [{ text: PRISMIC_TITLE }],
+          },
+        }),
+      findNewsItems: () =>
+        Promise.resolve({
+          data: {
+            id: '',
+            meta: '',
+            body: [{}, {}, {}, {}, {}, {}, {}, {}],
+          },
+        }),
+    })
+    wrapper = await getInitialised('locale-home', {
+      localVue,
+      computed: {
+        $prismic() {
+          return { asText: () => PRISMIC_META }
+        },
+      },
+      stubs: {
+        'prismic-custom-slice-zone': true,
+      },
+    })
+  })
+
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
+  test('mounts properly', () => {
+    expect(wrapper.vm).toBeTruthy()
+  })
+
+  test('renders properly', () => {
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  test('gets the correct title', () => {
+    expect(wrapper.vm.$metaInfo.title).toBe(`${PRISMIC_TITLE} | Pix`)
+    expect(wrapper.vm.$data.title).toBe(PRISMIC_TITLE)
+  })
+
+  test('gets the correct meta description from Prismic', () => {
+    expect(findMetaContent('og:description')).toBe(PRISMIC_META)
+    expect(findMetaContent('description')).toBe(PRISMIC_META)
+  })
+
+  test('uses the fallback meta description when not filled in Prismic', async () => {
+    wrapper = await getInitialised('locale-home', {
+      localVue,
+      computed: {
+        $prismic() {
+          return { asText: () => '' }
+        },
+      },
+      stubs: {
+        'prismic-custom-slice-zone': true,
+      },
+    })
+
+    expect(findMetaContent('og:description')).toBe(fallbackDescription)
+    expect(findMetaContent('description')).toBe(fallbackDescription)
+  })
+
+  function findMetaContent(hid) {
+    const meta = wrapper.vm.$metaInfo.meta.find((m) => m.hid === hid)
+    expect(meta).toBeTruthy()
+    return wrapper.vm.$metaInfo.meta.find((m) => m.hid === hid).content
+  }
+})

--- a/tests/plugins/locale-observer.test.js
+++ b/tests/plugins/locale-observer.test.js
@@ -1,0 +1,64 @@
+import localeObserver from '~/plugins/locale-observer'
+
+describe('Plugins | locale-observer', () => {
+  beforeEach(() => {
+    let cookieJar = ''
+
+    jest.spyOn(document, 'cookie', 'set').mockImplementation((cookie) => {
+      cookieJar = cookie
+    })
+    jest.spyOn(document, 'cookie', 'get').mockImplementation(() => cookieJar)
+  })
+
+  describe('when user switch locale', () => {
+    describe('when no cookie', () => {
+      it('save locale cookie', () => {
+        // given
+        document.cookie = ''
+        const oldLocale = ''
+        const newLocale = 'en-gb'
+        const context = {
+          app: {
+            i18n: {},
+          },
+          route: {
+            path: '/',
+          },
+        }
+
+        // when
+        localeObserver(context)
+        context.app.i18n.onBeforeLanguageSwitch(oldLocale, newLocale)
+
+        // then
+        expect(document.cookie).toEqual(
+          'locale=en-gb; path=/; max-age=31536000'
+        )
+      })
+    })
+
+    describe('when cookie', () => {
+      it('save locale cookie', () => {
+        // given
+        document.cookie = 'locale=en-gb; path=/; max-age=31536000'
+        const oldLocale = 'en-gb'
+        const newLocale = 'fr'
+        const context = {
+          app: {
+            i18n: {},
+          },
+          route: {
+            path: '/',
+          },
+        }
+
+        // when
+        localeObserver(context)
+        context.app.i18n.onBeforeLanguageSwitch(oldLocale, newLocale)
+
+        // then
+        expect(document.cookie).toEqual('locale=fr; path=/; max-age=31536000')
+      })
+    })
+  })
+})

--- a/tests/services/filter-nuxt-pages.test.js
+++ b/tests/services/filter-nuxt-pages.test.js
@@ -1,0 +1,52 @@
+import { filterNuxtPages } from '~/services/filter-nuxt-pages'
+
+describe('FilterNuxtPages', () => {
+  describe('when is french domain', () => {
+    it('should return only locale home at root path', function () {
+      // given
+      const config = {
+        isPixSite: true,
+        isFrenchDomain: true,
+      }
+      const routes = [
+        { name: 'locale_home___fr-fr', path: '/' },
+        { name: 'index', path: '/' },
+        { name: 'foo', path: '/foo' },
+      ]
+
+      // when
+      const filteredRoutes = filterNuxtPages(routes, config)
+
+      // then
+      expect(filteredRoutes).toEqual([
+        { name: 'locale_home___fr-fr', path: '/' },
+        { name: 'foo', path: '/foo' },
+      ])
+    })
+  })
+
+  describe('when is international domain', () => {
+    it('should return routes as is', function () {
+      // given
+      const config = {
+        isPixSite: true,
+        isFrenchDomain: false,
+      }
+      const routes = [
+        { name: 'locale_home___fr', path: '/fr/' },
+        { name: 'index', path: '/' },
+        { name: 'foo', path: '/foo' },
+      ]
+
+      // when
+      const filteredRoutes = filterNuxtPages(routes, config)
+
+      // then
+      expect(filteredRoutes).toEqual([
+        { name: 'locale_home___fr', path: '/fr/' },
+        { name: 'index', path: '/' },
+        { name: 'foo', path: '/foo' },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement l'utilisateur doit choisir sa locale lorsqu'il arrive sur le site international. Et lorsqu'il revient à la racine du site, il lui est redemandé de choisir, ce qui rajoute une interaction et fait que l'accès à Pix n'est pas immédiat.

## :gift: Proposition
- Enregistrer la locale à l'aide d'un cookie grâce [à la callback proposée par nuxt-i18n](https://i18n.nuxtjs.org/callbacks) qui se déclenche lors d'un changement de locale.
- Supprimer la rédirection faite par `nuxt-i18n` pour recoder la redirection dans une nouvelle page `index` : 
	- vers `/locale-choice` quand il n'a pas de cookie `locale`
	- vers l'index de la bonne locale (`localized-home`), quand il a un cookie 
- La nouvelle page index est présente uniquement pour le sitre vitrine international (`pix.org`)

## :star2: Remarques

Les pistes explorées : 

### Middleware

- Au début on ne déclenchait pas les middlewares, car nous n'avions pas de liens internes => corrigé par la PR #456
- Dans nos essais on a eu un problème avec le SSR en dev car on ne pouvait pas accéder au cookie du côté server, mais avec la variable `process.client`, nous avons pu obtenir quelque chose de fonctionnel

Nous avons exploré l'utilisation du middleware en recodant le `rootRedirect` fait par `nuxt-i18n` et en ajoutant notre logique de redirection si un cookie `locale` est présent le POC était fonctionnel  : 

```js
export default function (context) {
  if (process.client) {
    const { route, redirect } = context
    if (route.path !== '/') {
      return
    }

    const localeCookie = _getLocaleFromCookie()
    return localeCookie
      ? redirect(`/${localeCookie}/`)
      : redirect('/locale-choice')
  }
}

function _getLocaleFromCookie() {
  const localeCookie = document.cookie
    .split('; ')
    .find((item) => item.startsWith('locale'))
  if (!localeCookie) return null
  return localeCookie.split('=')[1]
}
```

#### Avantages 
- [La rédirection se fait plus rapidement car elle se situe avant le `mounted` d'une page](https://nuxtjs.org/docs/concepts/nuxt-lifecycle/).

#### Inconvénients 
- Se fait à chaque changement de page, alors que nous en avons besoin que sur la page `index`
- Inclut du js pas utile pour les autres pages
- On obtenait une 403, car le serveur n'arrivait pas à accéder à la page `index` à la racine, car celle-ci n'existe pas.

### Plugin

- Testé avec le hook `beforeEach` du vue-router [navigation guards](https://router.vuejs.org/guide/advanced/navigation-guards.html). Cependant le rootRedirect qu'on demande dans la configuration de nuxt-i18n surgissait ensuite. C'est pourtant pas en accord avec [le lifecycle exposé par Nuxt](https://nuxtjs.org/docs/concepts/nuxt-lifecycle/), cette piste pourrait être aussi exploré de nouveau. 
- Testé avec le hook [`window.onNuxtReady`](https://nuxtjs.org/docs/concepts/context-helpers/#onnuxtready-helper) qui est sensé se lancer qu'une seule fois, mais parfois il se déclenchait parfois plusieurs fois aussi bien en dev qu'en statique. Est-ce que c'est du à nuxt-i18n et/ou au rootRedirect ? A explorer de nouveau.

Ces pistes nous ont causées des problèmes de scintillement de pages car les redirections sont faites une fois l'application chargée du côté client et parfois plusieurs fois.

### Nginx
- L'idée était de faire la redirection vers le contenu du cookie `locale` si l'utilisateur en avait un. Malheureusement, avec notre config actuelle le navigateur met en cache la page d'accueil, donc on ne repassait pas par le serveur et l'utilisateur était systématiquement renvoyé sur la sélection de locale.
- Le gros avantage de `nginx` était que l'utilisateur n'avait pas de scintillement de page comme la redirection était faite du côté du serveur

```
 location = / {
    if ($cookie_locale ~ ^[a-zA-Z-]+$) {
      return 302 /$cookie_locale/;
    }
  }
```

### Redirection navigateur vs. [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) 

```diff
  mounted() {
-    const preferredLocale = this.getLocaleFromCookie()
-    document.location = preferredLocale
-      ? `/${preferredLocale}/`
-      : '/locale-choice'
+    const chosenLocale = this.getLocaleFromCookie()
+    const url = chosenLocale ? `/${chosenLocale}/` : '/locale-choice'
+    this.$router.push(url)
  }
```

Pas de différence notable au niveau des performances. Mais la version History API est nettement plus simple à tester.

## :santa: Pour tester

Procédure à suivre :

1. Vérifier que le fonctionnement des sites Pix Pro (.fr) et Pix Pro (.org) n'a pas été modifié
2. Vérifier que le fonctionnement du site Pix Site (.fr) n'a pas été modifié
3. Aller sur Pix Site (.org), peu importe la page, et supprimer le cookie `locale` qui pourrait être dans le navigateur
4. Aller à la racine de Pix Site (.org) (en suivant les liens ci-dessous des applications déployées ou en entrant un URL manuellement dans la barre d'adresse du navigateur) et constater une redirection vers la page `/locale-choice` qui oblige de choisir sa locale
5. Cliquer sur le « bouton » d'une des 3 locales _International Français_, _International English_ ou _FWB_. Constater une redirection vers la page de locale correspondante, respectivement `/fr`, `/en-gb` ou `/fr-be`. Constater dans le navigateur l'ajout d'un cookie `locale` ayant pour valeur l'identifiant de la locale sélectionnée, `fr`, `en-gb` ou `fr-be`
6. Aller à la racine de Pix Site (.org) (en suivant les liens ci-dessous des applications déployées ou en entrant un URL manuellement dans la barre d'adresse du navigateur) et constater la redirection vers la page de locale correspondant à la locale précédemment sélectionnée
7. Entrer manuellement dans la barre d'adresse du navigateur différents URL de pages de contenu existantes (`XXX/fr-be/les-tests`, `/fr/pix-et-unesco`, `XXX/en-gb/the-tests`, etc. etc.) et constater qu'aucune redirection n'a lieu
8. Reprendre la procédure au numéro _3._ en choisissant une locale différente
9. Reprendre la procédure au numéro _3._ en activant son cache navigateur
