### PR TITLE
[FIX] Correction de style sur la page de choix de locale

### DIFF
--- a/components/LocaleLink.vue
+++ b/components/LocaleLink.vue
@@ -1,6 +1,6 @@
 <template>
   <pix-link class="locale-link" :href="indexForGivenLocale()">
-    <img :src="'/images/' + locale.icon" alt="" />
+    <img class="locale-link__icon" :src="'/images/' + locale.icon" alt="" />
     <span class="locale-link__text">{{ locale.name }}</span>
   </pix-link>
 </template>
@@ -32,7 +32,7 @@ export default {
 .locale-link {
   display: flex;
   align-items: center;
-  gap: 16px;
+  min-width: min(18em, 90vw);
   padding: 16px;
   background: rgba(255, 255, 255, 0.8);
   transition: background-color ease-out 320ms;
@@ -53,8 +53,22 @@ export default {
     background: rgba(193, 199, 208, 0.6);
   }
 
+  &__icon {
+    flex-shrink: 0;
+    margin-right: 16px;
+  }
+
   &__text {
+    flex-grow: 1;
+    overflow-x: hidden;
     overflow-wrap: break-word;
+  }
+}
+
+[href$='/fr'],
+[href$='/en-gb'] {
+  .locale-link__icon {
+    filter: brightness(50%);
   }
 }
 </style>

--- a/pages/pix-site/locale-choice.vue
+++ b/pages/pix-site/locale-choice.vue
@@ -32,6 +32,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.locale-choice {
+  padding: 3rem 0;
+}
+
 .logo-pix {
   margin: 0 auto 5vh;
   display: block;
@@ -46,7 +50,7 @@ export default {
 .planet {
   margin: 5vh auto 0;
   display: block;
-  min-width: 295px;
+  width: max(16vw, 90%);
 }
 
 @include device-is('large-mobile') {
@@ -56,11 +60,11 @@ export default {
 
   .planet {
     position: absolute;
-    top: 0;
-    right: calc(100% + 3vw);
-    width: 20vw;
+    top: 50%;
+    right: calc(100% + 4vw);
     max-width: unset;
     margin: 0;
+    transform: translateY(-50%);
   }
 }
 </style>


### PR DESCRIPTION
## :christmas_tree: Problème

Nécessité de corriger quelques points de style.

## :gift: Proposition

- Liens :
  * Définition d'une taille minimum
  * Background moins opaque
  * Mise en place de la cassure de mot si l'écran est très peu large 
  * L'icône des liens internationaux est noircie
- Mise en place d'un padding top et bottom autour du bloc principal
- Modification de la taille de la planète en fonction de tailles d'écran

## :santa: Pour tester

Aller sur la page [https://site-pr457.review.pix.org/locale-choice/](https://site-pr457.review.pix.org/locale-choice/) et vérifier le style.

Faire la comparaison avec le [fichier Figma](https://www.figma.com/file/CyPZAUwh8sX5nCPkEFbCsB/Archive-Sketch-Site-vitrine-(Master-%40-f3b54aa)?node-id=278%3A29299&t=BeQVk0aaUVoVL4yk-0)
