### PR TITLE
[TECH] Rendre le script npm run clean vraiment utile en supprimant le répertoire dist et pas node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "tests"
   },
   "scripts": {
-    "clean": "rm -rf node_modules .nuxt",
+    "clean": "rm -rf .nuxt dist",
     "build": "SITE_DOMAIN=pix.fr nuxt generate --fail-on-error && SITE_DOMAIN=pix.org nuxt generate --fail-on-error && npm run signal-jira",
     "start": "nuxt start",
     "dev:site": "SITE=pix-site SITE_DOMAIN=pix.fr nuxt",


### PR DESCRIPTION
## :christmas_tree: Problème

`npm run clean` ne supprime pas le répertoire `dist` alors que c'est un répertoire généré et que justement lorsqu'on teste on souhaite pouvoir supprimer tous les fichiers générés. Et par ailleurs le répertoire `node_modules` est, lui, supprimé alors que cela n'a non seulement aucune valeur ajoutée car on peut faire la même chose avec la commande `npm ci` mais qu'en plus c'est nuisible puisqu'on se retrouve avec un projet inutilisable alors qu'on voulait uniquement supprimer les fichiers générés.

## :gift: Proposition

`npm run clean` supprime tous les fichiers générés et uniquement les fichiers générés : `.nuxt`, `dist`

## :star2: Remarques

RAS

## :santa: Pour tester

1. Exécuter `npm run build:site` et vérifier que les répertoires `.nuxt` et `dist` sont présents
2. Exécuter `npm run clean` et vérifier que les répertoires `.nuxt` et `dist` ont été supprimés