### PR TITLE
[BUGFIX] Fermer le Burger Menu à la navigation

### DIFF
--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -1,7 +1,7 @@
 <template>
   <header class="navigation-slice-zone" role="banner">
     <client-only>
-      <slide-menu width="320" class="burger-menu">
+      <slide-menu width="320" class="burger-menu" :close-on-navigation="true">
         <burger-menu-nav :items="burgerMenuLinks" />
       </slide-menu>
     </client-only>


### PR DESCRIPTION
## :christmas_tree: Problème
En mobile (zone d'affichage plus petite), le Burger Menu ne se fermait pas lorsque l'on naviguait. Le contenu de la page changeait mais il restait ouvert.

## :gift: Proposition
Ajouter le paramètre [`close-on-navigation` de vue-burger-menu](https://www.npmjs.com/package/vue-burger-menu#close-on-navigation).

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier en mobile (zone d'affichage plus petite) que le Burger Menu se ferme bien lors d'un clic sur un de ces liens. Vérifier sur les liens de notre page, ainsi que sur les liens de changement de locale (.org).
