### PR TITLE
[BUGFIX] Stocker la préférence de locale "International Français"

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -14,7 +14,7 @@ const i18nConfigurationForFrenchDomain = {
 }
 
 const i18nConfigurationForInternationalDomain = {
-  defaultLocale: 'fr',
+  defaultLocale: config.isPixSite ? null : 'fr',
   strategy: 'prefix',
   vueI18n: {
     fallbackLocale: 'fr',

--- a/pages/pix-pro/index.vue
+++ b/pages/pix-pro/index.vue
@@ -16,7 +16,7 @@
 import { documentFetcher, DOCUMENTS } from '~/services/document-fetcher'
 
 export default {
-  name: 'LocaleHome',
+  name: 'Index',
   nuxtI18n: {
     paths: {
       fr: '/',


### PR DESCRIPTION
## :christmas_tree: Problème
Sur la page de sélection de locale préférée, le clic sur "International Français" ne déclenche pas l’événement `i18n.onBeforeLanguageSwitch` car c'est la locale par défaut. À cause de ça, le cookie `locale=fr` n'est pas positionné et l'utilisateur n'est ensuite pas redirigé automatiquement sur sa préférence.

De plus, au build Pix Pro, nous n'avons plus d'index.html dans `/dist/pix.org` depuis la #455 (`pages/pix-pro/index.vue`). Donc Nginx renvoie une 403 avant de nous rediriger côté client par la page d'erreur. On constate donc un clignotement de la page d'erreur.

## :gift: Proposition
Ne plus déclarer de `defaultLocale` car on souhaite ne pas avoir de locale par défaut :).

Cette solution a un impact identifié : les pages accessibles sans préfixe de locale `/***` ne sont plus redirigées vers `/fr/***`. À ma connaissance, la seule page concernée est la page d'erreur où on retrouve donc la clé de traduction "error-content" affichée telle quelle. Pas d'impact sur les assets static accessibles via `/images/background-comment-ca-marche.jpg` (je suppose que nuxt-i18n ne passe pas dessus).

La config `i18n`, en particulier `fallbackLocale` devrait corriger ce problème mais semble ne pas fonctionner malheureusement. Ce sera à creuser par la suite.

Sur Pix Pro, on souhaite toujours une `defaultLocale` pour rediriger automatiquement l'utilisateur vers `/fr`. On en profite pour renommer le fichier locale-home.vue en index.vue pour créer un index.html à la racine de pro.pix.org. On a testé une autre approche en créant un fichier `/pages/pix-pro/index.vue` minimal (avec un i18n à `false`) qu'on pensait être suffisant mais qui n'effectuait finalement pas de redirection donc on arrivait sur une page blanche...

## :star2: Remarques
Tout est dis ?

## :santa: Pour tester
Vérifier que le stockage de la `locale=fr` au clic sur "International Français" est corrigé.

Vérifier que les assets statics (dossier `assets` et `static`) sont toujours accessibles.

Constater que la page d'erreur non localisée contient seulement le message "error-content".
