### PR TITLE
[FEATURE] Faire en sorte que le cookie de langue de pix.org soit lisible sur app.pix.org (PIX-6904)

### DIFF
--- a/plugins/locale-observer.js
+++ b/plugins/locale-observer.js
@@ -1,3 +1,5 @@
+import { config } from '../config/environment'
+
 export default function ({ app }) {
   app.i18n.onBeforeLanguageSwitch = (oldLocale, newLocale) => {
     _setLocaleCookie(newLocale)
@@ -5,5 +7,5 @@ export default function ({ app }) {
 }
 
 function _setLocaleCookie(locale) {
-  document.cookie = `locale=${locale}; path=/; max-age=31536000`
+  document.cookie = `locale=${locale}; path=/; domain=${config.siteDomain}; max-age=31536000`
 }

--- a/tests/plugins/locale-observer.test.js
+++ b/tests/plugins/locale-observer.test.js
@@ -1,5 +1,11 @@
 import localeObserver from '~/plugins/locale-observer'
 
+jest.mock('~/config/environment', () => ({
+  config: {
+    siteDomain: 'pix.org',
+  },
+}))
+
 describe('Plugins | locale-observer', () => {
   beforeEach(() => {
     let cookieJar = ''
@@ -32,7 +38,7 @@ describe('Plugins | locale-observer', () => {
 
         // then
         expect(document.cookie).toEqual(
-          'locale=en-gb; path=/; max-age=31536000'
+          'locale=en-gb; path=/; domain=pix.org; max-age=31536000'
         )
       })
     })
@@ -57,7 +63,9 @@ describe('Plugins | locale-observer', () => {
         context.app.i18n.onBeforeLanguageSwitch(oldLocale, newLocale)
 
         // then
-        expect(document.cookie).toEqual('locale=fr; path=/; max-age=31536000')
+        expect(document.cookie).toEqual(
+          'locale=fr; path=/; domain=pix.org; max-age=31536000'
+        )
       })
     })
   })


### PR DESCRIPTION
## :christmas_tree: Problème

On ne peut pas accéder au cookie `locale` de https://pix.org/ sur https://app.pix.org/ et donc on ne peut pas réutiliser cette information dans un contexte plus large, notamment :
* pour que l'utilisateur puisse utiliser Pix App immédiatement dans la locale qu'il a choisi lorsqu'il s'est rendu sur https://pix.org/
* pour que Pix puisse par la suite effectuer des statistiques sur les locales utilisées par les utilisateurs

## :gift: Proposition

Positionner le cookie `locale` spécifiquement sur le domaine et ne pas laisser le cookie être positionné par défaut sur le host, cf. https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie

## :star2: Remarques

### Consentement

On n'a pas à demander de consentement des utilisateurs pour stocker et utiliser ce cookie `locale` sur aucun site web de Pix, que ce soit https://pix.org/, https://app.pix.org, etc. En effet le choix de la langue fait partie des exceptions (explicitement listée même) définies par la CNIL :

> Les traceurs qui sont exemptés de consentement … les traceurs de personnalisation de l'interface utilisateur (par exemple, pour le choix de la langue ou de la présentation d’un service), lorsqu’une telle personnalisation constitue un élément intrinsèque et attendu du service

cf. https://www.cnil.fr/en/node/120386#:~:text=Qu%27entend%2Don%20par%20les%20termes%20%22cookies%22%20ou%20%22%20traceurs%20%22%3F

### Domaine

Le terme `domain` dans la Web API des cookies est polysémique et peut donc apporter de la confusion.

Quand le cookie est positionné sur le domaine alors la propriété `domain` du cookie contient un `.` devant le nom du domaine. Ainsi cette PR crée des cookies avec la propriété `domain` ayant la valeur `.pix.org`, alors qu'actuellement le comportement sur https://pix.org/ est que les cookies ont par défaut une propriété `domaine` ayant pour valeur `pix.org` (sans point devant).

### Portée

L'impact de cette PR est que la préférence de locale de l'utilisateur est aussi partagée entre tous les sites vitrines du même domaine (https://pix.org/ et https://pro.pix.org/ ).

À noter également que toutes toutes toutes les requêtes effectuées sur le domaine `.pix.org` vont faire transiter ce cookie `locale`.

### Sécurité

Sur la sécurisation du cookie `locale` :

* On ne peut pas configurer la propriété `HTTPOnly` car la page `locale-choice` de pix-site positionne le cookie locale par le biais de JavaScript côté client justement
* On pourrait mettre la propriété `Secure` pour éviter certaines classes d'attaques menées par le biais du cookie. Mais 
pour l'instant nous renonçons à commiter une solution avec la propriété `Secure` car nous n'avons pas trouvé de condition adéquate pour décider quand positionner ce `Secure`. Une solution pourrait être de se baser  sur une variable d'environnement (par exemple `if (process.env.UNSECURE)` etc.) mais cela créerait une nouvelle divergence de fonctionnement qui se rajouterait aux autres divergences de fonctionnement déjà présentes. Or c'est ce que nous cherchons à limiter dans ce projet. Donc à rediscuter plus tard.

## :santa: Pour tester

1. Aller sur la RA de pix.org, choisir sa locale et constater que le cookie est positionné sur `.pix.org`
2. Aller sur https://app.pix.org et constater que ce cookie nouvellement créé est bien disponible dans ce contexte
