### PR TITLE
[BUGFIX] Corrections d'accessibilité de la langue sur la page de choix de locale

### DIFF
--- a/layouts/empty.vue
+++ b/layouts/empty.vue
@@ -5,5 +5,12 @@
 <script>
 export default {
   name: 'Empty',
+  head() {
+    return {
+      htmlAttrs: {
+        lang: this.$i18n.fallbackLocale,
+      },
+    }
+  },
 }
 </script>

--- a/pages/pix-site/index.vue
+++ b/pages/pix-site/index.vue
@@ -13,6 +13,7 @@
           :key="locale.code"
           class="locale-choice__link"
           :locale="locale"
+          :lang="locale.code"
         />
         <pix-image class="planet" :field="{ url: '/images/planet.svg' }" />
       </div>


### PR DESCRIPTION
## :christmas_tree: Problème
Sur la nouvelle page d'accueil de pix.org permettant à l'utilisateur de choisir sa locale préférée l'attribut `lang` de la page n'est pas défini. Cela pose des soucis d'accessibilité et de SEO.

De plus chaque bouton de choix de locale est rédigé dans une langue différente qu'il faut identifier pour l'accessibilité et le SEO également.

## :gift: Proposition
Ajouter une langue par défaut sur l'entièreté de la page d'accueil de choix de locale de pix.org et définir sur chaque bouton de choix de locale une langue correspondant à sa locale.

<img width="500" alt="Capture d’écran 2023-01-13 à 12 33 45" src="https://user-images.githubusercontent.com/82950611/212311066-f2a28b13-3e9c-45f6-b4c7-71e7195978f7.png">

## :star2: Remarques
Le choix de l'attribut `lang="fr"` sur la page d'accueil est basé sur le fait que la `fallbackLocale` est elle-même déjà établie à `fr`.

## :santa: Pour tester
Se rendre sur pix.org (en veillant à ne pas avoir de cookie) et vérifier que la page contient bien un attribut `lang` avec comme valeur `fr`, et que chaque lien émettant une redirection vers une locale différente a un attribut `lang` qui correspond à sa locale.
