### PR TITLE
[FEATURE] Reordonner les choix du language-switcher pour être iso avec la page d'accueil de Pix.org (PIX-6833).

### DIFF
--- a/config/localization/pix-site.js
+++ b/config/localization/pix-site.js
@@ -53,16 +53,16 @@ export const localization = {
       ],
     },
     {
-      name: 'france',
-      localeCode: 'fr-fr',
-      icon: 'flag-fr.svg',
-      subtitle: null,
-    },
-    {
       name: 'fwb-acronym',
       localeCode: 'fr-be',
       icon: 'flag-be.svg',
       subtitle: 'fwb',
+    },
+    {
+      name: 'france',
+      localeCode: 'fr-fr',
+      icon: 'flag-fr.svg',
+      subtitle: null,
     },
   ],
   locales: availableLocales,

--- a/tests/components/__snapshots__/LocaleSwitcher.test.js.snap
+++ b/tests/components/__snapshots__/LocaleSwitcher.test.js.snap
@@ -85,33 +85,6 @@ exports[`Component: LocaleSwitcher when site is pix-pro should render the locale
       </div>
     </li>
     <li
-      class="locale-switcher__dropdown-menu--active"
-    >
-      <div
-        class="locale-switcher__locale"
-      >
-        <a
-          href="http://example.fr/"
-        >
-          <img
-            alt=""
-            class="locale-switcher__img"
-            src="/images/flag-fr.svg"
-          />
-           
-          <div
-            class="locale__text"
-          >
-            <div>
-              
-            </div>
-             
-            <!---->
-          </div>
-        </a>
-      </div>
-    </li>
-    <li
       class=""
     >
       <div
@@ -140,6 +113,33 @@ exports[`Component: LocaleSwitcher when site is pix-pro should render the locale
               
             
             </div>
+          </div>
+        </a>
+      </div>
+    </li>
+    <li
+      class="locale-switcher__dropdown-menu--active"
+    >
+      <div
+        class="locale-switcher__locale"
+      >
+        <a
+          href="http://example.fr/"
+        >
+          <img
+            alt=""
+            class="locale-switcher__img"
+            src="/images/flag-fr.svg"
+          />
+           
+          <div
+            class="locale__text"
+          >
+            <div>
+              
+            </div>
+             
+            <!---->
           </div>
         </a>
       </div>
@@ -237,33 +237,6 @@ exports[`Component: LocaleSwitcher when site is pix-site should render the local
       </div>
     </li>
     <li
-      class="locale-switcher__dropdown-menu--active"
-    >
-      <div
-        class="locale-switcher__locale"
-      >
-        <a
-          href="http://example.fr/"
-        >
-          <img
-            alt=""
-            class="locale-switcher__img"
-            src="/images/flag-fr.svg"
-          />
-           
-          <div
-            class="locale__text"
-          >
-            <div>
-              
-            </div>
-             
-            <!---->
-          </div>
-        </a>
-      </div>
-    </li>
-    <li
       class=""
     >
       <div
@@ -292,6 +265,33 @@ exports[`Component: LocaleSwitcher when site is pix-site should render the local
               
             
             </div>
+          </div>
+        </a>
+      </div>
+    </li>
+    <li
+      class="locale-switcher__dropdown-menu--active"
+    >
+      <div
+        class="locale-switcher__locale"
+      >
+        <a
+          href="http://example.fr/"
+        >
+          <img
+            alt=""
+            class="locale-switcher__img"
+            src="/images/flag-fr.svg"
+          />
+           
+          <div
+            class="locale__text"
+          >
+            <div>
+              
+            </div>
+             
+            <!---->
           </div>
         </a>
       </div>

--- a/tests/config/localization/pix-site.test.js
+++ b/tests/config/localization/pix-site.test.js
@@ -75,16 +75,16 @@ describe('#localization', () => {
         ],
       },
       {
-        name: 'france',
-        localeCode: 'fr-fr',
-        icon: 'flag-fr.svg',
-        subtitle: null,
-      },
-      {
         name: 'fwb-acronym',
         localeCode: 'fr-be',
         icon: 'flag-be.svg',
         subtitle: 'fwb',
+      },
+      {
+        name: 'france',
+        localeCode: 'fr-fr',
+        icon: 'flag-fr.svg',
+        subtitle: null,
       },
     ]
 


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, l'ordre sur la page index .org et l'ordre de locale switcher sont différents. 

## :gift: Proposition
Nous souhaitons avoir le même ordre que sur l'index de .org.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Se rendre sur les sites vitrines et constater que l'ordre de page index est identique que celui de language switcher.