### PR TITLE
 [FEATURE] Ajouter la page de choix de locale sur pro.pix.org (PIX-6834).

### DIFF
--- a/config/localization/pix-pro.js
+++ b/config/localization/pix-pro.js
@@ -5,16 +5,22 @@ export const availableLocales = [
     code: 'fr',
     file: 'fr.js',
     domain: config.domain.international,
+    name: 'International Français',
+    icon: 'globe-europe.svg',
   },
   {
     code: 'en-gb',
     file: 'en-gb.js',
     domain: config.domain.international,
+    name: 'International English',
+    icon: 'globe-europe.svg',
   },
   {
     code: 'fr-fr',
     file: 'fr-fr.js',
     domain: config.domain.french,
+    name: 'France',
+    icon: 'flag-fr.svg',
   },
 ]
 export const localization = {

--- a/pages/pix-pro/locale-home.vue
+++ b/pages/pix-pro/locale-home.vue
@@ -1,0 +1,65 @@
+<template>
+  <div>
+    <div v-if="type === FORM_PAGE">
+      <form-page :content="document.data" />
+    </div>
+    <div v-if="type === SIMPLE_PAGE">
+      <simple-page :content="document.data" />
+    </div>
+    <div v-if="type === SLICES_PAGE">
+      <prismic-custom-slice-zone :slices="document.data.body" />
+    </div>
+  </div>
+</template>
+
+<script>
+import { documentFetcher, DOCUMENTS } from '~/services/document-fetcher'
+
+export default {
+  name: 'LocaleHome',
+  nuxtI18n: {
+    paths: {
+      fr: '/',
+      'fr-fr': '/',
+      'en-gb': '/',
+    },
+  },
+  async asyncData({ app, req, error, currentPagePath }) {
+    try {
+      const document = await documentFetcher(
+        app.$prismic,
+        app.i18n,
+        req
+      ).getPageByUid('decouvrir-pix-pro')
+      const meta = document.data.meta
+
+      return { currentPagePath, meta, document }
+    } catch (e) {
+      error({ statusCode: 404, message: 'Page not found' })
+    }
+  },
+  data() {
+    return {
+      FORM_PAGE: DOCUMENTS.FORM_PAGE,
+      SIMPLE_PAGE: DOCUMENTS.SIMPLE_PAGE,
+      SLICES_PAGE: DOCUMENTS.SLICES_PAGE,
+    }
+  },
+  head() {
+    const meta = this.$getMeta(this.meta, this.currentPagePath, this.$prismic)
+
+    return {
+      meta,
+      title: `${this.title} | Pix Pro`,
+    }
+  },
+  computed: {
+    type() {
+      return this.document.type
+    },
+    title() {
+      return this.document.data.title[0].text
+    },
+  },
+}
+</script>

--- a/services/filter-nuxt-pages.js
+++ b/services/filter-nuxt-pages.js
@@ -1,5 +1,5 @@
 export function filterNuxtPages(routes, config) {
-  if (config.isPixSite && config.isFrenchDomain) {
+  if (config.isFrenchDomain) {
     return routes.filter(
       (route) => !(route.name === 'index' && route.path === '/')
     )

--- a/tests/pages/pix-pro/index.test.js
+++ b/tests/pages/pix-pro/index.test.js
@@ -1,0 +1,115 @@
+import { shallowMount } from '@vue/test-utils'
+import Vue from 'vue'
+import Index from '@/pages/pix-pro/index.vue'
+
+describe('Index Page', () => {
+  let $router
+
+  beforeEach(() => {
+    $router = {
+      replace: jest.fn(),
+    }
+
+    let cookieJar = ''
+
+    jest.spyOn(document, 'cookie', 'set').mockImplementation((cookie) => {
+      cookieJar = cookie
+    })
+    jest.spyOn(document, 'cookie', 'get').mockImplementation(() => cookieJar)
+  })
+
+  describe('#mounted', () => {
+    describe('when there is no cookie', () => {
+      test('do not redirect', async () => {
+        // given
+        document.cookie = ''
+
+        // when
+        const wrapper = shallowMount(Index, {
+          mocks: { $router },
+          stubs: ['client-only', 'pix-image', 'locale-link'],
+        })
+        await Vue.nextTick()
+
+        // then
+        expect($router.replace).not.toHaveBeenCalled()
+        const localeLinks = wrapper.findAll('locale-link-stub')
+        expect(localeLinks.length).toBe(4)
+      })
+    })
+
+    describe('when there is a cookie', () => {
+      test('redirects to locale page', async () => {
+        // given
+        document.cookie = 'foo=bar; locale=fr'
+
+        // when
+        const wrapper = shallowMount(Index, {
+          mocks: { $router },
+          stubs: ['client-only', 'pix-image', 'locale-link'],
+        })
+        await Vue.nextTick()
+
+        // then
+        expect($router.replace).toHaveBeenCalledWith('/fr/')
+        const localeLinks = wrapper.findAll('locale-link-stub')
+        expect(localeLinks.length).toBe(0)
+      })
+    })
+  })
+
+  describe('#methods', () => {
+    describe('#getLocaleFromCookie', () => {
+      describe('when there is no cookie', () => {
+        test('returns no locale', () => {
+          // given
+          document.cookie = ''
+          const wrapper = shallowMount(Index, {
+            mocks: { $router },
+            stubs: ['client-only', 'pix-image', 'locale-link'],
+          })
+
+          // when
+          const chosenLocale = wrapper.vm.getLocaleFromCookie()
+
+          // then
+          expect(chosenLocale).toBe(null)
+        })
+      })
+
+      describe('when there is a cookie', () => {
+        test('returns the proper locale', () => {
+          // given
+          document.cookie = 'foo=bar; locale=fr'
+          const wrapper = shallowMount(Index, {
+            mocks: { $router },
+            stubs: ['client-only', 'pix-image', 'locale-link'],
+          })
+
+          // when
+          const chosenLocale = wrapper.vm.getLocaleFromCookie()
+
+          // then
+          expect(chosenLocale).toBe('fr')
+        })
+      })
+
+      describe('with a crafted cookie', () => {
+        test('cookie value is ignored', () => {
+          // given
+          document.cookie = 'foo=bar; locale=1234-crafted-cookie'
+          const wrapper = shallowMount(Index, {
+            mocks: { $router },
+            stubs: ['client-only', 'pix-image', 'locale-link'],
+          })
+
+          // when
+          const chosenLocale = wrapper.vm.getLocaleFromCookie()
+
+          // then
+          expect(chosenLocale).toBe(null)
+        })
+      })
+    })
+  })
+})

--- a/tests/services/filter-nuxt-pages.test.js
+++ b/tests/services/filter-nuxt-pages.test.js
@@ -5,7 +5,6 @@ describe('FilterNuxtPages', () => {
     it('should return only locale home at root path', function () {
       // given
       const config = {
-        isPixSite: true,
         isFrenchDomain: true,
       }
       const routes = [
@@ -29,7 +28,6 @@ describe('FilterNuxtPages', () => {
     it('should return routes as is', function () {
       // given
       const config = {
-        isPixSite: true,
         isFrenchDomain: false,
       }
       const routes = [


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, les comportements de pix.org et pro.pix.org ne sont pas iso, ce qui ajoute de la complexité. Le besoin pour le pro d'avoir une page de choix de langue est aussi présent.

## :gift: Proposition
Ajouter la nouvelle page de choix de langue sur le site PRO

## :star2: Remarques

## :santa: Pour tester
Se rendre sur la RA pro.org
- Constater qu'une page d'accueil permettant de choisir sa locale est présente
- Revenir sur pro.pix.org et constater qu'on est redirigé vers la locale précédemment choisie