### PR TITLE
[TECH] Supprimer le dossier lang du fichier `.slugignore`

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -5,7 +5,6 @@ assets
 components
 config
 docs
-lang
 layouts
 middleware
 modules


### PR DESCRIPTION
## :egg: Problème
[Le fichier `.slugignore`](https://doc.scalingo.com/platform/app/slugignore) référence les fichiers/dossiers qui doivent être supprimer après la construction de l'application. Ca permet d'avoir une image plus petite et qui contient que le nécessaire pour la partie run. 

Nous avons récemment déplacé les traductions dans le dossier `config/localization/translations`, nous n'avons donc plus de dossier `lang`. Cependant, le fichier `.slugignore` le référence toujours et essaie donc de le supprimer à chaque construction de l'application sur Scalingo.

<img width="539" alt="image" src="https://user-images.githubusercontent.com/26384707/213480045-85a681b8-b41e-4b73-b05e-46d7cfea2232.png">


## :bowl_with_spoon: Proposition
Supprimer le dossier du fichier.

## :milk_glass: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :butter: Pour tester
Constater dans le déploiement de la RA que l'erreur n'est plus présente