### PR TITLE
[TECH] Permettre l'ajout de logs dynamiquement grâce à une variable d'environnement.

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -9,7 +9,17 @@ log_format keyvalue
   ' duration=${request_time}s'
   ' bytes=$bytes_sent'
   ' referer="$http_referer"'
-  ' user_agent="$http_user_agent"';
+  ' user_agent="$http_user_agent"'<%#
+    To allow dynamic logging format for nginx,
+    create a json that contains the key/value pairs
+    you want to add to nginx logging.
+    For the logs to be correctly parsed, use the nginx_logger_version parameter.
+    For example:
+    ADDITIONAL_NGINX_LOGS='{"nginx_logger_version":"1", "my_custom_header":"$http_my_custom_header"}'
+  %><%
+    require 'json';
+    JSON.parse(ENV['ADDITIONAL_NGINX_LOGS']||'{}').each do |nginx_key,value| %>
+  ' <%= nginx_key %>="<%= value %>"'<% end %>;
 
 # In order to avoid logging access twice per request
 # it is necessary to turn off the top-level (e.g. http) buildpack default access_log


### PR DESCRIPTION
## :egg: Problème
A l'instar de nos autres apps, le nginx de ce repository ne dispose pas d'un moyen d'ajouter des logs dynamiquement.

## :bowl_with_spoon: Proposition
Ajouter le mécanisme déjà présent dans nos autres configurations (cf: https://github.com/1024pix/pix/blob/dev/admin/servers.conf.erb) 

## :milk_glass: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :butter: Pour tester
- Ajouter la variable d'environnement : `ADDITIONAL_NGINX_LOGS={"foo":"bar"}`
- Constater dans les logs que nous pouvons retrouver cette variable