### PR TITLE
[BUGFIX] Eviter l'erreur de déploiement quand une URL de la navigation n'est pas encore définie

### DIFF
--- a/components/slices/NavigationZone.vue
+++ b/components/slices/NavigationZone.vue
@@ -111,11 +111,13 @@ export default {
       }
     },
     subIsActive(subNavigationLinks) {
-      const paths = subNavigationLinks.map((subNavigationLink) => {
-        const splittedLink = subNavigationLink.link.url.split('/')
-        const linkIndex = splittedLink.length - 1
-        return splittedLink[linkIndex]
-      })
+      const paths = subNavigationLinks
+        .filter((subNavigationLink) => subNavigationLink.link.url !== undefined)
+        .map((subNavigationLink) => {
+          const splittedLink = subNavigationLink.link.url.split('/')
+          const linkIndex = splittedLink.length - 1
+          return splittedLink[linkIndex]
+        })
       return paths.some((path) => {
         return this.$route.path.includes(path)
       })

--- a/tests/components/slices/NavigationZone.test.js
+++ b/tests/components/slices/NavigationZone.test.js
@@ -111,5 +111,19 @@ describe('NavigationZone slice', () => {
         expect(component.vm.isOpenDropdown(dropdownIndex)).toBeFalsy()
       })
     })
+
+    describe('#subIsActive', () => {
+      it("should return false if links does not contain a link.url that's the same as the current route", () => {
+        $route.path = '/tests'
+        const links = [{ link: { url: '/current' } }]
+        expect(component.vm.subIsActive(links)).toBe(false)
+      })
+
+      it('should return true if links contains link.url same as the current route', () => {
+        $route.path = '/tests'
+        const links = [{ link: {} }, { link: { url: '/tests' } }]
+        expect(component.vm.subIsActive(links)).toBe(true)
+      })
+    })
   })
 })


### PR DESCRIPTION
## :egg: Problème
Si le contenu Prismic est publié avec un lien dans la navbar sans URL, impossible de développer/builder.

## :bowl_with_spoon: Proposition
Gérer ce cas pour éviter de crasher le build. La proposition consiste en filtrer les URLs qui ne sont pas définies dans la méthode permettant de savoir si on est sur le lien actif ou non.

## :milk_glass: Remarques
Potentiellement ça rendra des trucs bizarres en prod mais c'est la comm qui gère.

Ajouté 2 tests auto sur la méthode qui throwait.

## :butter: Pour tester
Vérifier que je n'ai pas fait n'importe quoi.
