### PR TITLE
[TECH] Simplifier le serializer d'html utilisé par Prismic

### DIFF
--- a/app/prismic/html-serializer.js
+++ b/app/prismic/html-serializer.js
@@ -1,5 +1,4 @@
 import prismicDOM from 'prismic-dom'
-import linkResolver from './link-resolver'
 
 const Elements = prismicDOM.RichText.Elements
 
@@ -7,18 +6,7 @@ export default function (type, element, content, children) {
   // Generate links to Prismic Documents as <router-link> components
   // Present by default, it is recommended to keep this
   if (type === Elements.hyperlink) {
-    let result = ''
-    const url = prismicDOM.Link.url(element.data, linkResolver)
-
-    if (element.data.link_type === 'Document') {
-      result = `<a href="${url}" data-nuxt-link>${content}</a>`
-    } else {
-      const target = element.data.target
-        ? `target="'${element.data.target}'" rel="noopener"`
-        : ''
-      result = `<a href="${url}" ${target}>${content}</a>`
-    }
-    return result
+    return `<pix-prismic-link field="${element.data}">${content}</pix-prismic-link>`
   }
 
   // If the image is also a link to a Prismic Document, it will return a <router-link> component
@@ -29,16 +17,7 @@ export default function (type, element, content, children) {
     }" copyright="${element.copyright || ''}">`
 
     if (element.linkTo) {
-      const url = prismicDOM.Link.url(element.linkTo, linkResolver)
-
-      if (element.linkTo.link_type === 'Document') {
-        result = `<nuxt-link to="${url}">${result}</nuxt-link>`
-      } else {
-        const target = element.linkTo.target
-          ? `target="${element.linkTo.target}" rel="noopener"`
-          : ''
-        result = `<a href="${url}" ${target}>${result}</a>`
-      }
+      result = `<pix-prismic-link field="${element.linkTo}">${result}</pix-prismic-link>`
     }
     const wrapperClassList = [element.label || '', 'block-img']
     result = `<p class="${wrapperClassList.join(' ')}">${result}</p>`


### PR DESCRIPTION
## :egg: Problème
Actuellement, le fichier `html-serializer` est complexe, car pour les liens il essaie de savoir si il doit créer un lien interne `nuxt-link` ou un lien vers un autre site en utilisant une balise `<a>`. 
Cela pour les liens et pour les images qui sont englobées dans un lien. 

## :bowl_with_spoon: Proposition
Utiliser le composant `<PixPrismicLink>` qui fait exactement le mécanisme pour savoir si c'est un lien interne ou non.

## :milk_glass: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :butter: Pour tester
### Lien
#### Externe
- Se rendre sur la page d'accueil constater que le bouton "Je m'inscris gratuitement" envoi bien vers un lien externe
#### Interne
- Se rendre sur la page `/competences` constater que le lien interne fonctionne correctement et qu'il n'y a pas de reloading de la page

### Image
Je n'ai pas trouvé de cas avec l'image si vous en connaissez je suis preneur 