### PR TITLE
[TECH] Gérer plusieurs suivi différents sur Matomo pour les différentes locales.

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -13,8 +13,6 @@ export const config = {
     containerUrl: process.env.MATOMO_CONTAINER,
     fwbContainerUrl: process.env.MATOMO_CONTAINER_FWB,
     debug: process.env.MATOMO_DEBUG || false,
-    globalSiteId: process.env.MATOMO_GLOBAL_SITE_ID,
-    fwbSiteId: process.env.MATOMO_FWB_SITE_ID,
   },
   featureToggles: {},
   domain: {

--- a/config/environment.js
+++ b/config/environment.js
@@ -12,6 +12,8 @@ export const config = {
   matomo: {
     containerUrl: process.env.MATOMO_CONTAINER,
     debug: process.env.MATOMO_DEBUG || false,
+    globalSiteId: process.env.MATOMO_GLOBAL_SITE_ID,
+    fwbSiteId: process.env.MATOMO_FWB_SITE_ID,
   },
   featureToggles: {},
   domain: {

--- a/config/environment.js
+++ b/config/environment.js
@@ -11,6 +11,7 @@ export const config = {
   },
   matomo: {
     containerUrl: process.env.MATOMO_CONTAINER,
+    fwbContainerUrl: process.env.MATOMO_CONTAINER_FWB,
     debug: process.env.MATOMO_DEBUG || false,
     globalSiteId: process.env.MATOMO_GLOBAL_SITE_ID,
     fwbSiteId: process.env.MATOMO_FWB_SITE_ID,

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -241,6 +241,8 @@ if (config.matomo.containerUrl) {
       src: '/scripts/matomo-tracking.js',
       'data-global-site-id': config.matomo.globalSiteId,
       'data-fwb-site-id': config.matomo.fwbSiteId,
+      'data-global-container': config.matomo.containerUrl,
+      'data-fwb-container': config.matomo.fwbContainerUrl,
       'data-matomo-tracking': true,
     },
     {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -238,9 +238,10 @@ if (config.matomo.containerUrl) {
   nuxtConfig.head.script.push(
     {
       type: 'text/javascript',
-      src: config.matomo.containerUrl,
-      async: true,
-      defer: true,
+      src: '/scripts/matomo-tracking.js',
+      'data-global-site-id': config.matomo.globalSiteId,
+      'data-fwb-site-id': config.matomo.fwbSiteId,
+      'data-matomo-tracking': true,
     },
     {
       type: 'text/javascript',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -239,8 +239,6 @@ if (config.matomo.containerUrl) {
     {
       type: 'text/javascript',
       src: '/scripts/matomo-tracking.js',
-      'data-global-site-id': config.matomo.globalSiteId,
-      'data-fwb-site-id': config.matomo.fwbSiteId,
       'data-global-container': config.matomo.containerUrl,
       'data-fwb-container': config.matomo.fwbContainerUrl,
       'data-matomo-tracking': true,

--- a/static/scripts/matomo-tracking.js
+++ b/static/scripts/matomo-tracking.js
@@ -20,3 +20,17 @@ _paq.push(['enableLinkTracking']);
   g.src=u+'matomo.js';
   s.parentNode.insertBefore(g,s);
 })()
+var globalContainer = document.querySelector('script[data-matomo-tracking="true"]').getAttribute('data-global-container');
+var fwbContainer = document.querySelector('script[data-matomo-tracking="true"]').getAttribute('data-fwb-container');
+
+var _mtm = window._mtm = window._mtm || [];
+_mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+g.async=true;
+if (window.location.toString().includes("fr-be")){
+  g.src='https://analytics.pix.fr/js/container_'+fwbContainer+'.js';
+} else {
+  g.src='https://analytics.pix.fr/js/container_'+globalContainer+'.js';
+}
+
+s.parentNode.insertBefore(g,s);

--- a/static/scripts/matomo-tracking.js
+++ b/static/scripts/matomo-tracking.js
@@ -1,0 +1,22 @@
+/* eslint-disable */
+var _paq = window._paq = window._paq || [];
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function() {
+  var u="https://analytics.pix.fr/"
+  _paq.push(['setTrackerUrl', u+'matomo.php']);
+
+  var globalSiteId = document.querySelector('script[data-matomo-tracking="true"]').getAttribute('data-global-site-id');
+  var fwbSiteId = document.querySelector('script[data-matomo-tracking="true"]').getAttribute('data-fwb-site-id');
+
+  if (window.location.toString().includes("fr-be")){
+    _paq.push(['setSiteId', fwbSiteId]);
+  } else {
+    _paq.push(['setSiteId', globalSiteId]);
+  }
+  var d=document; g=d.createElement('script'); s=d.getElementsByTagName('script')[0];
+  g.async=true;
+  g.src=u+'matomo.js';
+  s.parentNode.insertBefore(g,s);
+})()

--- a/static/scripts/matomo-tracking.js
+++ b/static/scripts/matomo-tracking.js
@@ -1,25 +1,5 @@
 /* eslint-disable */
-var _paq = window._paq = window._paq || [];
-/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-_paq.push(['trackPageView']);
-_paq.push(['enableLinkTracking']);
-(function() {
-  var u="https://analytics.pix.fr/"
-  _paq.push(['setTrackerUrl', u+'matomo.php']);
 
-  var globalSiteId = document.querySelector('script[data-matomo-tracking="true"]').getAttribute('data-global-site-id');
-  var fwbSiteId = document.querySelector('script[data-matomo-tracking="true"]').getAttribute('data-fwb-site-id');
-
-  if (window.location.toString().includes("fr-be")){
-    _paq.push(['setSiteId', fwbSiteId]);
-  } else {
-    _paq.push(['setSiteId', globalSiteId]);
-  }
-  var d=document; g=d.createElement('script'); s=d.getElementsByTagName('script')[0];
-  g.async=true;
-  g.src=u+'matomo.js';
-  s.parentNode.insertBefore(g,s);
-})()
 var globalContainer = document.querySelector('script[data-matomo-tracking="true"]').getAttribute('data-global-container');
 var fwbContainer = document.querySelector('script[data-matomo-tracking="true"]').getAttribute('data-fwb-container');
 


### PR DESCRIPTION
## :unicorn: Problème
Les analytics Matomo sont agrégés sur un seul et même site pour pix.fr/pix.org.
Le problème est qu'on ne peut pas proposer une interface d'analytics pour une seule langue à des utilisateurs.
Pour palier à ce problème, nous ajoutons un trackingId différent pour certaines langues. Matomo s'occupera ensuite d'agréger (si besoin) les différentes locales.

## :robot: Proposition
Au lieu d'importer le container Matomo directement, nous ajoutons un script matomo qui vérifie l'URL actuel du site pour changer le tracking ID.

## :rainbow: Remarques
- A voir pour le Tag Manager

## :100: Pour tester
Tests à faire avec Matomo + la RA.