### PR TITLE
[TECH] Ajouter un endpoint de géolocalisation (PIX-7084)

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -28,6 +28,10 @@ access_log off;
 
 port_in_redirect off;
 
+upstream api {
+  server <%= ENV['NGINX_GEOAPI_UPSTREAM_HOST'] %>:443 max_fails=<%= ENV['NGINX_GEOAPI_UPSTREAM_MAX_FAILS'] || 3 %> fail_timeout=<%= ENV['NGINX_GEOAPI_UPSTREAM_FAIL_TIMEOUT'] || '5s' %>;
+}
+
 server {
   access_log logs/access.log keyvalue;
 
@@ -40,6 +44,13 @@ server {
 
   if ($http_x_forwarded_host ~ \.org) {
     set $extension 'org';
+  }
+
+  location /geolocate {
+    proxy_pass https://api/me;
+    proxy_redirect default;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host <%= ENV['NGINX_GEOAPI_UPSTREAM_HOST'] %>;
   }
 
   charset utf-8;


### PR DESCRIPTION
## :unicorn: Problème
Nous avons besoin d’un endpoint /geolocate sur pix-site qui fasse appel au service de géolocalisation créé dans [PIX-7035: Créer un service de geolocalisationDEPLOYED ON INTEGRATION](https://1024pix.atlassian.net/browse/PIX-7035) et retourne le pays identifé pour l’utilisateur.

## :robot: Proposition
Dans la configuration nginx de pix-site, rediriger pix.org/geolocate vers l'URL de service de géolocalisation du container.

S’inspirer (et peut-être même reprendre) le POC réalisé par les captains dans cette PR #500.

## :rainbow: Remarques
Une fois l’url de la route décidée (et avant la mise en prod), il faudra demander aux captains de débloquer cette route sur Baleen (notamment pour éviter d’avoir un challenge js).

## :100: Pour tester
Appeler l'url `/geolocate` en intégration et vérifier qu'elle retourne bien un pays.
