### PR TITLE
[DOC] Documenter les nouvelle variables d'env de pix-site introduites pour la géolocalisation (PIX-7200)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,32 @@ If not present, Metabase cards will not be loaded.
 - type: String
 - default: none
 
+---
+
+`NGINX_GEOAPI_UPSTREAM_HOST`
+Host name of the GEOAPI service that is providing the "/me" endpoint.
+This variable is used only in the nginx configuration.
+If not present, nginx will start and stop in error with message "nginx: [emerg] no host in upstream".
+
+- presence: required
+- type: String
+- default: none
+
+`NGINX_GEOAPI_UPSTREAM_MAX_FAILS`
+This variable is used only in the nginx configuration.
+
+- presence: optional
+- type: Number
+- default: 3
+
+`NGINX_GEOAPI_UPSTREAM_FAIL_TIMEOUT`
+This variable is used only in the nginx configuration.
+
+- presence: optional
+- type: String
+- default: 5s
+
+
 ## Build Setup
 
 En dev, copier le fichier `sample.env` vers un `.env` et remplacer les valeurs.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ If not present, nginx will start and stop in error with message "nginx: [emerg] 
 - default: none
 
 `NGINX_GEOAPI_UPSTREAM_MAX_FAILS`
+Number of failed request to upstream before putting it in quarantine.
 This variable is used only in the nginx configuration.
 
 - presence: optional
@@ -93,6 +94,7 @@ This variable is used only in the nginx configuration.
 - default: 3
 
 `NGINX_GEOAPI_UPSTREAM_FAIL_TIMEOUT`
+Duration of the quarantine for a failed upstream server.
 This variable is used only in the nginx configuration.
 
 - presence: optional


### PR DESCRIPTION
## :unicorn: Problème

De nouvelles variables d’env nécessaires au fonctionnement de pix-site ont été ajouté par #502 mais elles n’ont pas été documentées.

## :robot: Proposition

Ajouter ces trois variables d’environnement au README de pix-site en précisant leur utilité (demander aux captains si besoin) et en précisant qu’elles sont utilisées par le configuration nginx :

* `NGINX_GEOAPI_UPSTREAM_HOST` (obligatoire)
* `NGINX_GEOAPI_UPSTREAM_MAX_FAILS` (facultatif)
* `NGINX_GEOAPI_UPSTREAM_FAIL_TIMEOUT` (facultatif)

## :rainbow: Remarques

RAS

## :100: Pour tester

Demander une relecture aux captains.
