### PR TITLE
[BUGFIX] Corriger le robots.txt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@nuxtjs/fontawesome": "^1.1.2",
         "@nuxtjs/i18n": "^7.1.0",
         "@nuxtjs/proxy": "^2.1.0",
-        "@nuxtjs/robots": "^3.0.0",
+        "@nuxtjs/robots": "^2.5.0",
         "@nuxtjs/style-resources": "^1.2.1",
         "@vue/test-utils": "^1.2.2",
         "autoprefixer": "^10.4.0",
@@ -1623,15 +1623,6 @@
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/standalone": {
-      "version": "7.20.14",
-      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.20.14.tgz",
-      "integrity": "sha512-zxdQD6+eMQumJFPOLpOZE34JAAGrZPMXCKvHR7Mtat/l+nHDOxlit5u85HDk5WkBXmvN5PhUMeimiC95KXD9+A==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3745,99 +3736,6 @@
       "integrity": "sha512-fk6CmUgwKCfX79EzcDQQpSCMxrHstvbLswFChHS0Vump+kFkw7nJBfTZoC1j0bOGoY9I7R3n2DGek5ajbcYnOw==",
       "dev": true
     },
-    "node_modules/@nuxt/kit": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.1.1.tgz",
-      "integrity": "sha512-wmqVCIuD/te6BKf3YiqWyMumKI5JIpkiv0li/1Y3QHnTkoxyIhLkbFgNcQHuBxJ3eMlk2UjAjAqWiqBHTX54vQ==",
-      "dev": true,
-      "dependencies": {
-        "@nuxt/schema": "3.1.1",
-        "c12": "^1.1.0",
-        "consola": "^2.15.3",
-        "defu": "^6.1.2",
-        "globby": "^13.1.3",
-        "hash-sum": "^2.0.0",
-        "ignore": "^5.2.4",
-        "jiti": "^1.16.2",
-        "knitwork": "^1.0.0",
-        "lodash.template": "^4.5.0",
-        "mlly": "^1.1.0",
-        "pathe": "^1.1.0",
-        "pkg-types": "^1.0.1",
-        "scule": "^1.0.0",
-        "semver": "^7.3.8",
-        "unctx": "^2.1.1",
-        "unimport": "^2.0.1",
-        "untyped": "^1.2.2"
-      },
-      "engines": {
-        "node": "^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@nuxt/kit/node_modules/defu": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
-      "dev": true
-    },
-    "node_modules/@nuxt/kit/node_modules/globby": {
-      "version": "13.1.3",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
-      "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
-      "dev": true,
-      "dependencies": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.11",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@nuxt/kit/node_modules/pathe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
-      "integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
-      "dev": true
-    },
-    "node_modules/@nuxt/kit/node_modules/scule": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/scule/-/scule-1.0.0.tgz",
-      "integrity": "sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==",
-      "dev": true
-    },
-    "node_modules/@nuxt/kit/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@nuxt/kit/node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@nuxt/loading-screen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@nuxt/loading-screen/-/loading-screen-2.0.4.tgz",
@@ -3925,54 +3823,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@nuxt/schema": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.1.1.tgz",
-      "integrity": "sha512-/KuoCDVGrLD9W7vwuYhu4HbdT/BpbrhA4Pm9dGn7Jah40kHDGqUnJxugvMjt+4suq53rLQyTA0LRDWfFxfxAOQ==",
-      "dev": true,
-      "dependencies": {
-        "c12": "^1.1.0",
-        "create-require": "^1.1.1",
-        "defu": "^6.1.2",
-        "hookable": "^5.4.2",
-        "jiti": "^1.16.2",
-        "pathe": "^1.1.0",
-        "pkg-types": "^1.0.1",
-        "postcss-import-resolver": "^2.0.0",
-        "scule": "^1.0.0",
-        "std-env": "^3.3.1",
-        "ufo": "^1.0.1",
-        "unimport": "^2.0.1",
-        "untyped": "^1.2.2"
-      },
-      "engines": {
-        "node": "^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@nuxt/schema/node_modules/defu": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
-      "dev": true
-    },
-    "node_modules/@nuxt/schema/node_modules/pathe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
-      "integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
-      "dev": true
-    },
-    "node_modules/@nuxt/schema/node_modules/scule": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/scule/-/scule-1.0.0.tgz",
-      "integrity": "sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==",
-      "dev": true
-    },
-    "node_modules/@nuxt/schema/node_modules/ufo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-      "dev": true
     },
     "node_modules/@nuxt/server": {
       "version": "2.16.0",
@@ -4488,14 +4338,10 @@
       }
     },
     "node_modules/@nuxtjs/robots": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/robots/-/robots-3.0.0.tgz",
-      "integrity": "sha512-qsHGW1KXBvV5Kq7u3huPnFCUTbHS4Fk8Za2mNPgmUXcwLgp3exvhPtdZfIdjrCF/aZk3A8OZONNmGghs6CecBA==",
-      "dev": true,
-      "dependencies": {
-        "@nuxt/kit": "^3.0.0",
-        "h3": "^1.0.1"
-      }
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/robots/-/robots-2.5.0.tgz",
+      "integrity": "sha512-z1F3HXb05NiZga8Cuq6k5bbowfJOScPtbSOakip0nege+1aI9pGoajzap8eR5s1qwLXAk9Ts+NcgetoUn5lwrQ==",
+      "dev": true
     },
     "node_modules/@nuxtjs/style-resources": {
       "version": "1.2.1",
@@ -4568,34 +4414,6 @@
         "prismic-dom": "^2.2.0",
         "vue": "^2.6.0"
       }
-    },
-    "node_modules/@rollup/pluginutils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
-      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.21",
@@ -6894,45 +6712,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/c12": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/c12/-/c12-1.1.0.tgz",
-      "integrity": "sha512-9KRFWEng+TH8sGST4NNdiKzZGw1Z1CHnPGAmNqAyVP7suluROmBjD8hsiR34f94DdlrvtGvvmiGDsoFXlCBWIw==",
-      "dev": true,
-      "dependencies": {
-        "defu": "^6.1.1",
-        "dotenv": "^16.0.3",
-        "giget": "^1.0.0",
-        "jiti": "^1.16.0",
-        "mlly": "^1.0.0",
-        "pathe": "^1.0.0",
-        "pkg-types": "^1.0.1",
-        "rc9": "^2.0.0"
-      }
-    },
-    "node_modules/c12/node_modules/defu": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
-      "dev": true
-    },
-    "node_modules/c12/node_modules/pathe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
-      "integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
-      "dev": true
-    },
-    "node_modules/c12/node_modules/rc9": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.0.1.tgz",
-      "integrity": "sha512-9EfjLgNmzP9255YX8bGnILQcmdtOXKtUlFTu8bOZPJVtaUDZ2imswcUdpK51tMjTRQyB7r5RebNijrzuyGXcVA==",
-      "dev": true,
-      "dependencies": {
-        "defu": "^6.1.2",
-        "destr": "^1.2.2",
-        "flat": "^5.0.2"
-      }
-    },
     "node_modules/cacache": {
       "version": "15.3.0",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
@@ -7658,12 +7437,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/cookie-es": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-0.5.0.tgz",
-      "integrity": "sha512-RyZrFi6PNpBFbIaQjXDlFIhFVqV42QeKSZX1yQIl6ihImq6vcHNGMtqQ/QzY3RMPuYSkvsRwtnt5M9NeYxKt0g==",
-      "dev": true
     },
     "node_modules/copy-concurrently": {
       "version": "1.0.5",
@@ -9782,15 +9555,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -10629,42 +10393,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/giget": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/giget/-/giget-1.0.0.tgz",
-      "integrity": "sha512-KWELZn3Nxq5+0So485poHrFriK9Bn3V/x9y+wgqrHkbmnGbjfLmZ685/SVA/ovW+ewoqW0gVI47pI4yW/VNobQ==",
-      "dev": true,
-      "dependencies": {
-        "colorette": "^2.0.19",
-        "defu": "^6.1.1",
-        "https-proxy-agent": "^5.0.1",
-        "mri": "^1.2.0",
-        "node-fetch-native": "^1.0.1",
-        "pathe": "^1.0.0",
-        "tar": "^6.1.12"
-      },
-      "bin": {
-        "giget": "dist/cli.mjs"
-      }
-    },
-    "node_modules/giget/node_modules/defu": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
-      "dev": true
-    },
-    "node_modules/giget/node_modules/node-fetch-native": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.0.1.tgz",
-      "integrity": "sha512-VzW+TAk2wE4X9maiKMlT+GsPU4OMmR1U9CrHSmd3DFLn2IcZ9VJ6M6BBugGfYUnPCLSYxXdZy17M0BEJyhUTwg==",
-      "dev": true
-    },
-    "node_modules/giget/node_modules/pathe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
-      "integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
-      "dev": true
-    },
     "node_modules/git-config-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-2.0.0.tgz",
@@ -10808,24 +10536,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/h3": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.1.0.tgz",
-      "integrity": "sha512-kx3u+RMzY963fU8NNT2ePWgsryAn9DNztPqbHia/M7HgA+rtXKjHjED9/uidcYPmImNwAfJsCachCzh2T3QH2A==",
-      "dev": true,
-      "dependencies": {
-        "cookie-es": "^0.5.0",
-        "destr": "^1.2.2",
-        "radix3": "^1.0.0",
-        "ufo": "^1.0.1"
-      }
-    },
-    "node_modules/h3/node_modules/ufo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-      "dev": true
     },
     "node_modules/hable": {
       "version": "3.0.0",
@@ -11223,12 +10933,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "node_modules/hookable": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.4.2.tgz",
-      "integrity": "sha512-6rOvaUiNKy9lET1X0ECnyZ5O5kSV0PJbtA5yZUgdEF7fGJEVwSLSislltyt7nFwVVALYHQJtfGeAR2Y0A0uJkg==",
-      "dev": true
     },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
@@ -14182,12 +13886,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-      "dev": true
-    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -14226,12 +13924,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/knitwork": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/knitwork/-/knitwork-1.0.0.tgz",
-      "integrity": "sha512-dWl0Dbjm6Xm+kDxhPQJsCBTxrJzuGl0aP9rhr+TG8D3l+GL90N8O8lYUi7dTSAN2uuDqCtNgb6aEuQH5wsiV8Q==",
-      "dev": true
     },
     "node_modules/kuler": {
       "version": "2.0.0",
@@ -14475,18 +14167,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/magic-string": {
-      "version": "0.26.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
-      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
-      "dev": true,
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -14833,30 +14513,6 @@
       "dev": true,
       "optional": true
     },
-    "node_modules/mlly": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.1.0.tgz",
-      "integrity": "sha512-cwzBrBfwGC1gYJyfcy8TcZU1f+dbH/T+TuOhtYP2wLv/Fb51/uV7HJQfBPtEupZ2ORLRU1EKFS/QfS3eo9+kBQ==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.8.1",
-        "pathe": "^1.0.0",
-        "pkg-types": "^1.0.1",
-        "ufo": "^1.0.1"
-      }
-    },
-    "node_modules/mlly/node_modules/pathe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
-      "integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
-      "dev": true
-    },
-    "node_modules/mlly/node_modules/ufo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-      "dev": true
-    },
     "node_modules/moment": {
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
@@ -14888,15 +14544,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "node_modules/mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/mrmime": {
@@ -15952,23 +15599,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/pkg-types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.1.tgz",
-      "integrity": "sha512-jHv9HB+Ho7dj6ItwppRDDl0iZRYBD0jsakHXtFgoLr+cHSF6xC+QL54sJmWxyGxOLYSHm0afhXhXcQDQqH9z8g==",
-      "dev": true,
-      "dependencies": {
-        "jsonc-parser": "^3.2.0",
-        "mlly": "^1.0.0",
-        "pathe": "^1.0.0"
-      }
-    },
-    "node_modules/pkg-types/node_modules/pathe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
-      "integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
-      "dev": true
     },
     "node_modules/pluralize": {
       "version": "8.0.0",
@@ -17440,12 +17070,6 @@
         }
       ]
     },
-    "node_modules/radix3": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.0.0.tgz",
-      "integrity": "sha512-6n3AEXth91ASapMVKiEh2wrbFJmI+NBilrWE0AbiGgfm0xet0QXC8+a3K19r1UVYjUjctUgB053c3V/J6V0kCQ==",
-      "dev": true
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -18890,13 +18514,6 @@
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
       "deprecated": "See https://github.com/lydell/source-map-url#deprecated"
     },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-      "dev": true
-    },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -19208,18 +18825,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/strip-literal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.0.0.tgz",
-      "integrity": "sha512-5o4LsH1lzBzO9UFH63AJ2ad2/S2AVx6NtjOcaz+VTT2h1RiRvbipW72z8M/lxEhcPHDBQwpDrnTF7sXy/7OwCQ==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.8.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/style-resources-loader": {
@@ -20138,18 +19743,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/unctx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.1.1.tgz",
-      "integrity": "sha512-RffJlpvLOtolWsn0fxXsuSDfwiWcR6cyuykw2e0+zAggvGW1SesXt9WxIWlWpJhwVCZD/WlxxLqKLS50Q0CkWA==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.8.1",
-        "estree-walker": "^3.0.1",
-        "magic-string": "^0.26.7",
-        "unplugin": "^1.0.0"
-      }
-    },
     "node_modules/undici": {
       "version": "5.14.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
@@ -20204,61 +19797,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/unimport": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/unimport/-/unimport-2.1.0.tgz",
-      "integrity": "sha512-GDVIxATluUquX8EqelT6DtnmnZaXGID1jsO9IXwlnxb0OIEqKAxTOnTlnGmHbseoGTh+ZC9kcNDaO18HYQj9KA==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.2",
-        "escape-string-regexp": "^5.0.0",
-        "fast-glob": "^3.2.12",
-        "local-pkg": "^0.4.3",
-        "magic-string": "^0.27.0",
-        "mlly": "^1.1.0",
-        "pathe": "^1.1.0",
-        "pkg-types": "^1.0.1",
-        "scule": "^1.0.0",
-        "strip-literal": "^1.0.0",
-        "unplugin": "^1.0.1"
-      }
-    },
-    "node_modules/unimport/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/unimport/node_modules/magic-string": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
-      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/unimport/node_modules/pathe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
-      "integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
-      "dev": true
-    },
-    "node_modules/unimport/node_modules/scule": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/scule/-/scule-1.0.0.tgz",
-      "integrity": "sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==",
-      "dev": true
-    },
     "node_modules/union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -20305,27 +19843,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/unplugin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.0.1.tgz",
-      "integrity": "sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.8.1",
-        "chokidar": "^3.5.3",
-        "webpack-sources": "^3.2.3",
-        "webpack-virtual-modules": "^0.5.0"
-      }
-    },
-    "node_modules/unplugin/node_modules/webpack-sources": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
@@ -20369,24 +19886,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/untyped": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/untyped/-/untyped-1.2.2.tgz",
-      "integrity": "sha512-EANYd5L6AdpgfldlgMcmvOOnj092nWhy0ybhc7uhEH12ipytDYz89EOegBQKj8qWL3u1wgYnmFjADhsuCJs5Aw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.20.12",
-        "@babel/standalone": "^7.20.12",
-        "@babel/types": "^7.20.7",
-        "scule": "^1.0.0"
-      }
-    },
-    "node_modules/untyped/node_modules/scule": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/scule/-/scule-1.0.0.tgz",
-      "integrity": "sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==",
-      "dev": true
     },
     "node_modules/upath": {
       "version": "2.0.1",
@@ -21531,12 +21030,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/webpack-virtual-modules": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
-      "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
-      "dev": true
     },
     "node_modules/webpack/node_modules/acorn": {
       "version": "6.4.2",
@@ -23515,12 +23008,6 @@
         "regenerator-runtime": "^0.13.11"
       }
     },
-    "@babel/standalone": {
-      "version": "7.20.14",
-      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.20.14.tgz",
-      "integrity": "sha512-zxdQD6+eMQumJFPOLpOZE34JAAGrZPMXCKvHR7Mtat/l+nHDOxlit5u85HDk5WkBXmvN5PhUMeimiC95KXD9+A==",
-      "dev": true
-    },
     "@babel/template": {
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
@@ -24980,80 +24467,6 @@
         }
       }
     },
-    "@nuxt/kit": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.1.1.tgz",
-      "integrity": "sha512-wmqVCIuD/te6BKf3YiqWyMumKI5JIpkiv0li/1Y3QHnTkoxyIhLkbFgNcQHuBxJ3eMlk2UjAjAqWiqBHTX54vQ==",
-      "dev": true,
-      "requires": {
-        "@nuxt/schema": "3.1.1",
-        "c12": "^1.1.0",
-        "consola": "^2.15.3",
-        "defu": "^6.1.2",
-        "globby": "^13.1.3",
-        "hash-sum": "^2.0.0",
-        "ignore": "^5.2.4",
-        "jiti": "^1.16.2",
-        "knitwork": "^1.0.0",
-        "lodash.template": "^4.5.0",
-        "mlly": "^1.1.0",
-        "pathe": "^1.1.0",
-        "pkg-types": "^1.0.1",
-        "scule": "^1.0.0",
-        "semver": "^7.3.8",
-        "unctx": "^2.1.1",
-        "unimport": "^2.0.1",
-        "untyped": "^1.2.2"
-      },
-      "dependencies": {
-        "defu": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-          "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
-          "dev": true
-        },
-        "globby": {
-          "version": "13.1.3",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
-          "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
-          "dev": true,
-          "requires": {
-            "dir-glob": "^3.0.1",
-            "fast-glob": "^3.2.11",
-            "ignore": "^5.2.0",
-            "merge2": "^1.4.1",
-            "slash": "^4.0.0"
-          }
-        },
-        "pathe": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
-          "integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
-          "dev": true
-        },
-        "scule": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/scule/-/scule-1.0.0.tgz",
-          "integrity": "sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "slash": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-          "dev": true
-        }
-      }
-    },
     "@nuxt/loading-screen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@nuxt/loading-screen/-/loading-screen-2.0.4.tgz",
@@ -25113,53 +24526,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        }
-      }
-    },
-    "@nuxt/schema": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.1.1.tgz",
-      "integrity": "sha512-/KuoCDVGrLD9W7vwuYhu4HbdT/BpbrhA4Pm9dGn7Jah40kHDGqUnJxugvMjt+4suq53rLQyTA0LRDWfFxfxAOQ==",
-      "dev": true,
-      "requires": {
-        "c12": "^1.1.0",
-        "create-require": "^1.1.1",
-        "defu": "^6.1.2",
-        "hookable": "^5.4.2",
-        "jiti": "^1.16.2",
-        "pathe": "^1.1.0",
-        "pkg-types": "^1.0.1",
-        "postcss-import-resolver": "^2.0.0",
-        "scule": "^1.0.0",
-        "std-env": "^3.3.1",
-        "ufo": "^1.0.1",
-        "unimport": "^2.0.1",
-        "untyped": "^1.2.2"
-      },
-      "dependencies": {
-        "defu": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-          "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
-          "dev": true
-        },
-        "pathe": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
-          "integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
-          "dev": true
-        },
-        "scule": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/scule/-/scule-1.0.0.tgz",
-          "integrity": "sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==",
-          "dev": true
-        },
-        "ufo": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-          "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-          "dev": true
         }
       }
     },
@@ -25617,14 +24983,10 @@
       }
     },
     "@nuxtjs/robots": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/robots/-/robots-3.0.0.tgz",
-      "integrity": "sha512-qsHGW1KXBvV5Kq7u3huPnFCUTbHS4Fk8Za2mNPgmUXcwLgp3exvhPtdZfIdjrCF/aZk3A8OZONNmGghs6CecBA==",
-      "dev": true,
-      "requires": {
-        "@nuxt/kit": "^3.0.0",
-        "h3": "^1.0.1"
-      }
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/robots/-/robots-2.5.0.tgz",
+      "integrity": "sha512-z1F3HXb05NiZga8Cuq6k5bbowfJOScPtbSOakip0nege+1aI9pGoajzap8eR5s1qwLXAk9Ts+NcgetoUn5lwrQ==",
+      "dev": true
     },
     "@nuxtjs/style-resources": {
       "version": "1.2.1",
@@ -25682,25 +25044,6 @@
       "resolved": "https://registry.npmjs.org/@prismicio/vue/-/vue-2.1.2.tgz",
       "integrity": "sha512-hbOiaIjAliB9dsOXM1di5FsZ7KZ0XE60FRhW9WUIpMYxs/ZoebXZJouMKXNsRZZgm+qB5tgJ/IMNN0s0YqAKvw==",
       "requires": {}
-    },
-    "@rollup/pluginutils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
-      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-          "dev": true
-        }
-      }
     },
     "@sinclair/typebox": {
       "version": "0.25.21",
@@ -27536,47 +26879,6 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw=="
     },
-    "c12": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/c12/-/c12-1.1.0.tgz",
-      "integrity": "sha512-9KRFWEng+TH8sGST4NNdiKzZGw1Z1CHnPGAmNqAyVP7suluROmBjD8hsiR34f94DdlrvtGvvmiGDsoFXlCBWIw==",
-      "dev": true,
-      "requires": {
-        "defu": "^6.1.1",
-        "dotenv": "^16.0.3",
-        "giget": "^1.0.0",
-        "jiti": "^1.16.0",
-        "mlly": "^1.0.0",
-        "pathe": "^1.0.0",
-        "pkg-types": "^1.0.1",
-        "rc9": "^2.0.0"
-      },
-      "dependencies": {
-        "defu": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-          "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
-          "dev": true
-        },
-        "pathe": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
-          "integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
-          "dev": true
-        },
-        "rc9": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.0.1.tgz",
-          "integrity": "sha512-9EfjLgNmzP9255YX8bGnILQcmdtOXKtUlFTu8bOZPJVtaUDZ2imswcUdpK51tMjTRQyB7r5RebNijrzuyGXcVA==",
-          "dev": true,
-          "requires": {
-            "defu": "^6.1.2",
-            "destr": "^1.2.2",
-            "flat": "^5.0.2"
-          }
-        }
-      }
-    },
     "cacache": {
       "version": "15.3.0",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
@@ -28159,12 +27461,6 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "dev": true
-    },
-    "cookie-es": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-0.5.0.tgz",
-      "integrity": "sha512-RyZrFi6PNpBFbIaQjXDlFIhFVqV42QeKSZX1yQIl6ihImq6vcHNGMtqQ/QzY3RMPuYSkvsRwtnt5M9NeYxKt0g==",
       "dev": true
     },
     "copy-concurrently": {
@@ -29731,15 +29027,6 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
     },
-    "estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -30381,41 +29668,6 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
-    "giget": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/giget/-/giget-1.0.0.tgz",
-      "integrity": "sha512-KWELZn3Nxq5+0So485poHrFriK9Bn3V/x9y+wgqrHkbmnGbjfLmZ685/SVA/ovW+ewoqW0gVI47pI4yW/VNobQ==",
-      "dev": true,
-      "requires": {
-        "colorette": "^2.0.19",
-        "defu": "^6.1.1",
-        "https-proxy-agent": "^5.0.1",
-        "mri": "^1.2.0",
-        "node-fetch-native": "^1.0.1",
-        "pathe": "^1.0.0",
-        "tar": "^6.1.12"
-      },
-      "dependencies": {
-        "defu": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-          "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
-          "dev": true
-        },
-        "node-fetch-native": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.0.1.tgz",
-          "integrity": "sha512-VzW+TAk2wE4X9maiKMlT+GsPU4OMmR1U9CrHSmd3DFLn2IcZ9VJ6M6BBugGfYUnPCLSYxXdZy17M0BEJyhUTwg==",
-          "dev": true
-        },
-        "pathe": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
-          "integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
-          "dev": true
-        }
-      }
-    },
     "git-config-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-2.0.0.tgz",
@@ -30525,26 +29777,6 @@
       "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
       "requires": {
         "duplexer": "^0.1.2"
-      }
-    },
-    "h3": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.1.0.tgz",
-      "integrity": "sha512-kx3u+RMzY963fU8NNT2ePWgsryAn9DNztPqbHia/M7HgA+rtXKjHjED9/uidcYPmImNwAfJsCachCzh2T3QH2A==",
-      "dev": true,
-      "requires": {
-        "cookie-es": "^0.5.0",
-        "destr": "^1.2.2",
-        "radix3": "^1.0.0",
-        "ufo": "^1.0.1"
-      },
-      "dependencies": {
-        "ufo": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-          "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-          "dev": true
-        }
       }
     },
     "hable": {
@@ -30834,12 +30066,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "hookable": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.4.2.tgz",
-      "integrity": "sha512-6rOvaUiNKy9lET1X0ECnyZ5O5kSV0PJbtA5yZUgdEF7fGJEVwSLSislltyt7nFwVVALYHQJtfGeAR2Y0A0uJkg==",
-      "dev": true
     },
     "hosted-git-info": {
       "version": "2.8.9",
@@ -32978,12 +32204,6 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
-    "jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-      "dev": true
-    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -33011,12 +32231,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
       "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ=="
-    },
-    "knitwork": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/knitwork/-/knitwork-1.0.0.tgz",
-      "integrity": "sha512-dWl0Dbjm6Xm+kDxhPQJsCBTxrJzuGl0aP9rhr+TG8D3l+GL90N8O8lYUi7dTSAN2uuDqCtNgb6aEuQH5wsiV8Q==",
-      "dev": true
     },
     "kuler": {
       "version": "2.0.0",
@@ -33231,15 +32445,6 @@
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
         "yallist": "^4.0.0"
-      }
-    },
-    "magic-string": {
-      "version": "0.26.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
-      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
-      "dev": true,
-      "requires": {
-        "sourcemap-codec": "^1.4.8"
       }
     },
     "make-dir": {
@@ -33505,32 +32710,6 @@
       "dev": true,
       "optional": true
     },
-    "mlly": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.1.0.tgz",
-      "integrity": "sha512-cwzBrBfwGC1gYJyfcy8TcZU1f+dbH/T+TuOhtYP2wLv/Fb51/uV7HJQfBPtEupZ2ORLRU1EKFS/QfS3eo9+kBQ==",
-      "dev": true,
-      "requires": {
-        "acorn": "^8.8.1",
-        "pathe": "^1.0.0",
-        "pkg-types": "^1.0.1",
-        "ufo": "^1.0.1"
-      },
-      "dependencies": {
-        "pathe": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
-          "integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
-          "dev": true
-        },
-        "ufo": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-          "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-          "dev": true
-        }
-      }
-    },
     "moment": {
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
@@ -33559,12 +32738,6 @@
           }
         }
       }
-    },
-    "mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "dev": true
     },
     "mrmime": {
       "version": "1.0.1",
@@ -34397,25 +33570,6 @@
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "requires": {
         "find-up": "^4.0.0"
-      }
-    },
-    "pkg-types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.1.tgz",
-      "integrity": "sha512-jHv9HB+Ho7dj6ItwppRDDl0iZRYBD0jsakHXtFgoLr+cHSF6xC+QL54sJmWxyGxOLYSHm0afhXhXcQDQqH9z8g==",
-      "dev": true,
-      "requires": {
-        "jsonc-parser": "^3.2.0",
-        "mlly": "^1.0.0",
-        "pathe": "^1.0.0"
-      },
-      "dependencies": {
-        "pathe": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
-          "integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
-          "dev": true
-        }
       }
     },
     "pluralize": {
@@ -35336,12 +34490,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
-    },
-    "radix3": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.0.0.tgz",
-      "integrity": "sha512-6n3AEXth91ASapMVKiEh2wrbFJmI+NBilrWE0AbiGgfm0xet0QXC8+a3K19r1UVYjUjctUgB053c3V/J6V0kCQ==",
-      "dev": true
     },
     "randombytes": {
       "version": "2.1.0",
@@ -36449,12 +35597,6 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
     },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
-    },
     "spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -36707,15 +35849,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
-    },
-    "strip-literal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.0.0.tgz",
-      "integrity": "sha512-5o4LsH1lzBzO9UFH63AJ2ad2/S2AVx6NtjOcaz+VTT2h1RiRvbipW72z8M/lxEhcPHDBQwpDrnTF7sXy/7OwCQ==",
-      "dev": true,
-      "requires": {
-        "acorn": "^8.8.1"
-      }
     },
     "style-resources-loader": {
       "version": "1.5.0",
@@ -37397,18 +36530,6 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
-    "unctx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.1.1.tgz",
-      "integrity": "sha512-RffJlpvLOtolWsn0fxXsuSDfwiWcR6cyuykw2e0+zAggvGW1SesXt9WxIWlWpJhwVCZD/WlxxLqKLS50Q0CkWA==",
-      "dev": true,
-      "requires": {
-        "acorn": "^8.8.1",
-        "estree-walker": "^3.0.1",
-        "magic-string": "^0.26.7",
-        "unplugin": "^1.0.0"
-      }
-    },
     "undici": {
       "version": "5.14.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
@@ -37448,54 +36569,6 @@
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
       "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w=="
     },
-    "unimport": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/unimport/-/unimport-2.1.0.tgz",
-      "integrity": "sha512-GDVIxATluUquX8EqelT6DtnmnZaXGID1jsO9IXwlnxb0OIEqKAxTOnTlnGmHbseoGTh+ZC9kcNDaO18HYQj9KA==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^5.0.2",
-        "escape-string-regexp": "^5.0.0",
-        "fast-glob": "^3.2.12",
-        "local-pkg": "^0.4.3",
-        "magic-string": "^0.27.0",
-        "mlly": "^1.1.0",
-        "pathe": "^1.1.0",
-        "pkg-types": "^1.0.1",
-        "scule": "^1.0.0",
-        "strip-literal": "^1.0.0",
-        "unplugin": "^1.0.1"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-          "dev": true
-        },
-        "magic-string": {
-          "version": "0.27.0",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
-          "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
-          "dev": true,
-          "requires": {
-            "@jridgewell/sourcemap-codec": "^1.4.13"
-          }
-        },
-        "pathe": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
-          "integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
-          "dev": true
-        },
-        "scule": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/scule/-/scule-1.0.0.tgz",
-          "integrity": "sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==",
-          "dev": true
-        }
-      }
-    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -37533,26 +36606,6 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
-    "unplugin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.0.1.tgz",
-      "integrity": "sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==",
-      "dev": true,
-      "requires": {
-        "acorn": "^8.8.1",
-        "chokidar": "^3.5.3",
-        "webpack-sources": "^3.2.3",
-        "webpack-virtual-modules": "^0.5.0"
-      },
-      "dependencies": {
-        "webpack-sources": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-          "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
-          "dev": true
-        }
-      }
-    },
     "unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
@@ -37586,26 +36639,6 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-        }
-      }
-    },
-    "untyped": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/untyped/-/untyped-1.2.2.tgz",
-      "integrity": "sha512-EANYd5L6AdpgfldlgMcmvOOnj092nWhy0ybhc7uhEH12ipytDYz89EOegBQKj8qWL3u1wgYnmFjADhsuCJs5Aw==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "^7.20.12",
-        "@babel/standalone": "^7.20.12",
-        "@babel/types": "^7.20.7",
-        "scule": "^1.0.0"
-      },
-      "dependencies": {
-        "scule": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/scule/-/scule-1.0.0.tgz",
-          "integrity": "sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==",
-          "dev": true
         }
       }
     },
@@ -38830,12 +37863,6 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
-    },
-    "webpack-virtual-modules": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
-      "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
-      "dev": true
     },
     "webpackbar": {
       "version": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@nuxtjs/fontawesome": "^1.1.2",
     "@nuxtjs/i18n": "^7.1.0",
     "@nuxtjs/proxy": "^2.1.0",
-    "@nuxtjs/robots": "^3.0.0",
+    "@nuxtjs/robots": "^2.5.0",
     "@nuxtjs/style-resources": "^1.2.1",
     "@vue/test-utils": "^1.2.2",
     "autoprefixer": "^10.4.0",


### PR DESCRIPTION
## :unicorn: Problème
Suite à la mise à jour de la dépendance `@nuxtjs/robots` en version 3.0, le path /robot.txt ne fonctionne plus.  
Un warning est aussi présent lors du lancement de l'app en local : 
```
WARN  Module @nuxtjs/robots is disabled due to incompatibility issues:       
 - [bridge] Nuxt bridge is required
```
Après vérification. La version 3.0 ne supporte plus Nuxt 2 mais uniquement [Nuxt3/Nuxt Bridge](https://github.com/nuxt-community/robots-module/blob/main/CHANGELOG.md#-breaking-changes).

## :robot: Proposition
Rollback la montée de version fait dans cette [PR](https://github.com/1024pix/pix-site/pull/483).

## :rainbow: Remarques
- Si la commande `npm ci` ne passe pas sur la CI, pour cause de désynchronisation entre` package.json`et`package-lock.json`, vérifier dans la config npm globale que `legacy-peer-deps = false` ! 

## :100: Pour tester
- Vérifier, sur la review-app, que l'url `/robots.txt` fonctionne bien 😄 