### PR TITLE
[BUGFIX] Affichage de la modal (PIX-7189)

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -79,7 +79,7 @@ const nuxtConfig = {
     '~/plugins/components.js',
     '~/plugins/meta.js',
     { src: '~plugins/slide-menu', mode: 'client' },
-    '~plugins/vue-js-modal',
+    { src: '~plugins/vue-js-modal.js', mode: 'client' },
     { src: '~/plugins/prismicLinks', mode: 'client' },
     { src: '~/plugins/locale-observer', mode: 'client' },
   ],

--- a/plugins/vue-js-modal.js
+++ b/plugins/vue-js-modal.js
@@ -1,4 +1,4 @@
 import Vue from 'vue'
-import VModal from 'vue-js-modal/dist/ssr.index'
+import VModal from 'vue-js-modal'
 
 Vue.use(VModal)

--- a/tests/components/slices/PageBanner.test.js
+++ b/tests/components/slices/PageBanner.test.js
@@ -1,0 +1,40 @@
+import { shallowMount } from '@vue/test-utils'
+import VModal from 'vue-js-modal'
+import { createLocalVue } from '../../pages/pix-site/utils'
+import PageBanner from '~/components/slices/PageBanner'
+
+const localVue = createLocalVue()
+localVue.use(VModal)
+
+describe('Slice: Page Banner', () => {
+  let component
+
+  it('should render component', () => {
+    // given & when
+    component = shallowMount(PageBanner, {
+      localVue,
+      stubs: {
+        'prismic-rich-text': true,
+        fa: true,
+        'media-player': true,
+      },
+      propsData: {
+        slice: {
+          primary: {
+            banner_font_contrast: '',
+            title: '',
+            textContent: '',
+            hasImage: false,
+            hasBackgroundImage: false,
+            imageUrl: undefined,
+          },
+          items: [{ banner_link_url: { url: 'pix-videos/' } }],
+        },
+      },
+    })
+
+    // then
+    const result = component.html()
+    expect(result).toMatchSnapshot()
+  })
+})

--- a/tests/components/slices/__snapshots__/PageBanner.test.js.snap
+++ b/tests/components/slices/__snapshots__/PageBanner.test.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Slice: Page Banner should render component 1`] = `
+"<div id="slice-0">
+  <section class="banner row-block">
+    <div class="row-block__main-content">
+      <prismic-rich-text-stub class="title--big title--"></prismic-rich-text-stub>
+      <prismic-rich-text-stub class="text--normal text--"></prismic-rich-text-stub>
+      <div class="banner__button-group">
+        <div>
+          <!----> <button class="button button-video button--">
+            <fa-stub icon="play-circle"></fa-stub>
+
+          </button>
+          <modal-stub name="videoModal" resizeedges="r,br,b,bl,l,tl,t,tr" centerresize="true" resizeindicator="true" overlaytransition="vm-transition--overlay" transition="vm-transition--modal" clicktoclose="true" classes="" minwidth="0" minheight="0" maxwidth="9007199254740991" maxheight="9007199254740991" width="600" height="auto" shiftx="0.5" shifty="0.5">
+            <media-player-stub video-url="pix-videos/"></media-player-stub>
+          </modal-stub>
+        </div>
+      </div>
+    </div>
+    <!---->
+  </section>
+</div>"
+`;


### PR DESCRIPTION
## :unicorn: Problème
L'accès à la vidéo d'accueil dans une modal était cassé.

## :robot: Proposition
Passer le paramétrage de la librairie en rendu client plutôt qu'en SSR.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier sur la RA que la vidéo s'affiche correctement.