### PR TITLE
[TECH] Corrige un warning sur l'usage du `nextTick`

### DIFF
--- a/tests/pages/pix-pro/index.test.js
+++ b/tests/pages/pix-pro/index.test.js
@@ -1,5 +1,4 @@
 import { shallowMount } from '@vue/test-utils'
-import Vue from 'vue'
 import Index from '@/pages/pix-pro/index.vue'
 
 describe('Index Page', () => {
@@ -29,7 +28,7 @@ describe('Index Page', () => {
           mocks: { $router },
           stubs: ['client-only', 'pix-image', 'locale-link'],
         })
-        await Vue.nextTick()
+        await wrapper.vm.$nextTick()
 
         // then
         expect($router.replace).not.toHaveBeenCalled()
@@ -48,7 +47,7 @@ describe('Index Page', () => {
           mocks: { $router },
           stubs: ['client-only', 'pix-image', 'locale-link'],
         })
-        await Vue.nextTick()
+        await wrapper.vm.$nextTick()
 
         // then
         expect($router.replace).toHaveBeenCalledWith('/fr/')

--- a/tests/pages/pix-site/index.test.js
+++ b/tests/pages/pix-site/index.test.js
@@ -1,5 +1,4 @@
 import { shallowMount } from '@vue/test-utils'
-import Vue from 'vue'
 import Index from '@/pages/pix-site/index.vue'
 
 describe('Index Page', () => {
@@ -29,7 +28,7 @@ describe('Index Page', () => {
           mocks: { $router },
           stubs: ['client-only', 'pix-image', 'locale-link'],
         })
-        await Vue.nextTick()
+        await wrapper.vm.$nextTick()
 
         // then
         expect($router.replace).not.toHaveBeenCalled()
@@ -48,7 +47,7 @@ describe('Index Page', () => {
           mocks: { $router },
           stubs: ['client-only', 'pix-image', 'locale-link'],
         })
-        await Vue.nextTick()
+        await wrapper.vm.$nextTick()
 
         // then
         expect($router.replace).toHaveBeenCalledWith('/fr/')


### PR DESCRIPTION
## :unicorn: Problème
On importe la dépendance `Vue` pour utiliser la méthode `nextTick`. Le linter nous conseille d'importer uniquement la méthode (j'imagine pour du three shaking).

## :robot: Proposition
Directement utiliser la méthode `wrapper.vm.$nextTick()` pour ne pas avoir besoin d'importer quoi que ce soit.

## :rainbow: Remarques
Aucune idée de si c'est une bonne pratique ou non mais ça corrige l'erreur de lint.

## :100: Pour tester
Vérifier que la CI passe toujours.
