### PR TITLE
[BUGFIX] Corriger le positionnement du cookie locale en local en mode dev

### DIFF
--- a/plugins/locale-observer.js
+++ b/plugins/locale-observer.js
@@ -1,11 +1,21 @@
 import { config } from '../config/environment'
 
-export default function ({ app }) {
+export default function (context) {
+  const { app, isDev } = context
   app.i18n.onBeforeLanguageSwitch = (oldLocale, newLocale) => {
-    _setLocaleCookie(newLocale)
+    _setLocaleCookie(newLocale, isDev)
   }
 }
 
-function _setLocaleCookie(locale) {
-  document.cookie = `locale=${locale}; path=/; domain=${config.siteDomain}; max-age=31536000`
+function _setLocaleCookie(locale, isDev) {
+  const localeCookieProperties = [
+    `locale=${locale}`,
+    'path=/',
+    'max-age=31536000',
+  ]
+  if (!isDev) {
+    localeCookieProperties.push(`domain=${config.siteDomain}`)
+  }
+
+  document.cookie = localeCookieProperties.join('; ')
 }

--- a/plugins/locale-observer.js
+++ b/plugins/locale-observer.js
@@ -12,6 +12,7 @@ function _setLocaleCookie(locale, isDev) {
     `locale=${locale}`,
     'path=/',
     'max-age=31536000',
+    'SameSite=Strict',
   ]
   if (!isDev) {
     localeCookieProperties.push(`domain=${config.siteDomain}`)

--- a/tests/plugins/locale-observer.test.js
+++ b/tests/plugins/locale-observer.test.js
@@ -17,13 +17,70 @@ describe('Plugins | locale-observer', () => {
   })
 
   describe('when user switch locale', () => {
+    describe('when not isDev', () => {
+      describe('when no cookie', () => {
+        it('saves locale cookie', () => {
+          // given
+          document.cookie = ''
+          const oldLocale = ''
+          const newLocale = 'en-gb'
+          const context = {
+            app: {
+              i18n: {},
+            },
+            route: {
+              path: '/',
+            },
+          }
+
+          // when
+          localeObserver(context)
+          context.app.i18n.onBeforeLanguageSwitch(oldLocale, newLocale)
+
+          // then
+          expect(document.cookie).toEqual(
+            'locale=en-gb; path=/; max-age=31536000; domain=pix.org'
+          )
+        })
+      })
+
+      describe('when cookie', () => {
+        it('saves locale cookie', () => {
+          // given
+          document.cookie = 'locale=en-gb; path=/; max-age=31536000'
+          const oldLocale = 'en-gb'
+          const newLocale = 'fr'
+          const context = {
+            app: {
+              i18n: {},
+            },
+            route: {
+              path: '/',
+            },
+          }
+
+          // when
+          localeObserver(context)
+          context.app.i18n.onBeforeLanguageSwitch(oldLocale, newLocale)
+
+          // then
+          expect(document.cookie).toEqual(
+            'locale=fr; path=/; max-age=31536000; domain=pix.org'
+          )
+        })
+      })
+    })
+  })
+
+  describe('when isDev', () => {
     describe('when no cookie', () => {
-      it('save locale cookie', () => {
+      it('saves locale cookie', () => {
         // given
         document.cookie = ''
         const oldLocale = ''
         const newLocale = 'en-gb'
         const context = {
+          isDev: true,
           app: {
             i18n: {},
           },
@@ -38,18 +95,19 @@ describe('Plugins | locale-observer', () => {
 
         // then
         expect(document.cookie).toEqual(
-          'locale=en-gb; path=/; domain=pix.org; max-age=31536000'
+          'locale=en-gb; path=/; max-age=31536000'
         )
       })
     })
 
     describe('when cookie', () => {
-      it('save locale cookie', () => {
+      it('saves locale cookie', () => {
         // given
         document.cookie = 'locale=en-gb; path=/; max-age=31536000'
         const oldLocale = 'en-gb'
         const newLocale = 'fr'
         const context = {
+          isDev: true,
           app: {
             i18n: {},
           },
@@ -63,9 +121,7 @@ describe('Plugins | locale-observer', () => {
         context.app.i18n.onBeforeLanguageSwitch(oldLocale, newLocale)
 
         // then
-        expect(document.cookie).toEqual(
-          'locale=fr; path=/; domain=pix.org; max-age=31536000'
-        )
+        expect(document.cookie).toEqual('locale=fr; path=/; max-age=31536000')
       })
     })
   })

--- a/tests/plugins/locale-observer.test.js
+++ b/tests/plugins/locale-observer.test.js
@@ -39,7 +39,7 @@ describe('Plugins | locale-observer', () => {
 
           // then
           expect(document.cookie).toEqual(
-            'locale=en-gb; path=/; max-age=31536000; domain=pix.org'
+            'locale=en-gb; path=/; max-age=31536000; SameSite=Strict; domain=pix.org'
           )
         })
       })
@@ -47,7 +47,8 @@ describe('Plugins | locale-observer', () => {
       describe('when cookie', () => {
         it('saves locale cookie', () => {
           // given
-          document.cookie = 'locale=en-gb; path=/; max-age=31536000'
+          document.cookie =
+            'locale=en-gb; path=/; max-age=31536000; SameSite=Strict'
           const oldLocale = 'en-gb'
           const newLocale = 'fr'
           const context = {
@@ -65,7 +66,7 @@ describe('Plugins | locale-observer', () => {
 
           // then
           expect(document.cookie).toEqual(
-            'locale=fr; path=/; max-age=31536000; domain=pix.org'
+            'locale=fr; path=/; max-age=31536000; SameSite=Strict; domain=pix.org'
           )
         })
       })
@@ -95,7 +96,7 @@ describe('Plugins | locale-observer', () => {
 
         // then
         expect(document.cookie).toEqual(
-          'locale=en-gb; path=/; max-age=31536000'
+          'locale=en-gb; path=/; max-age=31536000; SameSite=Strict'
         )
       })
     })
@@ -103,7 +104,8 @@ describe('Plugins | locale-observer', () => {
     describe('when cookie', () => {
       it('saves locale cookie', () => {
         // given
-        document.cookie = 'locale=en-gb; path=/; max-age=31536000'
+        document.cookie =
+          'locale=en-gb; path=/; max-age=31536000; SameSite=Strict'
         const oldLocale = 'en-gb'
         const newLocale = 'fr'
         const context = {
@@ -121,7 +123,9 @@ describe('Plugins | locale-observer', () => {
         context.app.i18n.onBeforeLanguageSwitch(oldLocale, newLocale)
 
         // then
-        expect(document.cookie).toEqual('locale=fr; path=/; max-age=31536000')
+        expect(document.cookie).toEqual(
+          'locale=fr; path=/; max-age=31536000; SameSite=Strict'
+        )
       })
     })
   })


### PR DESCRIPTION
## :unicorn: Problème

Actuellement en local en dev mode, le choix de locale de l'utilisateur n'est pas enregistré.

Dans la console web l'erreur est la suivante  :
```
Le cookie « locale » a été rejeté car le domaine est invalide.
```

Par ailleurs il y a également une autre erreur dans la console web :
```
Le cookie « locale » n’a pas de valeur d’attribut « SameSite » appropriée. Bientôt, les cookies dont l’attribut « SameSite » est manquant ou défini avec une valeur invalide seront traités comme « Lax ». Cela signifie que le cookie ne sera plus envoyé dans des contextes tiers. Si votre application dépend de la disponibilité de ce cookie dans de tels contextes, veuillez lui ajouter l’attribut « SameSite=None ». Pour en savoir plus sur l’attribut « SameSite », consultez https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite
```

C'est une régression introduite par #466.

## :robot: Proposition

### Correction de la régression

Positionnement de la propriété `domain` dans le cookie uniquement lorsque pas `isDev`.

### Propriété SameSite

En plus de la correction de la régression, ajout supplémentaire d'une propriété `SameSite=Strict` pour corriger l'autre warning dans la console web.

Pour la [propriété `SameSite`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
) c'est le choix `SameSite=Strict` qui est fait pour les raisons suivantes : 
* `SameSite=None` enverrait le cookie locale tout le temps, dans tous les contextes, pour toutes les requêtes, ce n'est pas ce que nous souhaitons
* `SameSite=Lax` fait que : Cookies are not sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating to the origin site (i.e., when following a link). Nous n'avons pas ce besoin.
*  `SameSite=Strict`  fait que le cookie locale n'est envoyé que lorsqu'il est dans un contexte où il est un _first-party_ cookie https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#third-party_cookies, ce qui convient exactement aux cas où on veut pouvoir lire/écrire la valeur du cookie locale sur les sites web `*.pix.org`.

## :rainbow: Remarques

RAS

## :100: Pour tester

### Vérifier que le problème est corrigé

1. Exécuter `npm run dev:site:org`
2. Aller sur http://localhost:8000/ et supprimer tout cookie `locale` qui pourrait exister
3. Aller sur la page racine du site web et choisir une locale
4. Vérifier que ce choix de locale est bien enregistré dans le cookie `locale`

### Vérifier qu'il n'y a pas de régression sur le fonctionnement de production (c'est à dire pas `isDev`)

1. Aller sur la RA https://site-pr511.review.pix.org/  et supprimer tout cookie `locale` qui pourrait exister
2. Aller sur la page racine du site web et choisir une locale
3. Vérifier que ce choix de locale est bien enregistré dans le cookie `locale`
4. Aller sur https://app.pix.org et constater que ce cookie nouvellement créé est bien disponible dans ce contexte et avec la propriété `SameSite=Strict`
