### PR TITLE
[FEATURE] Afficher une bannière pour suggérer aux utilisateurs hors de France visitant pix.fr d'aller sur pix.org (PIX-7041)

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,12 @@ For detailed explanation on how things work, check out [Nuxt.js docs](https://nu
 
 ### NGINX
 
+La configuration NGINX a besoin de la variable NGINX_GEOAPI_UPSTREAM_HOST (ne pas la définir cause une erreur) :
+
+```
+export NGINX_GEOAPI_UPSTREAM_HOST=example.net # remplacer example.net par le host name du service de geolocalisation
+```
+
 Pour tester la configuration NGINX des sites statiques en local, il suffit de faire:
 
 ```

--- a/assets/scss/globals/_colors.scss
+++ b/assets/scss/globals/_colors.scss
@@ -2,6 +2,7 @@
 $blue: #3d68ff;
 $blue-zodiac: #505f79;
 $white: #ffffff;
+$black: #000;
 
 // secondary
 $blue-hover: darken($blue, 12%);

--- a/components/LocaleSuggestionBanner.vue
+++ b/components/LocaleSuggestionBanner.vue
@@ -28,12 +28,12 @@ export default {
 .locale-suggestion-banner {
   top: 0;
   left: 0;
-  height: 70px;
+  height: 4.375rem;
   width: 100%;
 
   color: $white;
   background-color: $black;
-  padding: 2px;
+  padding: 0.125rem;
 
   display: flex;
   flex-direction: row;
@@ -53,14 +53,14 @@ export default {
 }
 
 .close {
-  margin-right: 20px;
+  margin-right: 1.25rem;
   opacity: 0.5;
   transition: 0.5s;
   cursor: pointer;
-  height: 20px;
+  height: 1.25rem;
 
-  @media (min-width: 769px) {
-    margin-right: 32px;
+  @include device-is('tablet') {
+    margin-right: 2rem;
   }
 
   &:hover {

--- a/components/LocaleSuggestionBanner.vue
+++ b/components/LocaleSuggestionBanner.vue
@@ -1,0 +1,70 @@
+<template>
+  <div v-if="isOpen" class="locale-suggestion-banner">
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <p v-html="$t('locale-suggestion-banner-text')"></p>
+    <img
+      class="close"
+      src="/images/close-icon.svg"
+      alt="Fermer"
+      @click.stop="$emit('handleCloseBanner')"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'LocaleSuggestionBanner',
+  props: {
+    isOpen: {
+      required: true,
+      type: Boolean,
+      default: false,
+    },
+  },
+}
+</script>
+
+<style lang="scss">
+.locale-suggestion-banner {
+  top: 0;
+  left: 0;
+  height: 70px;
+  width: 100%;
+
+  color: $white;
+  background-color: $black;
+  padding: 2px;
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  p {
+    text-align: center;
+    line-height: 1rem;
+    font-size: 0.875rem;
+    margin: 0 auto;
+  }
+
+  a {
+    color: $white;
+    text-decoration: underline;
+  }
+}
+
+.close {
+  margin-right: 20px;
+  opacity: 0.5;
+  transition: 0.5s;
+  cursor: pointer;
+  height: 20px;
+
+  @media (min-width: 769px) {
+    margin-right: 32px;
+  }
+
+  &:hover {
+    opacity: 1;
+  }
+}
+</style>

--- a/config/localization/translations/en-gb.js
+++ b/config/localization/translations/en-gb.js
@@ -62,4 +62,5 @@ export default {
     '<br/>If you need help, you can check out the ' +
     '<a href="https://support.pix.org/en/support/home">support</a>.' +
     '</p>',
+  'locale-suggestion-banner-text': `You don't seem to be in France. Do you want to access the <a href="https://${process.env.DOMAIN_ORG}">Pix international website</a>?`,
 }

--- a/config/localization/translations/fr-be.js
+++ b/config/localization/translations/fr-be.js
@@ -62,4 +62,5 @@ export default {
     '<br/>Si vous avez besoin d’aide, vous pouvez consulter le ' +
     '<a href="https://support.pix.org/fr/support/home">support</a>.' +
     '</p>',
+  'locale-suggestion-banner-text': `Vous semblez ne pas être en France. Voulez-vous accéder au <a href="https://${process.env.DOMAIN_ORG}">site Pix international</a> ?`,
 }

--- a/config/localization/translations/fr-fr.js
+++ b/config/localization/translations/fr-fr.js
@@ -62,4 +62,5 @@ export default {
     '<br/>Si vous avez besoin d’aide, vous pouvez consulter le ' +
     '<a href="https://support.pix.org/fr/support/home">support</a>.' +
     '</p>',
+  'locale-suggestion-banner-text': `Vous semblez ne pas être en France. Voulez-vous accéder au <a href="https://${process.env.DOMAIN_ORG}">site Pix international</a> ?`,
 }

--- a/config/localization/translations/fr.js
+++ b/config/localization/translations/fr.js
@@ -62,4 +62,5 @@ export default {
     '<br/>Si vous avez besoin d’aide, vous pouvez consulter le ' +
     '<a href="https://support.pix.org/fr/support/home">support</a>.' +
     '</p>',
+  'locale-suggestion-banner-text': `Vous semblez ne pas être en France. Voulez-vous accéder au <a href="https://${process.env.DOMAIN_ORG}">site Pix international</a> ?`,
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,6 +1,10 @@
 <template>
   <div id="app" class="app-viewport">
     <hot-news-banner />
+    <locale-suggestion-banner
+      :is-open="showOutOfFranceBanner"
+      @handleCloseBanner="closeLocaleSuggestionBanner"
+    />
     <navigation-slice-zone />
     <main role="main">
       <nuxt />
@@ -39,6 +43,11 @@ export default {
         lang: this.$i18n.locale,
       },
     }
+  },
+  methods: {
+    closeLocaleSuggestionBanner() {
+      this.showOutOfFranceBanner = false
+    },
   },
 }
 </script>

--- a/tests/components/LocaleSuggestionBanner.test.js
+++ b/tests/components/LocaleSuggestionBanner.test.js
@@ -1,0 +1,48 @@
+import { mount } from '@vue/test-utils'
+import LocaleSuggestionBanner from '~/components/LocaleSuggestionBanner.vue'
+
+describe('Component: LocaleSuggestionBanner', () => {
+  let processEnvBackup
+
+  beforeEach(() => {
+    processEnvBackup = { ...process.env }
+  })
+
+  afterEach(() => {
+    process.env = { ...processEnvBackup }
+  })
+
+  describe('when on french domain (pix-site.fr)', () => {
+    describe('when user is located outside of France', () => {
+      it('renders the locale suggestion banner', () => {
+        // given
+        process.env.DOMAIN_ORG = 'example.org'
+        const $t = () =>
+          `Vous semblez ne pas être en France. Voulez-vous accéder au <a href="https://${process.env.DOMAIN_ORG}">site Pix international</a> ?`
+
+        // when
+        const component = mount(LocaleSuggestionBanner, {
+          propsData: { isOpen: true },
+          mocks: { $t },
+        })
+
+        // then
+        expect(component.find('a').html()).toContain(
+          '<a href="https://example.org">site Pix international</a>'
+        )
+      })
+    })
+
+    describe('when user is located in France', () => {
+      it('does not render the locale suggestion banner', () => {
+        // given & when
+        const component = mount(LocaleSuggestionBanner, {
+          propsData: { isOpen: false },
+        })
+
+        // then
+        expect(component.find('.locale-suggestion-banner').exists()).toBe(false)
+      })
+    })
+  })
+})

--- a/tests/layouts/default.test.js
+++ b/tests/layouts/default.test.js
@@ -1,22 +1,40 @@
-import { shallowMount } from '@vue/test-utils'
+import { mount, shallowMount } from '@vue/test-utils'
 import VueMeta from 'vue-meta'
 import { createLocalVue } from '../pages/pix-site/utils'
 import DefaultLayout from '~/layouts/default.vue'
+import LocaleSuggestionBanner from '~/components/LocaleSuggestionBanner.vue'
 
 const localVue = createLocalVue()
 localVue.use(VueMeta, { keyName: 'head' })
 
-describe.only('Default layout', () => {
-  let $i18n, wrapper
+jest.mock('~/config/environment', () => ({
+  config: {
+    site: 'pix-site',
+    isPixSite: true,
+    domain: {
+      french: 'example.fr',
+      international: 'example.org',
+    },
+  },
+}))
+
+describe('Default layout', () => {
+  let $i18n, wrapper, processEnvBackup
+
   const stubs = {
     HotNewsBanner: true,
     NavigationSliceZone: true,
+    LocaleSuggestionBanner: true,
     Nuxt: true,
     FooterSliceZone: true,
   }
-
   beforeEach(() => {
     $i18n = { locale: 'fr-be' }
+    processEnvBackup = { ...process.env }
+  })
+
+  afterEach(() => {
+    process.env = { ...processEnvBackup }
   })
 
   it('should render the #app element', () => {
@@ -70,6 +88,37 @@ describe.only('Default layout', () => {
         'lang',
         $i18n.locale
       )
+    })
+  })
+
+  describe('when on french domain (pix-site.fr)', () => {
+    describe('when user is located outside of France', () => {
+      describe('when user click on the close button in the locale suggestion banner', () => {
+        it('closes the banner', async () => {
+          // given
+          process.env.DOMAIN_ORG = 'example.org'
+          const $t = () =>
+            `Vous semblez ne pas être en France. Voulez-vous accéder au <a href="https://${process.env.DOMAIN_ORG}">site Pix international</a> ?`
+          wrapper = mount(DefaultLayout, {
+            localVue,
+            components: { LocaleSuggestionBanner },
+            stubs: { ...stubs, LocaleSuggestionBanner: false },
+            mocks: { $i18n, $t },
+            data() {
+              return { showOutOfFranceBanner: true }
+            },
+          })
+
+          // when
+          const closeButton = wrapper.find('.locale-suggestion-banner > img')
+          await closeButton.trigger('click')
+
+          // then
+          expect(wrapper.find('.locale-suggestion-banner > img').exists()).toBe(
+            false
+          )
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu’un utilisateur localisé hors de la France visite le site vitrine français, nous avons besoin de lui proposer de se rendre sur le site vitrine international, afin qu'il puisse choisir le site correspondant à sa locale préférée.

## :robot: Proposition

Afficher une bannière avec le texte “Vous semblez ne pas être en France. Voulez-vous accéder au site Pix international ?" et un lien vers la page de choix de locale de pix.org si et seulement si :
* le visiteur est sur le site français (pix.fr)
* le visiteur a été identifié comme étant hors de France par le endpoint de geolocalisation

## :rainbow: Remarques

Utilisation de PixLink

## :100: Pour tester

Idéalement utiliser un VPN (le navigateur Opera dispose d'un VPN intégré gratuit) pour pouvoir tester les différents cas en modifiant votre pays de sortie sur le réseau.

1. Aller sur la review-app de `pix.fr` (https://site-pr512.review.pix.fr/) : 
   * Si vous êtes en France, constater que la bannière ne s'affiche pas
   * Si vous êtes hors de France, constater que la bannière s'affiche et que lorsque vous cliquez sur le lien, vous êtes bien redirigé sur `pix.org` ( soit sur la page de choix de locale, soit directement sur le site avec votre locale préférée choisie précédemment). 
2. Aller sur chacune des 3 autres review-apps et constater que la bannière ne s'affiche sur aucune d'elle
