### PR TITLE
[TECH] Rendre la variable NGINX_GEOAPI_UPSTREAM_HOST optionnelle pour l'utilisation du projet en version statique (PIX-7328)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ If not present, Metabase cards will not be loaded.
 `NGINX_GEOAPI_UPSTREAM_HOST`
 Host name of the GEOAPI service that is providing the "/me" endpoint.
 This variable is used only in the nginx configuration.
-If not present, nginx will start and stop in error with message "nginx: [emerg] no host in upstream".
+If not present, the geolocalisation won't be available in the application.
 
-- presence: required
+- presence: optional
 - type: String
 - default: none
 

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -28,9 +28,11 @@ access_log off;
 
 port_in_redirect off;
 
+<% if ENV['NGINX_GEOAPI_UPSTREAM_HOST'] %>
 upstream api {
   server <%= ENV['NGINX_GEOAPI_UPSTREAM_HOST'] %>:443 max_fails=<%= ENV['NGINX_GEOAPI_UPSTREAM_MAX_FAILS'] || 3 %> fail_timeout=<%= ENV['NGINX_GEOAPI_UPSTREAM_FAIL_TIMEOUT'] || '5s' %>;
 }
+<% end %>
 
 server {
   access_log logs/access.log keyvalue;
@@ -46,12 +48,14 @@ server {
     set $extension 'org';
   }
 
+<% if ENV['NGINX_GEOAPI_UPSTREAM_HOST'] %>
   location /geolocate {
     proxy_pass https://api/me;
     proxy_redirect default;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host <%= ENV['NGINX_GEOAPI_UPSTREAM_HOST'] %>;
   }
+<% end %>
 
   charset utf-8;
 


### PR DESCRIPTION
## :unicorn: Problème

Actuellement quand on ne positionne pas la variable `NGINX_GEOAPI_UPSTREAM_HOST` on ne peut pas réaliser les actions suivantes :
* `npm run dev:site:e2e`
* `npm run dev:pro:e2e`

C'est gênant pour les développeurs qui veulent travailler sur le projet sans se soucier ni avoir à connaître les fonctionnalités liées à la géolocalisation.

## :robot: Proposition

Faire que la configuration nginx soit fonctionnelle même lorsque la variable `NGINX_GEOAPI_UPSTREAM_HOST` n'est pas définie, en ajoutant une condition au format [ERB (Ruby Templating)](https://docs.ruby-lang.org/en/master/ERB.html) sur les blocs de configuration dans lesquels cette variable est nécessaire.

## :rainbow: Remarques

RAS

## :100: Pour tester

Vérifier que, sans définir la variable `NGINX_GEOAPI_UPSTREAM_HOST`, les pix-sites sont toujours fonctionnels sauf en ce qui concerne la géolocalisation. On pourra s'en assurer notamment en exécutant les scripts npm suivants : 

* `npm run dev:site:e2e`
* `npm run dev:pro:e2e`
