### PR TITLE
[BUGFIX]: Corriger le problème d'affichage de la bannière hors de France en affichage réduit

### DIFF
--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -86,6 +86,7 @@ export default {
 <style lang="scss">
 .navigation-slice-zone {
   box-shadow: -1px 9px 29px -16px rgba(199, 191, 199, 0.9);
+  position: relative;
 
   .burger-menu {
     display: block;


### PR DESCRIPTION
## :unicorn: Problème
Suite à l'ajout de la bannière "hors de France", un bug d'affichage a été constaté, en vue mobile, sur le burger menu qui se trouve dans la bannière.

<img width="401" alt="Capture d’écran 2023-02-23 à 18 54 01" src="https://user-images.githubusercontent.com/11760574/220989691-26530376-5ca8-41da-95b6-3df66020e538.png">

## :robot: Proposition
Corriger la position du menu burger en le mettant en bas.

## :rainbow: Remarques
Pas de remarques.

## :100: Pour tester
- Aller sur la review-app de pix.fr en vue mobile avec un VPN (Opera en embarque un nativement) pour être positionné hors de France 😄 
- Vérifier que le menu burger se trouve à la bonne position !
