### PR TITLE
[FEATURE] Remplacer la locale en-GB par en dans le cookie (PIX-7474)

### DIFF
--- a/pages/pix-pro/index.vue
+++ b/pages/pix-pro/index.vue
@@ -22,6 +22,7 @@
 
 <script>
 import { localization } from '~/config/localization'
+import { getLocaleFromCookie } from '~/services/get-locale-from-cookie'
 
 export default {
   layout: 'empty',
@@ -33,38 +34,11 @@ export default {
     }
   },
   mounted() {
-    const chosenLocale = this.getLocaleFromCookie()
+    const chosenLocale = getLocaleFromCookie()
     if (chosenLocale) {
       return this.$router.replace(`/${chosenLocale}/`)
     }
     this.shouldDisplayLocaleChoice = true
-  },
-  methods: {
-    getLocaleFromCookie() {
-      const localeCookie = document.cookie
-        .split('; ')
-        .find((item) => item.startsWith('locale'))
-
-      if (!localeCookie) return null
-
-      try {
-        const chosenLocale = localeCookie.split('=')[1]
-
-        if (!chosenLocale) return null
-
-        const canonicalChosenLocale = Intl.getCanonicalLocales(chosenLocale)[0]
-        const canonicalCurrentLocales = localization.localesForCurrentSite.map(
-          ({ code }) => Intl.getCanonicalLocales(code)[0]
-        )
-
-        if (!canonicalCurrentLocales.includes(canonicalChosenLocale))
-          return null
-
-        return canonicalChosenLocale.toLowerCase()
-      } catch (error) {
-        return null
-      }
-    },
   },
 }
 </script>

--- a/pages/pix-site/index.vue
+++ b/pages/pix-site/index.vue
@@ -23,6 +23,7 @@
 
 <script>
 import { localization } from '~/config/localization'
+import { getLocaleFromCookie } from '~/services/get-locale-from-cookie'
 
 export default {
   layout: 'empty',
@@ -34,38 +35,11 @@ export default {
     }
   },
   mounted() {
-    const chosenLocale = this.getLocaleFromCookie()
+    const chosenLocale = getLocaleFromCookie()
     if (chosenLocale) {
       return this.$router.replace(`/${chosenLocale}/`)
     }
     this.shouldDisplayLocaleChoice = true
-  },
-  methods: {
-    getLocaleFromCookie() {
-      const localeCookie = document.cookie
-        .split('; ')
-        .find((item) => item.startsWith('locale'))
-
-      if (!localeCookie) return null
-
-      try {
-        const chosenLocale = localeCookie.split('=')[1]
-
-        if (!chosenLocale) return null
-
-        const canonicalChosenLocale = Intl.getCanonicalLocales(chosenLocale)[0]
-        const canonicalCurrentLocales = localization.localesForCurrentSite.map(
-          ({ code }) => Intl.getCanonicalLocales(code)[0]
-        )
-
-        if (!canonicalCurrentLocales.includes(canonicalChosenLocale))
-          return null
-
-        return canonicalChosenLocale.toLowerCase()
-      } catch (error) {
-        return null
-      }
-    },
   },
 }
 </script>

--- a/plugins/locale-observer.js
+++ b/plugins/locale-observer.js
@@ -8,7 +8,11 @@ export default function (context) {
 }
 
 function _setLocaleCookie(locale, isDev) {
-  const canonicalName = Intl.getCanonicalLocales(locale)?.[0]
+  let canonicalName = Intl.getCanonicalLocales(locale)?.[0]
+
+  if (canonicalName === 'en-GB') {
+    canonicalName = 'en'
+  }
 
   const localeCookieProperties = [
     `locale=${canonicalName}`,

--- a/services/get-locale-from-cookie.js
+++ b/services/get-locale-from-cookie.js
@@ -1,0 +1,31 @@
+import { localization } from '~/config/localization'
+
+export function getLocaleFromCookie() {
+  const localeCookie = document.cookie
+    .split('; ')
+    .find((item) => item.startsWith('locale'))
+
+  if (!localeCookie) return null
+
+  try {
+    const chosenLocale = localeCookie.split('=')[1]
+
+    if (!chosenLocale) return null
+
+    let canonicalChosenLocale = Intl.getCanonicalLocales(chosenLocale)[0]
+
+    if (canonicalChosenLocale === 'en') {
+      canonicalChosenLocale = 'en-GB'
+    }
+
+    const canonicalCurrentLocales = localization.localesForCurrentSite.map(
+      ({ code }) => Intl.getCanonicalLocales(code)[0]
+    )
+
+    if (!canonicalCurrentLocales.includes(canonicalChosenLocale)) return null
+
+    return canonicalChosenLocale.toLowerCase()
+  } catch (error) {
+    return null
+  }
+}

--- a/tests/pages/pix-pro/index.test.js
+++ b/tests/pages/pix-pro/index.test.js
@@ -1,6 +1,18 @@
 import { shallowMount } from '@vue/test-utils'
 import Index from '@/pages/pix-pro/index.vue'
 
+jest.mock('~/config/environment', () => {
+  return {
+    config: {
+      isPixSite: false,
+      domain: {
+        french: 'pix.fr',
+        international: 'pix.org',
+      },
+    },
+  }
+})
+
 describe('Index Page', () => {
   let $router
 
@@ -33,7 +45,7 @@ describe('Index Page', () => {
         // then
         expect($router.replace).not.toHaveBeenCalled()
         const localeLinks = wrapper.findAll('locale-link-stub')
-        expect(localeLinks.length).toBe(4)
+        expect(localeLinks.length).toBe(3)
       })
     })
 
@@ -92,97 +104,6 @@ describe('Index Page', () => {
           expect($router.replace).toHaveBeenCalledWith('/en-gb/')
           const localeLinks = wrapper.findAll('locale-link-stub')
           expect(localeLinks.length).toBe(0)
-        })
-      })
-    })
-  })
-
-  describe('#methods', () => {
-    describe('#getLocaleFromCookie', () => {
-      describe('when there is no cookie', () => {
-        test('returns no locale', () => {
-          // given
-          document.cookie = ''
-          const wrapper = shallowMount(Index, {
-            mocks: { $router },
-            stubs: ['client-only', 'pix-image', 'locale-link'],
-          })
-
-          // when
-          const chosenLocale = wrapper.vm.getLocaleFromCookie()
-
-          // then
-          expect(chosenLocale).toBe(null)
-        })
-      })
-
-      describe('when there is a locale cookie', () => {
-        describe('with value being only one subtag', () => {
-          test('returns the proper locale', () => {
-            // given
-            document.cookie = 'foo=bar; locale=fr'
-            const wrapper = shallowMount(Index, {
-              mocks: { $router },
-              stubs: ['client-only', 'pix-image', 'locale-link'],
-            })
-
-            // when
-            const chosenLocale = wrapper.vm.getLocaleFromCookie()
-
-            // then
-            expect(chosenLocale).toBe('fr')
-          })
-        })
-
-        describe('with value being in canonical BCP 47 format', () => {
-          test('returns the proper locale in lowercase', () => {
-            // given
-            document.cookie = 'foo=bar; locale=en-GB'
-            const wrapper = shallowMount(Index, {
-              mocks: { $router },
-              stubs: ['client-only', 'pix-image', 'locale-link'],
-            })
-
-            // when
-            const chosenLocale = wrapper.vm.getLocaleFromCookie()
-
-            // then
-            expect(chosenLocale).toBe('en-gb')
-          })
-        })
-
-        describe('in lowercase', () => {
-          test('returns the proper locale', () => {
-            // given
-            document.cookie = 'foo=bar; locale=en-gb'
-            const wrapper = shallowMount(Index, {
-              mocks: { $router },
-              stubs: ['client-only', 'pix-image', 'locale-link'],
-            })
-
-            // when
-            const chosenLocale = wrapper.vm.getLocaleFromCookie()
-
-            // then
-            expect(chosenLocale).toBe('en-gb')
-          })
-        })
-      })
-
-      describe('with a crafted cookie', () => {
-        test('cookie value is ignored', () => {
-          // given
-          document.cookie = 'foo=bar; locale=1234-crafted-cookie'
-          const wrapper = shallowMount(Index, {
-            mocks: { $router },
-            stubs: ['client-only', 'pix-image', 'locale-link'],
-          })
-
-          // when
-          const chosenLocale = wrapper.vm.getLocaleFromCookie()
-
-          // then
-          expect(chosenLocale).toBe(null)
         })
       })
     })

--- a/tests/pages/pix-site/index.test.js
+++ b/tests/pages/pix-site/index.test.js
@@ -1,6 +1,18 @@
 import { shallowMount } from '@vue/test-utils'
 import Index from '@/pages/pix-site/index.vue'
 
+jest.mock('~/config/environment', () => {
+  return {
+    config: {
+      isPixSite: true,
+      domain: {
+        french: 'pix.fr',
+        international: 'pix.org',
+      },
+    },
+  }
+})
+
 describe('Index Page', () => {
   let $router
 
@@ -92,97 +104,6 @@ describe('Index Page', () => {
           expect($router.replace).toHaveBeenCalledWith('/en-gb/')
           const localeLinks = wrapper.findAll('locale-link-stub')
           expect(localeLinks.length).toBe(0)
-        })
-      })
-    })
-  })
-
-  describe('#methods', () => {
-    describe('#getLocaleFromCookie', () => {
-      describe('when there is no cookie', () => {
-        test('returns no locale', () => {
-          // given
-          document.cookie = ''
-          const wrapper = shallowMount(Index, {
-            mocks: { $router },
-            stubs: ['client-only', 'pix-image', 'locale-link'],
-          })
-
-          // when
-          const chosenLocale = wrapper.vm.getLocaleFromCookie()
-
-          // then
-          expect(chosenLocale).toBe(null)
-        })
-      })
-
-      describe('when there is a locale cookie', () => {
-        describe('with value being only one subtag', () => {
-          test('returns the proper locale', () => {
-            // given
-            document.cookie = 'foo=bar; locale=fr'
-            const wrapper = shallowMount(Index, {
-              mocks: { $router },
-              stubs: ['client-only', 'pix-image', 'locale-link'],
-            })
-
-            // when
-            const chosenLocale = wrapper.vm.getLocaleFromCookie()
-
-            // then
-            expect(chosenLocale).toBe('fr')
-          })
-        })
-
-        describe('with value being in canonical BCP 47 format', () => {
-          test('returns the proper locale in lowercase', () => {
-            // given
-            document.cookie = 'foo=bar; locale=en-GB'
-            const wrapper = shallowMount(Index, {
-              mocks: { $router },
-              stubs: ['client-only', 'pix-image', 'locale-link'],
-            })
-
-            // when
-            const chosenLocale = wrapper.vm.getLocaleFromCookie()
-
-            // then
-            expect(chosenLocale).toBe('en-gb')
-          })
-        })
-
-        describe('in lowercase', () => {
-          test('returns the proper locale', () => {
-            // given
-            document.cookie = 'foo=bar; locale=en-gb'
-            const wrapper = shallowMount(Index, {
-              mocks: { $router },
-              stubs: ['client-only', 'pix-image', 'locale-link'],
-            })
-
-            // when
-            const chosenLocale = wrapper.vm.getLocaleFromCookie()
-
-            // then
-            expect(chosenLocale).toBe('en-gb')
-          })
-        })
-      })
-
-      describe('with a crafted cookie', () => {
-        test('cookie value is ignored', () => {
-          // given
-          document.cookie = 'foo=bar; locale=1234-crafted-cookie'
-          const wrapper = shallowMount(Index, {
-            mocks: { $router },
-            stubs: ['client-only', 'pix-image', 'locale-link'],
-          })
-
-          // when
-          const chosenLocale = wrapper.vm.getLocaleFromCookie()
-
-          // then
-          expect(chosenLocale).toBe(null)
         })
       })
     })

--- a/tests/plugins/locale-observer.test.js
+++ b/tests/plugins/locale-observer.test.js
@@ -16,66 +16,63 @@ describe('Plugins | locale-observer', () => {
     jest.spyOn(document, 'cookie', 'get').mockImplementation(() => cookieJar)
   })
 
-  describe('when user switch locale', () => {
-    describe('when not isDev', () => {
-      describe('when no cookie', () => {
-        it('saves locale cookie', () => {
-          // given
-          document.cookie = ''
-          const oldLocale = ''
-          const newLocale = 'en-gb'
-          const context = {
-            app: {
-              i18n: {},
-            },
-            route: {
-              path: '/',
-            },
-          }
+  describe('when in development mode', () => {
+    describe('when user choose a locale', () => {
+      it('saves locale in the cookie storage', () => {
+        // given
+        document.cookie = ''
+        const oldLocale = ''
+        const newLocale = 'fr-be'
+        const context = {
+          isDev: true,
+          app: {
+            i18n: {},
+          },
+          route: {
+            path: '/',
+          },
+        }
 
-          // when
-          localeObserver(context)
-          context.app.i18n.onBeforeLanguageSwitch(oldLocale, newLocale)
+        // when
+        localeObserver(context)
+        context.app.i18n.onBeforeLanguageSwitch(oldLocale, newLocale)
 
-          // then
-          expect(document.cookie).toEqual(
-            'locale=en-GB; path=/; max-age=31536000; SameSite=Strict; domain=pix.org'
-          )
-        })
-      })
-
-      describe('when cookie', () => {
-        it('saves locale cookie', () => {
-          // given
-          document.cookie =
-            'locale=en-gb; path=/; max-age=31536000; SameSite=Strict'
-          const oldLocale = 'en-gb'
-          const newLocale = 'fr'
-          const context = {
-            app: {
-              i18n: {},
-            },
-            route: {
-              path: '/',
-            },
-          }
-
-          // when
-          localeObserver(context)
-          context.app.i18n.onBeforeLanguageSwitch(oldLocale, newLocale)
-
-          // then
-          expect(document.cookie).toEqual(
-            'locale=fr; path=/; max-age=31536000; SameSite=Strict; domain=pix.org'
-          )
-        })
+        // then
+        expect(document.cookie).toEqual(
+          'locale=fr-BE; path=/; max-age=31536000; SameSite=Strict'
+        )
       })
     })
-  })
 
-  describe('when isDev', () => {
-    describe('when no cookie', () => {
+    describe('when user switch locale', () => {
       it('saves locale cookie', () => {
+        // given
+        document.cookie = 'locale=fr; path=/; max-age=31536000; SameSite=Strict'
+        const oldLocale = 'fr'
+        const newLocale = 'fr-be'
+        const context = {
+          isDev: true,
+          app: {
+            i18n: {},
+          },
+          route: {
+            path: '/',
+          },
+        }
+
+        // when
+        localeObserver(context)
+        context.app.i18n.onBeforeLanguageSwitch(oldLocale, newLocale)
+
+        // then
+        expect(document.cookie).toEqual(
+          'locale=fr-BE; path=/; max-age=31536000; SameSite=Strict'
+        )
+      })
+    })
+
+    describe('when user choose "en-gb" as locale', () => {
+      it('saves locale cookie with "en" value in the cookie storage', () => {
         // given
         document.cookie = ''
         const oldLocale = ''
@@ -96,20 +93,20 @@ describe('Plugins | locale-observer', () => {
 
         // then
         expect(document.cookie).toEqual(
-          'locale=en-GB; path=/; max-age=31536000; SameSite=Strict'
+          'locale=en; path=/; max-age=31536000; SameSite=Strict'
         )
       })
     })
+  })
 
-    describe('when cookie', () => {
-      it('saves locale cookie', () => {
+  describe('when in production mode', () => {
+    describe('when user choose a locale', () => {
+      it('saves locale in the cookie storage', () => {
         // given
-        document.cookie =
-          'locale=en-gb; path=/; max-age=31536000; SameSite=Strict'
-        const oldLocale = 'en-gb'
-        const newLocale = 'fr'
+        document.cookie = ''
+        const oldLocale = ''
+        const newLocale = 'fr-be'
         const context = {
-          isDev: true,
           app: {
             i18n: {},
           },
@@ -124,7 +121,59 @@ describe('Plugins | locale-observer', () => {
 
         // then
         expect(document.cookie).toEqual(
-          'locale=fr; path=/; max-age=31536000; SameSite=Strict'
+          'locale=fr-BE; path=/; max-age=31536000; SameSite=Strict; domain=pix.org'
+        )
+      })
+    })
+
+    describe('when user switch locale', () => {
+      it('saves locale cookie', () => {
+        // given
+        document.cookie = 'locale=fr; path=/; max-age=31536000; SameSite=Strict'
+        const oldLocale = 'fr'
+        const newLocale = 'fr-be'
+        const context = {
+          app: {
+            i18n: {},
+          },
+          route: {
+            path: '/',
+          },
+        }
+
+        // when
+        localeObserver(context)
+        context.app.i18n.onBeforeLanguageSwitch(oldLocale, newLocale)
+
+        // then
+        expect(document.cookie).toEqual(
+          'locale=fr-BE; path=/; max-age=31536000; SameSite=Strict; domain=pix.org'
+        )
+      })
+    })
+
+    describe('when user choose "en-gb" as locale', () => {
+      it('saves locale cookie with "en" value in the cookie storage', () => {
+        // given
+        document.cookie = ''
+        const oldLocale = ''
+        const newLocale = 'en-gb'
+        const context = {
+          app: {
+            i18n: {},
+          },
+          route: {
+            path: '/',
+          },
+        }
+
+        // when
+        localeObserver(context)
+        context.app.i18n.onBeforeLanguageSwitch(oldLocale, newLocale)
+
+        // then
+        expect(document.cookie).toEqual(
+          'locale=en; path=/; max-age=31536000; SameSite=Strict; domain=pix.org'
         )
       })
     })

--- a/tests/services/get-locale-from-cookie.test.js
+++ b/tests/services/get-locale-from-cookie.test.js
@@ -1,0 +1,101 @@
+const { getLocaleFromCookie } = require('~/services/get-locale-from-cookie')
+
+jest.mock('~/config/environment', () => {
+  return {
+    config: {
+      isPixSite: true,
+      domain: {
+        french: 'pix.fr',
+        international: 'pix.org',
+      },
+    },
+  }
+})
+
+describe('getLocaleFromCookie', () => {
+  beforeEach(() => {
+    let cookieJar = ''
+
+    jest.spyOn(document, 'cookie', 'set').mockImplementation((cookie) => {
+      cookieJar = cookie
+    })
+    jest.spyOn(document, 'cookie', 'get').mockImplementation(() => cookieJar)
+  })
+  describe('when there is no cookie', () => {
+    test('returns no locale', () => {
+      // given
+      document.cookie = ''
+      // when
+      const chosenLocale = getLocaleFromCookie()
+
+      // then
+      expect(chosenLocale).toBe(null)
+    })
+  })
+
+  describe('when there is a locale cookie', () => {
+    describe('with value being only one subtag', () => {
+      test('returns the proper locale', () => {
+        // given
+        document.cookie = 'foo=bar; locale=fr'
+
+        // when
+        const chosenLocale = getLocaleFromCookie()
+
+        // then
+        expect(chosenLocale).toBe('fr')
+      })
+    })
+
+    describe('with value equal to "en"', () => {
+      test('returns "en-gb"', () => {
+        // given
+        document.cookie = `foo=bar; locale=en`
+
+        // when
+        const chosenLocale = getLocaleFromCookie()
+
+        // then
+        expect(chosenLocale).toBe('en-gb')
+      })
+    })
+
+    describe('with value being in canonical BCP 47 format', () => {
+      test('returns the proper locale in lowercase', () => {
+        // given
+        document.cookie = 'foo=bar; locale=fr-BE'
+
+        // when
+        const chosenLocale = getLocaleFromCookie()
+
+        // then
+        expect(chosenLocale).toBe('fr-be')
+      })
+    })
+
+    describe('in lowercase', () => {
+      test('returns the proper locale', () => {
+        // given
+        document.cookie = 'foo=bar; locale=fr-be'
+        // when
+        const chosenLocale = getLocaleFromCookie()
+
+        // then
+        expect(chosenLocale).toBe('fr-be')
+      })
+    })
+  })
+
+  describe('with a crafted cookie', () => {
+    test('cookie value is ignored', () => {
+      // given
+      document.cookie = 'foo=bar; locale=1234-crafted-cookie'
+
+      // when
+      const chosenLocale = getLocaleFromCookie()
+
+      // then
+      expect(chosenLocale).toBe(null)
+    })
+  })
+})


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, la locale « international english » est gérée sur le site vitrine avec le code `en-gb`. Or ce code représente l’anglais britannique et non l’anglais international. 

## :robot: Proposition
Stocker, dans le cookie `locale`,  la valeur `en` au lieu de `en-gb`. Une rétrocompatibilité doit aussi être mise en place pour les utilisateurs ayant déjà un cookie `locale` avec une valeur `en-GB` ou `en-gb`.  

Ce travail et cette solution s'inscrive toujours dans le cadre de l’[ADR _Logique et stratégie de gestion des paramètres régionaux et des langues (locales & languages)_](https://github.com/1024pix/pix/blob/dev/docs/adr/0040-locales-languages.md).

Enfin, le remplacement de la locale `en-gb` vers `en` sur tout le reste des sites vitrines (URL des contenus, fichiers de traduction, etc.) se fera dans un second temps.

## :rainbow: Remarques
La méthode `getLocaleFromCookie` a été factorisée et mise à disposition dans un service dédié.

## :100: Pour tester
### Test sur Pix Site (.org)
#### Stockage cookie avec la valeur `en`
- Dans le cas où vous aviez déjà un cookie locale sur le domaine .org, le supprimer dans le navigateur.
- Aller sur la review-app https://site-pr522.review.pix.org/
- Sélectionner la locale « International English »
- Vérifier que la redirection se fait bien vers un URL ayant `/en-gb` comme préfixe
- Vérifier dans les cookies côté console navigateur que le cookie `locale` a bien une valeur `en`

#### Rétrocompatibilité
- Toujours sur la review app, modifier la valeur du cookie locale en `en-GB`.
- Saisir dans la barre d'url https://site-pr522.review.pix.org/
- Vérifier que la redirection se fait bien sur https://site-pr522.review.pix.org/en-gb

### Test sur Pix Pro (.org)
- Même procédure que pour le test sur Pix Site mais avec la review-app Pix Pro : https://pro-pr522.review.pix.org/ 😄 

