### PR TITLE
[FEATURE] Ne pas afficher le bandeau "vous semblez ne pas être en France" dans les DOM-TOMs (PIX-7713)

### DIFF
--- a/services/should-show-out-of-france-banner.js
+++ b/services/should-show-out-of-france-banner.js
@@ -1,14 +1,20 @@
 import { config } from '~/config/environment'
 
 export async function shouldShowOutOfFranceBanner(baseUrl) {
-  const FR_COUNTRY_CODE = 'FR'
-  const url = new URL('/geolocate', baseUrl)
-
   if (!config.isFrenchDomain || !config.isPixSite) return false
 
+  const country = await _getUserCountryFromGeolocationService(baseUrl)
+  if (!country) return false
+
+  const FR_COUNTRY_CODE = 'FR'
+  return country !== FR_COUNTRY_CODE
+}
+
+async function _getUserCountryFromGeolocationService(baseUrl) {
+  const url = new URL('/geolocate', baseUrl)
+
   const response = await fetch(url).then((res) => res.json())
+  if (!response) return undefined
 
-  if (!response?.country) return false
-
-  return response.country !== FR_COUNTRY_CODE
+  return response.country
 }

--- a/services/should-show-out-of-france-banner.js
+++ b/services/should-show-out-of-france-banner.js
@@ -1,6 +1,6 @@
 import { config } from '~/config/environment'
 
-const FR_COUNTRY_CODE = 'FR'
+const FRANCE_COUNTRY_CODE = 'FR'
 const DOM_TOM_COUNTRY_CODES = [
   'GA',
   'GF',
@@ -16,7 +16,7 @@ const DOM_TOM_COUNTRY_CODES = [
   'WF',
 ]
 const COUNTRIES_WHERE_BANNER_SHOULD_NOT_BE_SHOWN = [
-  FR_COUNTRY_CODE,
+  FRANCE_COUNTRY_CODE,
   ...DOM_TOM_COUNTRY_CODES,
 ]
 

--- a/services/should-show-out-of-france-banner.js
+++ b/services/should-show-out-of-france-banner.js
@@ -1,13 +1,32 @@
 import { config } from '~/config/environment'
 
+const FR_COUNTRY_CODE = 'FR'
+const DOM_TOM_COUNTRY_CODES = [
+  'GA',
+  'GF',
+  'MQ',
+  'RE',
+  'YT',
+  'NC',
+  'PF',
+  'BL',
+  'MF',
+  'PM',
+  'TF',
+  'WF',
+]
+const COUNTRIES_WHERE_BANNER_SHOULD_NOT_BE_SHOWN = [
+  FR_COUNTRY_CODE,
+  ...DOM_TOM_COUNTRY_CODES,
+]
+
 export async function shouldShowOutOfFranceBanner(baseUrl) {
   if (!config.isFrenchDomain || !config.isPixSite) return false
 
   const country = await _getUserCountryFromGeolocationService(baseUrl)
   if (!country) return false
 
-  const FR_COUNTRY_CODE = 'FR'
-  return country !== FR_COUNTRY_CODE
+  return _shouldShowBannerForCountry(country)
 }
 
 async function _getUserCountryFromGeolocationService(baseUrl) {
@@ -17,4 +36,8 @@ async function _getUserCountryFromGeolocationService(baseUrl) {
   if (!response) return undefined
 
   return response.country
+}
+
+function _shouldShowBannerForCountry(country) {
+  return !COUNTRIES_WHERE_BANNER_SHOULD_NOT_BE_SHOWN.includes(country)
 }

--- a/tests/services/should-show-out-of-france-banner.test.js
+++ b/tests/services/should-show-out-of-france-banner.test.js
@@ -78,6 +78,22 @@ describe('shouldShowOutOfFranceBanner', () => {
     })
   })
 
+  describe("When user's location is in a DOM-TOM", () => {
+    it('returns false', async () => {
+      // given
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(fetchResponse({ country: 'GA' }))
+
+      // when
+      const result = await shouldShowOutOfFranceBanner(baseUrl)
+
+      // then
+      expect(global.fetch).toHaveBeenCalled()
+      expect(result).toBe(false)
+    })
+  })
+
   describe("When user's location is not provided", () => {
     it('returns false', async () => {
       // given


### PR DESCRIPTION
## :unicorn: Problème

La bannière "vous semblez ne pas être en France" est affichée pour les utilisateurs situés dans les DOM-TOM.

## :robot: Proposition

Ajouter les codes pays dans les DOM-TOM en plus de celui de la France dans les exceptions à l'affichage de la bannière.

Pays | Code
-- | --
la Guadeloupe | GA
la Guyane | GF
la Martinique | MQ
la Réunion | RE
Mayotte | YT
la Nouvelle-Calédonie | NC
la Polynésie française | PF
Saint-Barthélemy | BL
Saint-Martin | MF
Saint-Pierre-et-Miquelon | PM
les Terres australes et antarctiques françaises | TF
les îles de Wallis-et-Futuna | WF

## :rainbow: Remarques

*RAS*

## :100: Pour tester

- Accéder à https://pix.fr/ en utilisant un VPN pour se géolocaliser dans un DOM-TOM 
	- constater que la bannière **est affichée**.
- Accéder à https://site-pr525.review.pix.fr/ en utilisant un VPN pour se géolocaliser dans un DOM-TOM
	- constater que la bannière **n'est pas affichée**.
