### PR TITLE
[TECH] Remplacer la locale "en-gb" en "en" (PIX-7514)

### DIFF
--- a/components/LocaleLink.vue
+++ b/components/LocaleLink.vue
@@ -66,7 +66,7 @@ export default {
 }
 
 [href$='/fr'],
-[href$='/en-gb'] {
+[href$='/en'] {
   .locale-link__icon {
     filter: brightness(50%);
   }

--- a/config/localization/pix-pro.js
+++ b/config/localization/pix-pro.js
@@ -9,8 +9,8 @@ export const availableLocales = [
     icon: 'globe-europe.svg',
   },
   {
-    code: 'en-gb',
-    file: 'en-gb.js',
+    code: 'en',
+    file: 'en.js',
     domain: config.domain.international,
     name: 'International English',
     icon: 'globe-europe.svg',
@@ -36,7 +36,7 @@ export const localization = {
         },
         {
           name: 'english',
-          localeCode: 'en-gb',
+          localeCode: 'en',
           icon: 'globe-europe.svg',
         },
       ],

--- a/config/localization/pix-site.js
+++ b/config/localization/pix-site.js
@@ -9,8 +9,8 @@ export const availableLocales = [
     icon: 'globe-europe.svg',
   },
   {
-    code: 'en-gb',
-    file: 'en-gb.js',
+    code: 'en',
+    file: 'en.js',
     domain: config.domain.international,
     name: 'International English',
     icon: 'globe-europe.svg',
@@ -44,7 +44,7 @@ export const localization = {
         },
         {
           name: 'english',
-          localeCode: 'en-gb',
+          localeCode: 'en',
           icon: 'globe-europe.svg',
         },
       ],

--- a/config/localization/translations/en.js
+++ b/config/localization/translations/en.js
@@ -1,7 +1,7 @@
 export default {
   fr: 'International FR',
   'fr-fr': 'France',
-  'en-gb': 'International EN',
+  en: 'International EN',
   'fr-be': 'Fédération Wallonie-Bruxelles',
   france: 'France',
   english: 'English',
@@ -57,11 +57,11 @@ export default {
     'pix-orga-registration': 'Request for information | Pix pro',
   },
   'preview-page-load': 'Preview page loading...',
-  'home-page-url': `https://${process.env.DOMAIN_ORG}/en-gb/`,
+  'home-page-url': `https://${process.env.DOMAIN_ORG}/en/`,
   'error-content':
     '<p>Oops! A problem has occurred, but do not panic!</p>' +
     '<p>You can go back to the ' +
-    `<a href="https://${process.env.DOMAIN_ORG}/en-gb/">homepage</a>.` +
+    `<a href="https://${process.env.DOMAIN_ORG}/en/">homepage</a>.` +
     '<br/>If you need help, you can check out the ' +
     '<a href="https://support.pix.org/en/support/home">support</a>.' +
     '</p>',

--- a/config/localization/translations/fr-be.js
+++ b/config/localization/translations/fr-be.js
@@ -1,7 +1,7 @@
 export default {
   fr: 'International FR',
   'fr-fr': 'France',
-  'en-gb': 'International EN',
+  en: 'International EN',
   'fr-be': 'Fédération Wallonie-Bruxelles',
   france: 'France',
   english: 'English',

--- a/config/localization/translations/fr-fr.js
+++ b/config/localization/translations/fr-fr.js
@@ -1,7 +1,7 @@
 export default {
   fr: 'International FR',
   'fr-fr': 'France',
-  'en-gb': 'International EN',
+  en: 'International EN',
   'fr-be': 'Fédération Wallonie-Bruxelles',
   france: 'France',
   english: 'English',

--- a/config/localization/translations/fr.js
+++ b/config/localization/translations/fr.js
@@ -1,7 +1,7 @@
 export default {
   fr: 'International FR',
   'fr-fr': 'France',
-  'en-gb': 'International EN',
+  en: 'International EN',
   'fr-be': 'Fédération Wallonie-Bruxelles',
   france: 'France',
   english: 'English',

--- a/config/localization/translations/index.js
+++ b/config/localization/translations/index.js
@@ -1,6 +1,6 @@
 import fr from './fr'
 import frFr from './fr-fr'
 import frBe from './fr-be'
-import enGb from './en-gb'
+import en from './en'
 
-export const translations = { fr, 'fr-fr': frFr, 'fr-be': frBe, 'en-gb': enGb }
+export const translations = { fr, 'fr-fr': frFr, 'fr-be': frBe, en }

--- a/pages/pix-pro/_custom-page.vue
+++ b/pages/pix-pro/_custom-page.vue
@@ -19,9 +19,9 @@ export default {
   name: 'CustomPage',
   nuxtI18n: {
     paths: {
+      en: '/:uid',
       fr: '/:uid',
       'fr-fr': '/:uid',
-      'en-gb': '/:uid',
     },
   },
   async asyncData({ params, app, req, error, currentPagePath }) {

--- a/pages/pix-pro/locale-home.vue
+++ b/pages/pix-pro/locale-home.vue
@@ -15,6 +15,15 @@
 <script>
 import { documentFetcher, DOCUMENTS } from '~/services/document-fetcher'
 
+const EN_HOME_DOCUMENT_UID = 'discover-pix-pro'
+const FR_HOME_DOCUMENT_UID = 'decouvrir-pix-pro'
+
+const HOME_DOCUMENT_UID_BY_LOCALE = {
+  en: EN_HOME_DOCUMENT_UID,
+  fr: FR_HOME_DOCUMENT_UID,
+  'fr-fr': FR_HOME_DOCUMENT_UID,
+}
+
 export default {
   name: 'LocaleHome',
   nuxtI18n: {
@@ -26,11 +35,14 @@ export default {
   },
   async asyncData({ app, req, error, currentPagePath }) {
     try {
+      const locale = app.i18n.locale || app.i18n.defaultLocale
+      const homeDocumentUid = HOME_DOCUMENT_UID_BY_LOCALE[locale]
+
       const document = await documentFetcher(
         app.$prismic,
         app.i18n,
         req
-      ).getPageByUid('decouvrir-pix-pro')
+      ).getPageByUid(homeDocumentUid)
       const meta = document.data.meta
 
       return { currentPagePath, meta, document }

--- a/pages/pix-pro/locale-home.vue
+++ b/pages/pix-pro/locale-home.vue
@@ -15,13 +15,13 @@
 <script>
 import { documentFetcher, DOCUMENTS } from '~/services/document-fetcher'
 
-const EN_HOME_DOCUMENT_UID = 'discover-pix-pro'
-const FR_HOME_DOCUMENT_UID = 'decouvrir-pix-pro'
+const HOME_DOCUMENT_UID_EN = 'discover-pix-pro'
+const HOME_DOCUMENT_UID_FR = 'decouvrir-pix-pro'
 
 const HOME_DOCUMENT_UID_BY_LOCALE = {
-  en: EN_HOME_DOCUMENT_UID,
-  fr: FR_HOME_DOCUMENT_UID,
-  'fr-fr': FR_HOME_DOCUMENT_UID,
+  en: HOME_DOCUMENT_UID_EN,
+  fr: HOME_DOCUMENT_UID_FR,
+  'fr-fr': HOME_DOCUMENT_UID_FR,
 }
 
 export default {

--- a/pages/pix-pro/locale-home.vue
+++ b/pages/pix-pro/locale-home.vue
@@ -19,9 +19,9 @@ export default {
   name: 'LocaleHome',
   nuxtI18n: {
     paths: {
+      en: '/',
       fr: '/',
       'fr-fr': '/',
-      'en-gb': '/',
     },
   },
   async asyncData({ app, req, error, currentPagePath }) {

--- a/pages/pix-site/_custom-page.vue
+++ b/pages/pix-site/_custom-page.vue
@@ -19,9 +19,9 @@ export default {
   name: 'CustomPage',
   nuxtI18n: {
     paths: {
+      en: '/:uid',
       fr: '/:uid',
       'fr-fr': '/:uid',
-      'en-gb': '/:uid',
       'fr-be': '/:uid',
     },
   },

--- a/pages/pix-site/locale-home.vue
+++ b/pages/pix-site/locale-home.vue
@@ -11,9 +11,9 @@ export default {
   name: 'LocaleHome',
   nuxtI18n: {
     paths: {
+      en: '/',
       fr: '/',
       'fr-fr': '/',
-      'en-gb': '/',
       'fr-be': '/',
     },
   },

--- a/pages/pix-site/news/_slug.vue
+++ b/pages/pix-site/news/_slug.vue
@@ -15,10 +15,10 @@ import { documentFetcher } from '~/services/document-fetcher'
 export default {
   nuxtI18n: {
     paths: {
+      en: '/news/:slug',
       fr: '/actualites/:slug',
       'fr-fr': '/actualites/:slug',
       'fr-be': '/actualites/:slug',
-      'en-gb': '/news/:slug',
     },
   },
   async asyncData({ params, app, req, error, route, currentPagePath }) {

--- a/pages/pix-site/news/index.vue
+++ b/pages/pix-site/news/index.vue
@@ -35,10 +35,10 @@ export default {
   name: 'Index',
   nuxtI18n: {
     paths: {
+      en: '/news',
       fr: '/actualites',
       'fr-fr': '/actualites',
       'fr-be': '/actualites',
-      'en-gb': '/news',
     },
   },
   async asyncData({ app, error, req }) {

--- a/plugins/locale-observer.js
+++ b/plugins/locale-observer.js
@@ -8,11 +8,7 @@ export default function (context) {
 }
 
 function _setLocaleCookie(locale, isDev) {
-  let canonicalName = Intl.getCanonicalLocales(locale)?.[0]
-
-  if (canonicalName === 'en-GB') {
-    canonicalName = 'en'
-  }
+  const canonicalName = Intl.getCanonicalLocales(locale)?.[0]
 
   const localeCookieProperties = [
     `locale=${canonicalName}`,

--- a/plugins/locale-observer.js
+++ b/plugins/locale-observer.js
@@ -1,13 +1,27 @@
-import { setCookie } from '~/services/cookie'
+import { getCookie, setCookie } from '~/services/cookie'
 
 export default function (context) {
   const { app, isDev } = context
   app.i18n.onBeforeLanguageSwitch = (oldLocale, newLocale) => {
     _setLocaleCookie(newLocale, isDev)
   }
+
+  _handleLocaleCookie(isDev)
 }
 
 function _setLocaleCookie(locale, isDev) {
   const canonicalName = Intl.getCanonicalLocales(locale)?.[0]
   setCookie('locale', canonicalName, isDev)
+}
+
+function _handleLocaleCookie(isDev) {
+  const localeCookie = getCookie('locale')
+
+  if (!localeCookie) return
+
+  try {
+    if (Intl.getCanonicalLocales(localeCookie)[0] === 'en-GB') {
+      setCookie('locale', 'en', isDev)
+    }
+  } catch (error) {}
 }

--- a/plugins/locale-observer.js
+++ b/plugins/locale-observer.js
@@ -1,4 +1,4 @@
-import { config } from '../config/environment'
+import { setCookie } from '~/services/cookie'
 
 export default function (context) {
   const { app, isDev } = context
@@ -9,16 +9,5 @@ export default function (context) {
 
 function _setLocaleCookie(locale, isDev) {
   const canonicalName = Intl.getCanonicalLocales(locale)?.[0]
-
-  const localeCookieProperties = [
-    `locale=${canonicalName}`,
-    'path=/',
-    'max-age=31536000',
-    'SameSite=Strict',
-  ]
-  if (!isDev) {
-    localeCookieProperties.push(`domain=${config.siteDomain}`)
-  }
-
-  document.cookie = localeCookieProperties.join('; ')
+  setCookie('locale', canonicalName, isDev)
 }

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -65,6 +65,7 @@ server {
   # Serve from dist/pix.fr or dist/pix.org depending on the extension
   root /app/dist/pix.$extension;
 
+  rewrite ^/en-gb(.*)$ /en$1 permanent;
   rewrite ^/(aide|help)$ https://support.pix.org redirect;
   rewrite ^/employeurs$ https://pro.pix.fr redirect;
 

--- a/services/cookie.js
+++ b/services/cookie.js
@@ -1,0 +1,28 @@
+import { config } from '~/config/environment'
+
+function getCookie(name) {
+  const cookie = document.cookie
+    .split('; ')
+    .find((item) => item.startsWith(name))
+
+  if (!cookie) return null
+
+  return cookie.split('=')[1]
+}
+
+function setCookie(name, value, isDev) {
+  const cookieProperties = [
+    `${name}=${value}`,
+    'path=/',
+    'max-age=31536000',
+    'SameSite=Strict',
+  ]
+
+  if (!isDev) {
+    cookieProperties.push(`domain=${config.siteDomain}`)
+  }
+
+  document.cookie = cookieProperties.join('; ')
+}
+
+export { getCookie, setCookie }

--- a/services/get-locale-from-cookie.js
+++ b/services/get-locale-from-cookie.js
@@ -1,14 +1,9 @@
+import { getCookie } from '~/services/cookie'
 import { localization } from '~/config/localization'
 
 export function getLocaleFromCookie() {
-  const localeCookie = document.cookie
-    .split('; ')
-    .find((item) => item.startsWith('locale'))
-
-  if (!localeCookie) return null
-
   try {
-    const chosenLocale = localeCookie.split('=')[1]
+    const chosenLocale = getCookie('locale')
 
     if (!chosenLocale) return null
 

--- a/services/get-locale-from-cookie.js
+++ b/services/get-locale-from-cookie.js
@@ -14,8 +14,8 @@ export function getLocaleFromCookie() {
 
     let canonicalChosenLocale = Intl.getCanonicalLocales(chosenLocale)[0]
 
-    if (canonicalChosenLocale === 'en') {
-      canonicalChosenLocale = 'en-GB'
+    if (canonicalChosenLocale === 'en-GB') {
+      canonicalChosenLocale = 'en'
     }
 
     const canonicalCurrentLocales = localization.localesForCurrentSite.map(

--- a/tests.sh
+++ b/tests.sh
@@ -24,6 +24,7 @@ function checkRedirect() {
   fi
 }
 
+checkRedirect pix.fr /en-gb "" "" 301 https://pix.fr/en/
 checkRedirect pix.fr / "" "" 200
 checkRedirect pix.fr /competences "" "" 301 http://pix.fr/competences/
 checkRedirect pix.org /_nuxt/LICENSES "" "" 200

--- a/tests/components/PixPrismicLink.test.js
+++ b/tests/components/PixPrismicLink.test.js
@@ -38,8 +38,8 @@ describe('Component: PixPrismicLink', () => {
           'https://pix.org/fr/une-page-si-t-es-pas-en-france',
           'https://pix.org/fr-be',
           'https://pix.org/fr-be/une-fois',
-          'https://pix.org/en-gb',
-          'https://pix.org/en-gb/tea-time',
+          'https://pix.org/en',
+          'https://pix.org/en/tea-time',
           'https://google.com/',
         ]
 
@@ -65,7 +65,7 @@ describe('Component: PixPrismicLink', () => {
             '/fr/la/totale?foo=bar#la-precision',
           ],
           ['https://pix.org/fr-be/une-fois', '/fr-be/une-fois'],
-          ['https://pix.org/en-gb/tea-time', '/en-gb/tea-time'],
+          ['https://pix.org/en/tea-time', '/en/tea-time'],
         ]
 
         for (const [url, expected] of urls) {
@@ -113,7 +113,7 @@ describe('Component: PixPrismicLink', () => {
           'https://pix.org/fr',
           'https://pix.org/fr/pourquoi',
           'https://pix.org/fr-be/une-fois',
-          'https://pix.org/en-gb/tea-time',
+          'https://pix.org/en/tea-time',
           'https://google.com/',
         ]
 
@@ -148,7 +148,7 @@ describe('Component: PixPrismicLink', () => {
           'https://pix.org/fr',
           'https://pix.org/fr/pourquoi',
           'https://pix.org/fr-be/une-fois',
-          'https://pix.org/en-gb/tea-time',
+          'https://pix.org/en/tea-time',
           'https://google.com/',
         ]
 
@@ -164,7 +164,7 @@ describe('Component: PixPrismicLink', () => {
 
     beforeEach(() => {
       $i18n = {
-        localeCodes: ['fr-fr', 'fr', 'fr-be', 'en-gb'],
+        localeCodes: ['fr-fr', 'fr', 'fr-be', 'en'],
         defaultLocale: 'fr-fr',
       }
     })
@@ -173,13 +173,13 @@ describe('Component: PixPrismicLink', () => {
       const paths = [
         ['/fr', 'fr'],
         ['/fr-be', 'fr-be'],
-        ['/en-gb', 'en-gb'],
+        ['/en', 'en'],
         ['/fr/path', 'fr'],
         ['/fr-be/path', 'fr-be'],
-        ['/en-gb/path', 'en-gb'],
+        ['/en/path', 'en'],
         ['/fr/path/subpath', 'fr'],
         ['/fr-be/path/subpath', 'fr-be'],
-        ['/en-gb/path/subpath', 'en-gb'],
+        ['/en/path/subpath', 'en'],
       ]
 
       for (const [path, expectedLocale] of paths) {
@@ -240,9 +240,9 @@ describe('Component: PixPrismicLink', () => {
             '/path/subpath',
             '/fr-ca/tabernacle',
             '/fr',
-            '/en-gb',
+            '/en',
             '/fr/une-page',
-            '/en-gb/path/subpath',
+            '/en/path/subpath',
           ]
 
           for (const url of urls) {
@@ -255,7 +255,7 @@ describe('Component: PixPrismicLink', () => {
     describe('pix.org', () => {
       beforeEach(() => {
         $i18n = {
-          localeCodes: ['fr', 'fr-be', 'en-gb'],
+          localeCodes: ['fr', 'fr-be', 'en'],
           defaultLocale: 'fr',
         }
       })
@@ -292,12 +292,7 @@ describe('Component: PixPrismicLink', () => {
         })
 
         it('should return false if the given URL is outside of fr', () => {
-          const urls = [
-            '/fr-be',
-            '/en-gb',
-            '/fr-be/une-page',
-            '/en-gb/path/subpath',
-          ]
+          const urls = ['/fr-be', '/en', '/fr-be/une-page', '/en/path/subpath']
 
           for (const url of urls) {
             expect(isCurrentLocaleURL(url, $i18n)).toBe(false)
@@ -324,9 +319,9 @@ describe('Component: PixPrismicLink', () => {
             '/une-page',
             '/path/subpath',
             '/fr',
-            '/en-gb',
+            '/en',
             '/fr/une-page',
-            '/en-gb/path/subpath',
+            '/en/path/subpath',
           ]
 
           for (const url of urls) {

--- a/tests/components/__snapshots__/LocaleSwitcher.test.js.snap
+++ b/tests/components/__snapshots__/LocaleSwitcher.test.js.snap
@@ -74,7 +74,7 @@ exports[`Component: LocaleSwitcher when site is pix-pro should render the locale
               class="locale-switcher__locale"
             >
               <a
-                href="http://example.org/en-gb"
+                href="http://example.org/en"
               >
                 
         
@@ -217,7 +217,7 @@ exports[`Component: LocaleSwitcher when site is pix-site should render the local
               class="locale-switcher__locale"
             >
               <a
-                href="http://example.org/en-gb"
+                href="http://example.org/en"
               >
                 
         

--- a/tests/config/localization/pix-pro.test.js
+++ b/tests/config/localization/pix-pro.test.js
@@ -39,8 +39,8 @@ describe('#getLocalesForCurrentSite', () => {
         file: 'fr.js',
       },
       {
-        code: 'en-gb',
-        file: 'en-gb.js',
+        code: 'en',
+        file: 'en.js',
       },
     ]
 

--- a/tests/config/localization/pix-pro.test.js
+++ b/tests/config/localization/pix-pro.test.js
@@ -67,7 +67,7 @@ describe('#localization', () => {
           },
           {
             name: 'english',
-            localeCode: 'en-gb',
+            localeCode: 'en',
             icon: 'globe-europe.svg',
           },
         ],

--- a/tests/config/localization/pix-site.test.js
+++ b/tests/config/localization/pix-site.test.js
@@ -34,8 +34,8 @@ describe('#getLocalesForCurrentSite', () => {
         file: 'fr.js',
       },
       {
-        code: 'en-gb',
-        file: 'en-gb.js',
+        code: 'en',
+        file: 'en.js',
       },
       {
         code: 'fr-be',

--- a/tests/config/localization/pix-site.test.js
+++ b/tests/config/localization/pix-site.test.js
@@ -66,7 +66,7 @@ describe('#localization', () => {
           },
           {
             name: 'english',
-            localeCode: 'en-gb',
+            localeCode: 'en',
             icon: 'globe-europe.svg',
           },
         ],

--- a/tests/pages/pix-pro/index.test.js
+++ b/tests/pages/pix-pro/index.test.js
@@ -4,11 +4,12 @@ import Index from '@/pages/pix-pro/index.vue'
 jest.mock('~/config/environment', () => {
   return {
     config: {
-      isPixSite: false,
       domain: {
         french: 'pix.fr',
         international: 'pix.org',
       },
+      isPixSite: false,
+      siteDomain: 'pix.fr',
     },
   }
 })
@@ -69,29 +70,10 @@ describe('Index Page', () => {
         })
       })
 
-      describe('with value being in canonical BCP 47 format', () => {
-        test('redirects to correct locale page', async () => {
-          // given
-          document.cookie = 'foo=bar; locale=en-GB'
-
-          // when
-          const wrapper = shallowMount(Index, {
-            mocks: { $router },
-            stubs: ['client-only', 'pix-image', 'locale-link'],
-          })
-          await wrapper.vm.$nextTick()
-
-          // then
-          expect($router.replace).toHaveBeenCalledWith('/en-gb/')
-          const localeLinks = wrapper.findAll('locale-link-stub')
-          expect(localeLinks.length).toBe(0)
-        })
-      })
-
       describe('in lowercase', () => {
         test('redirects to correct locale page', async () => {
           // given
-          document.cookie = 'foo=bar; locale=en-gb'
+          document.cookie = 'foo=bar; locale=FR'
 
           // when
           const wrapper = shallowMount(Index, {
@@ -101,7 +83,7 @@ describe('Index Page', () => {
           await wrapper.vm.$nextTick()
 
           // then
-          expect($router.replace).toHaveBeenCalledWith('/en-gb/')
+          expect($router.replace).toHaveBeenCalledWith('/fr/')
           const localeLinks = wrapper.findAll('locale-link-stub')
           expect(localeLinks.length).toBe(0)
         })

--- a/tests/pages/pix-site/index.test.js
+++ b/tests/pages/pix-site/index.test.js
@@ -4,11 +4,12 @@ import Index from '@/pages/pix-site/index.vue'
 jest.mock('~/config/environment', () => {
   return {
     config: {
-      isPixSite: true,
       domain: {
         french: 'pix.fr',
         international: 'pix.org',
       },
+      isPixSite: true,
+      siteDomain: 'pix.fr',
     },
   }
 })
@@ -72,7 +73,7 @@ describe('Index Page', () => {
       describe('with value being in canonical BCP 47 format', () => {
         test('redirects to correct locale page', async () => {
           // given
-          document.cookie = 'foo=bar; locale=en-GB'
+          document.cookie = 'foo=bar; locale=fr-BE'
 
           // when
           const wrapper = shallowMount(Index, {
@@ -82,7 +83,7 @@ describe('Index Page', () => {
           await wrapper.vm.$nextTick()
 
           // then
-          expect($router.replace).toHaveBeenCalledWith('/en-gb/')
+          expect($router.replace).toHaveBeenCalledWith('/fr-be/')
           const localeLinks = wrapper.findAll('locale-link-stub')
           expect(localeLinks.length).toBe(0)
         })
@@ -91,7 +92,7 @@ describe('Index Page', () => {
       describe('in lowercase', () => {
         test('redirects to correct locale page', async () => {
           // given
-          document.cookie = 'foo=bar; locale=en-gb'
+          document.cookie = 'foo=bar; locale=fr-be'
 
           // when
           const wrapper = shallowMount(Index, {
@@ -101,7 +102,7 @@ describe('Index Page', () => {
           await wrapper.vm.$nextTick()
 
           // then
-          expect($router.replace).toHaveBeenCalledWith('/en-gb/')
+          expect($router.replace).toHaveBeenCalledWith('/fr-be/')
           const localeLinks = wrapper.findAll('locale-link-stub')
           expect(localeLinks.length).toBe(0)
         })

--- a/tests/plugins/locale-observer.test.js
+++ b/tests/plugins/locale-observer.test.js
@@ -70,6 +70,31 @@ describe('Plugins | locale-observer', () => {
         )
       })
     })
+
+    describe('when user already has an "en-GB" locale cookie value', () => {
+      it('updates locale cookie value with "en"', () => {
+        // given
+        document.cookie =
+          'locale=en-GB; path=/; max-age=31536000; SameSite=Strict'
+        const context = {
+          isDev: true,
+          app: {
+            i18n: {},
+          },
+          route: {
+            path: '/',
+          },
+        }
+
+        // when
+        localeObserver(context)
+
+        // then
+        expect(document.cookie).toEqual(
+          'locale=en; path=/; max-age=31536000; SameSite=Strict'
+        )
+      })
+    })
   })
 
   describe('when in production mode', () => {

--- a/tests/plugins/locale-observer.test.js
+++ b/tests/plugins/locale-observer.test.js
@@ -70,33 +70,6 @@ describe('Plugins | locale-observer', () => {
         )
       })
     })
-
-    describe('when user choose "en-gb" as locale', () => {
-      it('saves locale cookie with "en" value in the cookie storage', () => {
-        // given
-        document.cookie = ''
-        const oldLocale = ''
-        const newLocale = 'en-gb'
-        const context = {
-          isDev: true,
-          app: {
-            i18n: {},
-          },
-          route: {
-            path: '/',
-          },
-        }
-
-        // when
-        localeObserver(context)
-        context.app.i18n.onBeforeLanguageSwitch(oldLocale, newLocale)
-
-        // then
-        expect(document.cookie).toEqual(
-          'locale=en; path=/; max-age=31536000; SameSite=Strict'
-        )
-      })
-    })
   })
 
   describe('when in production mode', () => {
@@ -148,32 +121,6 @@ describe('Plugins | locale-observer', () => {
         // then
         expect(document.cookie).toEqual(
           'locale=fr-BE; path=/; max-age=31536000; SameSite=Strict; domain=pix.org'
-        )
-      })
-    })
-
-    describe('when user choose "en-gb" as locale', () => {
-      it('saves locale cookie with "en" value in the cookie storage', () => {
-        // given
-        document.cookie = ''
-        const oldLocale = ''
-        const newLocale = 'en-gb'
-        const context = {
-          app: {
-            i18n: {},
-          },
-          route: {
-            path: '/',
-          },
-        }
-
-        // when
-        localeObserver(context)
-        context.app.i18n.onBeforeLanguageSwitch(oldLocale, newLocale)
-
-        // then
-        expect(document.cookie).toEqual(
-          'locale=en; path=/; max-age=31536000; SameSite=Strict; domain=pix.org'
         )
       })
     })

--- a/tests/services/cookie.test.js
+++ b/tests/services/cookie.test.js
@@ -1,0 +1,94 @@
+import { getCookie, setCookie } from '~/services/cookie'
+
+jest.mock('~/config/environment', () => ({
+  config: {
+    siteDomain: 'pix.org',
+  },
+}))
+
+describe('Services | Cookie', () => {
+  beforeEach(() => {
+    let cookieJar = ''
+
+    jest.spyOn(document, 'cookie', 'set').mockImplementation((cookie) => {
+      cookieJar = cookie
+    })
+    jest.spyOn(document, 'cookie', 'get').mockImplementation(() => cookieJar)
+  })
+  describe('#getCookie', () => {
+    describe('When name in parameter is undefined', () => {
+      it('returns null', () => {
+        // given & when
+        const result = getCookie(null)
+
+        // then
+        expect(result).toBeNull()
+      })
+    })
+
+    describe('When there is no cookie with name in parameter', () => {
+      it('returns null', () => {
+        // given
+        const name = 'foo2'
+        document.cookie = 'foo=bar'
+
+        // when
+        const result = getCookie(name)
+
+        // then
+        expect(result).toBeNull()
+      })
+    })
+
+    describe('When there is an existing cookie', () => {
+      it('returns cookie value', () => {
+        // given
+        const name = 'foo'
+        document.cookie = 'foo=bar'
+
+        // when
+        const result = getCookie(name)
+
+        // then
+        expect(result).toEqual('bar')
+      })
+    })
+  })
+
+  describe('#setCookie', () => {
+    describe('When in development mode', () => {
+      it('creates cookie in the cookie storage', () => {
+        // given
+        document.cookie = ''
+        const name = 'test'
+        const value = 'test2'
+        const isDev = true
+
+        // when
+        setCookie(name, value, isDev)
+
+        // then
+        expect(document.cookie).toEqual(
+          `${name}=${value}; path=/; max-age=31536000; SameSite=Strict`
+        )
+      })
+    })
+    describe('When in production mode', () => {
+      it('creates cookie in the cookie storage with domain attribute', () => {
+        // given
+        document.cookie = ''
+        const name = 'test'
+        const value = 'test2'
+        const isDev = false
+
+        // when
+        setCookie(name, value, isDev)
+
+        // then
+        expect(document.cookie).toEqual(
+          `${name}=${value}; path=/; max-age=31536000; SameSite=Strict; domain=pix.org`
+        )
+      })
+    })
+  })
+})

--- a/tests/services/get-locale-from-cookie.test.js
+++ b/tests/services/get-locale-from-cookie.test.js
@@ -47,8 +47,8 @@ describe('getLocaleFromCookie', () => {
       })
     })
 
-    describe('with value equal to "en"', () => {
-      test('returns "en-gb"', () => {
+    describe('with value equal to "en-gb"', () => {
+      test('returns "en"', () => {
         // given
         document.cookie = `foo=bar; locale=en`
 
@@ -56,7 +56,7 @@ describe('getLocaleFromCookie', () => {
         const chosenLocale = getLocaleFromCookie()
 
         // then
-        expect(chosenLocale).toBe('en-gb')
+        expect(chosenLocale).toBe('en')
       })
     })
 

--- a/tests/services/get-routes-to-generate.test.js
+++ b/tests/services/get-routes-to-generate.test.js
@@ -49,7 +49,7 @@ describe('#getRoutesToGenerate', () => {
           results: [
             { uid: 'route-to-generate', lang: 'fr-fr' },
             { uid: 'route-to-generate', lang: 'fr' },
-            { uid: 'route-to-generate', lang: 'en-gb' },
+            { uid: 'route-to-generate', lang: 'en' },
           ],
         }),
       }
@@ -89,7 +89,7 @@ describe('#getRoutesToGenerate', () => {
           results: [
             { uid: 'route-to-generate', lang: 'fr-fr' },
             { uid: 'route-to-generate', lang: 'fr' },
-            { uid: 'route-to-generate', lang: 'en-gb' },
+            { uid: 'route-to-generate', lang: 'en' },
           ],
         }),
       }
@@ -124,7 +124,7 @@ describe('#getRoutesToGenerate', () => {
           results: [
             { uid: 'route-to-generate', lang: 'fr-fr' },
             { uid: 'route-to-generate', lang: 'fr' },
-            { uid: 'route-to-generate', lang: 'en-gb' },
+            { uid: 'route-to-generate', lang: 'en' },
             { uid: 'route-to-generate', lang: 'xh-ZA' },
           ],
         }),

--- a/tests/services/link-resolver.test.js
+++ b/tests/services/link-resolver.test.js
@@ -14,9 +14,9 @@ describe('linkResolver', () => {
       expectedUrl: '/fr-be/test-uid',
     },
     {
-      lang: 'en-gb',
+      lang: 'en',
       uid: 'test-uid',
-      expectedUrl: '/en-gb/test-uid',
+      expectedUrl: '/en/test-uid',
     },
   ]
 
@@ -43,9 +43,9 @@ describe('linkResolver', () => {
         expectedUrl: '/fr-be/actualites/test-uid',
       },
       {
-        lang: 'en-gb',
+        lang: 'en',
         uid: 'test-uid',
-        expectedUrl: '/en-gb/news/test-uid',
+        expectedUrl: '/en/news/test-uid',
       },
     ]
 
@@ -74,8 +74,8 @@ describe('linkResolver', () => {
       },
       {
         tags: [TAGS.INDEX],
-        lang: 'en-gb',
-        expectedUrl: '/en-gb/',
+        lang: 'en',
+        expectedUrl: '/en/',
       },
     ]
 


### PR DESCRIPTION
## ☑️ Reste à faire
- [ ] Mettre à jour les liens dans les documents Prismic en remplaçant `en-gb` par `en` (edit: peut être fait après le merge)

## :unicorn: Problème
Aujourd’hui, la locale _International English_ est gérée sur le site vitrine avec le code `en-gb`. Or ce code représente l’anglais britannique et non l’anglais international qui a pour code `en`. Cela pose aussi d’autres problèmes de cohérence par rapport aux Pix apps qui elles utilisent la valeur `en` pour la `lang` des utilisateurs.

## :robot: Proposition
Remplacer l’utilisation de la valeur `en-gb` dans le site vitrine par la valeur `en`.

## :rainbow: Remarques

- Une précédente PR a déjà mis en place le remplacement dans le cookie `locale` des valeurs de locales `en-GB` et `en-gb` par `en` :  #522

- La façon de récupérer le document Prismic pour la home de Pix Pro a été modifiée car ne fonctionne plus avec la locale `en`. Cela fonctionnait pour la locale `en-gb` car celui-ici contenait avant l'uid `decouvrir-pix-pro` et Prismic conserve les anciens uid du document. Ce mécanisme va être amélioré dans un prochain ticket.

- La rétrocompatilité a été mise en place pour pouvoir lire les cookies avec une valeur `en-gb` (afin de renvoyer sur le `/en` du site) 😄 

## :100: Pour tester
### Pix Site
- Aller sur la RA .org https://site-pr538.review.pix.org/
- Si vous avez déjà une locale en cookie, cliquez sur International English dans le Locale Switcher. Sinon cliquez sur International English
- Vérifier que le lien est bien https://site-pr538.review.pix.org/en et que la page s'affiche bien en anglais
- Aller sur https://site-pr538.review.pix.org/en-gb et constater que la redirection se fait bien en https://site-pr538.review.pix.org/en.
- Changer la valeur du cookie locale en `en-gb`. 
- Rafraîchir la page et constater que ça fonctionne et que la valeur du cookie locale a été remis en `en`
- Parcourir les liens du menu (Discover Pix, The tests...). 
- Constater que les liens ont, pour le moment, toujours un path en /en-gb
- Cliquer sur les liens et voir que l'url affichée est bien en /en.

### Pix Pro
- Aller sur la RA .org https://pro-pr538.review.pix.org/
- Si vous avez déjà une locale en cookie, cliquez sur International English dans le Locale Switcher. Sinon cliquez sur International English
- Vérifier que le lien est bien https://pro-pr538.review.pix.org/en et que la page s'affiche bien en anglais
- Aller sur https://pro-pr538.review.pix.org/en-gb et constater que la redirection se fait bien en https://pro-pr538.review.pix.org/en.
- Changer la valeur du cookie locale en `en-gb`. 
- Rafraîchir la page et constater que ça fonctionne et que la valeur du cookie locale a été remis en `en`
- Parcourir les liens du menu (Discover Pix Pro, Business...). 
- Constater que les liens ont, pour le moment, toujours un path en /en-gb
- Cliquer sur les liens et voir que l'url affichée est bien en /en.