### PR TITLE
[TECH] Améliorer la condition d'affichage précisant si la locale est international dans le locale switcher en affichage réduit (PIX-8230)

### DIFF
--- a/components/LocaleSwitcher/LocaleSwitcher.vue
+++ b/components/LocaleSwitcher/LocaleSwitcher.vue
@@ -95,9 +95,7 @@
             >
               <img :src="getMenuItemIconPath(child)" :alt="child.icon" />
               {{ $t(option.name) }}
-              {{
-                child.icon === 'globe-europe.svg' ? ' - ' + $t(child.name) : ''
-              }}
+              {{ isInternational(child) ? ' - ' + $t(child.name) : '' }}
             </pix-link>
           </li>
         </ul>
@@ -170,6 +168,9 @@ export default {
       }
 
       return `/images/${menuItem.icon}`
+    },
+    isInternational(locale) {
+      return !locale.localeCode.includes('-')
     },
   },
 }

--- a/tests/components/LocaleSwitcher.test.js
+++ b/tests/components/LocaleSwitcher.test.js
@@ -56,7 +56,7 @@ describe('Component: LocaleSwitcher', () => {
       const wrapper = mount(LocaleSwitcher, {
         components: { LocaleSwitcherSubMenu, PixLink },
         mocks: { $t, $i18n },
-        stubs: { fa: true },
+        stubs: ['fa'],
       })
       await wrapper.find('button').trigger('click')
       await wrapper.find('.locale-switcher-sub-menu-button').trigger('click')
@@ -81,13 +81,58 @@ describe('Component: LocaleSwitcher', () => {
       const wrapper = mount(LocaleSwitcher, {
         components: { LocaleSwitcherSubMenu, PixLink },
         mocks: { $t, $i18n },
-        stubs: { fa: true },
+        stubs: ['fa'],
       })
       await wrapper.find('button').trigger('click')
       await wrapper.find('.locale-switcher-sub-menu-button').trigger('click')
 
       // then
       expect(wrapper.element).toMatchSnapshot()
+    })
+  })
+
+  describe.only('#isInternational', () => {
+    describe('when locale is international', () => {
+      it('returns true', () => {
+        // given
+        const $t = () => {}
+        const $i18n = { locale: 'fr-fr' }
+        const locale = {
+          localeCode: 'fr',
+        }
+        const wrapper = mount(LocaleSwitcher, {
+          components: { PixLink },
+          mocks: { $t, $i18n },
+          stubs: ['fa'],
+        })
+
+        // when
+        const result = wrapper.vm.isInternational(locale)
+
+        // then
+        expect(result).toBe(true)
+      })
+    })
+    describe('when locale is not international', () => {
+      it('returns false', () => {
+        // given
+        const $t = () => {}
+        const $i18n = { locale: 'fr-fr' }
+        const locale = {
+          localeCode: 'fr-fr',
+        }
+        const wrapper = mount(LocaleSwitcher, {
+          components: { PixLink },
+          mocks: { $t, $i18n },
+          stubs: ['fa'],
+        })
+
+        // when
+        const result = wrapper.vm.isInternational(locale)
+
+        // then
+        expect(result).toBe(false)
+      })
     })
   })
 })


### PR DESCRIPTION
## :unicorn: Problème
La condition permettant d'afficher la mention `international - ` se basait sur l'icone `gloabel-europe.svg`. Elle est donc dépendant du nom de l'icone.

## :robot: Proposition
Comme évoqué dans la PR #537. Il est mieux de se baser sur le `localCode` afin de déterminer si locale est internationale.
- Un `localeCode:en` est international et doit donc comporter la mention.
- Un `localeCode:fr-be` n'est pas international et ne doit pas comporter la mention.

## :rainbow: Remarques
R.A.S

## :100: Pour tester
- se rendre sur: https://site-pr542.review.pix.org/
- Réduire la taille de la fenêtre
- Constater dans le burger menu que la mention `international - ` se trouve seulement devant `Francais` et `English`
- Comparer avec la version en Production
