### PR TITLE
[BUGFIX] Associer le style actif aux liens des locales internationales du localeSwitcher du burger menu (PIX-8244)

### DIFF
--- a/components/LocaleSwitcher/LocaleSwitcher.vue
+++ b/components/LocaleSwitcher/LocaleSwitcher.vue
@@ -76,29 +76,25 @@
       {{ $t('locale-switcher.title') }}
     </p>
     <ul class="locale-switcher-burger-menu__list">
-      <li v-for="option in menu" :key="option.key">
-        <ul>
-          <li
-            v-for="child in option.children || [option]"
-            :key="child.name"
-            :class="[
-              'locale-switcher-burger-menu-list__locale',
-              {
-                'locale-switcher-burger-menu__list--active':
-                  option.localeCode === currentLocaleCode,
-              },
-            ]"
-          >
-            <pix-link
-              :href="getIndexUrl(child)"
-              class="locale-switcher-burger-menu-list__locale-link"
-            >
-              <img :src="getMenuItemIconPath(child)" :alt="child.icon" />
-              {{ $t(option.name) }}
-              {{ isInternational(child) ? ' - ' + $t(child.name) : '' }}
-            </pix-link>
-          </li>
-        </ul>
+      <li
+        v-for="menuItem in menuForMobile"
+        :key="menuItem.name"
+        :class="[
+          'locale-switcher-burger-menu-list__locale',
+          {
+            'locale-switcher-burger-menu__list--active':
+              menuItem.localeCode === currentLocaleCode,
+          },
+        ]"
+      >
+        <pix-link
+          :href="getIndexUrl(menuItem)"
+          class="locale-switcher-burger-menu-list__locale-link"
+        >
+          <img :src="getMenuItemIconPath(menuItem)" :alt="menuItem.icon" />
+          {{ isInternational(menuItem) ? $t('international') + ' - ' : '' }}
+          {{ $t(menuItem.name) }}
+        </pix-link>
       </li>
     </ul>
   </div>
@@ -121,6 +117,7 @@ export default {
       showMenu: false,
       showSubMenu: false,
       menu: localization.menu,
+      menuForMobile: localization.menuForMobile,
     }
   },
   computed: {

--- a/config/localization/pix-pro.js
+++ b/config/localization/pix-pro.js
@@ -47,9 +47,14 @@ export const localization = {
       icon: 'flag-fr.svg',
     },
   ],
+  menuForMobile: [],
   locales: availableLocales,
   localesForCurrentSite: getLocalesForCurrentSite(),
 }
+
+localization.menuForMobile = localization.menu.flatMap(
+  (menuItem) => menuItem.children || menuItem
+)
 
 export function getLocalesForCurrentSite() {
   if (config.isFrenchDomain) {

--- a/config/localization/pix-site.js
+++ b/config/localization/pix-site.js
@@ -60,9 +60,14 @@ export const localization = {
       icon: 'flag-fr.svg',
     },
   ],
+  menuForMobile: [],
   locales: availableLocales,
   localesForCurrentSite: getLocalesForCurrentSite(),
 }
+
+localization.menuForMobile = localization.menu.flatMap(
+  (menuItem) => menuItem.children || menuItem
+)
 
 export function getLocalesForCurrentSite() {
   if (config.isFrenchDomain) {

--- a/tests/components/LocaleSwitcher.test.js
+++ b/tests/components/LocaleSwitcher.test.js
@@ -91,7 +91,7 @@ describe('Component: LocaleSwitcher', () => {
     })
   })
 
-  describe.only('#isInternational', () => {
+  describe('#isInternational', () => {
     describe('when locale is international', () => {
       it('returns true', () => {
         // given
@@ -113,6 +113,7 @@ describe('Component: LocaleSwitcher', () => {
         expect(result).toBe(true)
       })
     })
+
     describe('when locale is not international', () => {
       it('returns false', () => {
         // given

--- a/tests/config/localization/pix-pro.test.js
+++ b/tests/config/localization/pix-pro.test.js
@@ -53,33 +53,57 @@ describe('#getLocalesForCurrentSite', () => {
 })
 
 describe('#localization', () => {
-  it('should return all menu entries for pix-pro', () => {
-    // given
-    const expectedResult = [
-      {
-        name: 'international',
-        icon: 'globe-europe.svg',
-        children: [
-          {
-            name: 'french',
-            localeCode: 'fr',
-            icon: 'globe-europe.svg',
-          },
-          {
-            name: 'english',
-            localeCode: 'en',
-            icon: 'globe-europe.svg',
-          },
-        ],
-      },
-      {
-        name: 'france',
-        localeCode: 'fr-fr',
-        icon: 'flag-fr.svg',
-      },
-    ]
+  describe('Desktop menu', function () {
+    it('return all menu entries for pix-pro', () => {
+      // when & then
+      const expectedResult = [
+        {
+          name: 'international',
+          icon: 'globe-europe.svg',
+          children: [
+            {
+              name: 'french',
+              localeCode: 'fr',
+              icon: 'globe-europe.svg',
+            },
+            {
+              name: 'english',
+              localeCode: 'en',
+              icon: 'globe-europe.svg',
+            },
+          ],
+        },
+        {
+          name: 'france',
+          localeCode: 'fr-fr',
+          icon: 'flag-fr.svg',
+        },
+      ]
+      expect(localization.menu).toEqual(expectedResult)
+    })
+  })
 
-    // when & then
-    expect(localization.menu).toEqual(expectedResult)
+  describe('Mobile menu', function () {
+    it('returns all menu entries for pix-pro', () => {
+      // when & then
+      const expectedResult = [
+        {
+          name: 'french',
+          localeCode: 'fr',
+          icon: 'globe-europe.svg',
+        },
+        {
+          name: 'english',
+          localeCode: 'en',
+          icon: 'globe-europe.svg',
+        },
+        {
+          name: 'france',
+          localeCode: 'fr-fr',
+          icon: 'flag-fr.svg',
+        },
+      ]
+      expect(localization.menuForMobile).toEqual(expectedResult)
+    })
   })
 })

--- a/tests/config/localization/pix-site.test.js
+++ b/tests/config/localization/pix-site.test.js
@@ -52,38 +52,67 @@ describe('#getLocalesForCurrentSite', () => {
 })
 
 describe('#localization', () => {
-  it('should return all menu entries for pix-site', () => {
-    // given
-    const expectedResult = [
-      {
-        name: 'international',
-        icon: 'globe-europe.svg',
-        children: [
-          {
-            name: 'french',
-            localeCode: 'fr',
-            icon: 'globe-europe.svg',
-          },
-          {
-            name: 'english',
-            localeCode: 'en',
-            icon: 'globe-europe.svg',
-          },
-        ],
-      },
-      {
-        name: 'fwb',
-        localeCode: 'fr-be',
-        icon: 'flag-be.svg',
-      },
-      {
-        name: 'france',
-        localeCode: 'fr-fr',
-        icon: 'flag-fr.svg',
-      },
-    ]
+  describe('Desktop menu', function () {
+    it('returns all menu entries for pix-site', () => {
+      // when & then
+      const expectedResult = [
+        {
+          name: 'international',
+          icon: 'globe-europe.svg',
+          children: [
+            {
+              name: 'french',
+              localeCode: 'fr',
+              icon: 'globe-europe.svg',
+            },
+            {
+              name: 'english',
+              localeCode: 'en',
+              icon: 'globe-europe.svg',
+            },
+          ],
+        },
+        {
+          name: 'fwb',
+          localeCode: 'fr-be',
+          icon: 'flag-be.svg',
+        },
+        {
+          name: 'france',
+          localeCode: 'fr-fr',
+          icon: 'flag-fr.svg',
+        },
+      ]
+      expect(localization.menu).toEqual(expectedResult)
+    })
+  })
 
-    // when & then
-    expect(localization.menu).toEqual(expectedResult)
+  describe('Mobile menu', function () {
+    it('returns all menu entries for pix-site', () => {
+      // when & then
+      const expectedResult = [
+        {
+          name: 'french',
+          localeCode: 'fr',
+          icon: 'globe-europe.svg',
+        },
+        {
+          name: 'english',
+          localeCode: 'en',
+          icon: 'globe-europe.svg',
+        },
+        {
+          name: 'fwb',
+          localeCode: 'fr-be',
+          icon: 'flag-be.svg',
+        },
+        {
+          name: 'france',
+          localeCode: 'fr-fr',
+          icon: 'flag-fr.svg',
+        },
+      ]
+      expect(localization.menuForMobile).toEqual(expectedResult)
+    })
   })
 })


### PR DESCRIPTION
## :unicorn: Problème

Quand la zone d'affichage du site web dans le navigateur est réduite en largeur, les liens des locales internationales ne possèdent pas la `class` `locale-switcher-burger-menu__list--active`.

## :robot: Proposition

Associer le style actif aux liens des locales internationales du localeSwitcher du burger menu en modifiant la condition d'ajout de la classe CSS.

## :rainbow: Remarques
Les locales internationales sont regroupées ensemble dans un sous tableau, d'où le besoins de `child` on va chercher dans cet objet.
On pourrait modifier cette structure de données afin de les mettre au même niveau que les autres locales, plutôt que de changer la condition .

## :100: Pour tester
- Se rendre sur https://site-pr545.review.pix.org/
- Naviguer entre toutes les locales
- Vérifier que lien comporte bien la class `locale-switcher-burger-menu__list--active`
