### PR TITLE
[BUGFIX] Rendre l'affichage des nouvelles actualités plus résilientes (PIX-8376)

### DIFF
--- a/components/NewsItemCard.vue
+++ b/components/NewsItemCard.vue
@@ -4,7 +4,7 @@
       class="news-item-card__link"
       :to="localePath({ name: 'news-slug', params: { slug: uid } })"
     >
-      <div class="news-item-card__header">
+      <div v-if="slice.illustration?.url" class="news-item-card__header">
         <!-- /!\ We keep this line if we think that an image would be better -->
         <div
           class="news-item-card__illustration"


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le build des pix-sites plantent si le champ illustration dans les documents Prismic de type news n’est pas renseigné.

## :robot: Proposition
Rendre optionnel l’utilisation de ce champ.

## :rainbow: Remarques
R.A.S

## :100: Pour tester
- Lancer `npm run build:site` en local et constaté qu'il n'y a pas d'erreur.