### PR TITLE
[FEATURE] Ajouter un feature toggle pour l'affichage des nouveaux menus (PIX-8995)

### DIFF
--- a/components/NavigationSliceZone.vue
+++ b/components/NavigationSliceZone.vue
@@ -1,6 +1,9 @@
 <template>
   <header class="navigation-slice-zone" role="banner">
-    <client-only>
+    <client-only v-if="isNewMenuAvailable">
+      <button class="new-burger-menu">new burger menu</button>
+    </client-only>
+    <client-only v-else>
       <slide-menu width="320" class="burger-menu" :close-on-navigation="true">
         <burger-menu-nav :items="burgerMenuLinks" />
       </slide-menu>
@@ -23,7 +26,10 @@
       </section>
     </div>
     <section class="navigation-slice-zone-content__bottom-side">
-      <slices-navigation-zone :navigation-zone-items="navigation" />
+      <nav v-if="isNewMenuAvailable" class="new-navigation-menu">
+        <p>new navigation zone</p>
+      </nav>
+      <slices-navigation-zone v-else :navigation-zone-items="navigation" />
     </section>
   </header>
 </template>
@@ -36,6 +42,7 @@ export default {
   data() {
     return {
       usedMainNavigation: [],
+      isNewMenuAvailable: process.env.FT_IS_NEW_MENU_AVAILABLE === 'true',
     }
   },
   async fetch() {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -41,6 +41,7 @@ const nuxtConfig = {
     DOMAIN_ORG: process.env.DOMAIN_ORG,
     DOMAIN_FR: process.env.DOMAIN_FR,
     SITE_DOMAIN: process.env.SITE_DOMAIN,
+    FT_IS_NEW_MENU_AVAILABLE: process.env.FT_IS_NEW_MENU_AVAILABLE,
   },
   dir: {
     pages: `pages/${process.env.SITE}`,

--- a/sample.env
+++ b/sample.env
@@ -11,3 +11,10 @@ DOMAIN_ORG=localhost:8000
 GEOAPI_HOST=<GEOAPI_HOST>
 
 SITE=pix-site
+
+# Burger menu and navigation menu with new structure are available
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_IS_NEW_MENU_AVAILABLE=false

--- a/tests/components/slices/NavigationSliceZone.test.js
+++ b/tests/components/slices/NavigationSliceZone.test.js
@@ -53,5 +53,35 @@ describe('NavigationSliceZone', () => {
         expect(result).toEqual(expectedSiteNavigation.data.body)
       })
     })
+
+    describe('when FT_IS_NEW_MENU_AVAILABLE is available', () => {
+      it('should return the new burger menu', () => {
+        // given
+        component = shallowMount(NavigationSliceZone, {
+          data() {
+            return { isNewMenuAvailable: true }
+          },
+          stubs,
+        })
+
+        // then
+        expect(component.find('button.new-burger-menu').exists()).toBe(true)
+        expect(component.find('.burger-menu').exists()).toBe(false)
+      })
+
+      it('should return the new navigation menu', () => {
+        // given
+        component = shallowMount(NavigationSliceZone, {
+          data() {
+            return { isNewMenuAvailable: true }
+          },
+          stubs,
+        })
+
+        // then
+        expect(component.find('nav.new-navigation-menu').exists()).toBe(true)
+        expect(component.find('nav.navigation-zone').exists()).toBe(false)
+      })
+    })
   })
 })


### PR DESCRIPTION
## :unicorn: Problème
On souhaite cacher pour le moment la prochaine nouvelle arborescence des menus.

## :robot: Proposition
Ajout d'un feature toggle FT_IS_NEW_MENU_AVAILABLE.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Vérifier que le feature toggle est activé et que les menus actuels ont été remplacé par un bouton de test concernant le burger menu et une navigation de test.
