### PR TITLE
[TECH] Désactiver renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>1024pix/renovate-config:aggressive"],
+  "extends": [
+    "github>1024pix/renovate-config:default"
+  ],
   "enabled": true
 }


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, renovate est en mode aggressif et merge des montées de version. Cela nous créer des problèmes en local pour développer.

## :robot: Proposition
Désactiver renovate

## :rainbow: Remarques
On le réactivera plus tard

## :100: Pour tester
tests verts