### PR TITLE
[BUGFIX] Restaurer la configuration de nuxt pour réparer le build

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -64,6 +64,7 @@ const nuxtConfig = {
       config.isSeoIndexingEnabled ? {} : { name: 'robots', content: 'noindex' },
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
+    script: [],
   },
   /*
    ** Customize the progress-bar color


### PR DESCRIPTION
## :unicorn: Problème
Le build est en erreur lors du déploiement scalingo

## :robot: Proposition
Restaurer la configuration de nuxt

## :rainbow: Remarques
Se fier à la CI était verte, mais ne nous a pas prémuni d'une erreur de build

## :100: Pour tester
le build est ok en local