### PR TITLE
[BUGFIX] Réparer les graphiques sur la page de statistiques (PIX-9542)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "axios": "^1.0.0",
         "babel-core": "7.0.0-bridge.0",
         "babel-jest": "^29.4.1",
-        "chart.js": "^3.0.0",
+        "chart.js": "^2.9.4",
         "core-js": "^3.30.2",
         "eslint": "^8.30.0",
         "eslint-config-prettier": "^9.0.0",
@@ -8787,10 +8787,33 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "node_modules/chart.js": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.9.1.tgz",
-      "integrity": "sha512-Ro2JbLmvg83gXF5F4sniaQ+lTbSv18E+TIf2cOeiH1Iqd2PGFOtem+DUufMZsCJwFE7ywPOpfXFBwRTGq7dh6w==",
-      "dev": true
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
+      "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
+      "dev": true,
+      "dependencies": {
+        "chartjs-color": "^2.1.0",
+        "moment": "^2.10.2"
+      }
+    },
+    "node_modules/chartjs-color": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
+      "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
+      "dev": true,
+      "dependencies": {
+        "chartjs-color-string": "^0.6.0",
+        "color-convert": "^1.9.3"
+      }
+    },
+    "node_modules/chartjs-color-string": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
+      "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "^1.0.0"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.5.3",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "axios": "^1.0.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^29.4.1",
-    "chart.js": "^3.0.0",
+    "chart.js": "^2.9.4",
     "core-js": "^3.30.2",
     "eslint": "^8.30.0",
     "eslint-config-prettier": "^9.0.0",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement la page de statistiques sur le site vitrine ne contient plus de graphiques. Cela provient d'un bug suite à une montée de version de la lib chart.js dont laquelle dépend la lib [vue-chartjs](https://vue-chartjs.org/).

## :robot: Proposition
Revenir à la version précédente de la lib chart.js pour que les graphiques s'affichent de nouveau.

## :100: Pour tester

- Aller sur la page des stats de [Pix Site (.fr)](https://site-pr582.review.pix.fr/statistiques)
- Constater la présence de graphiques