### PR TITLE
[BUGFIX] Corriger l'affichage de l'item menu actif

### DIFF
--- a/components/slices/NavigationZone.vue
+++ b/components/slices/NavigationZone.vue
@@ -111,15 +111,14 @@ export default {
       }
     },
     subIsActive(subNavigationLinks) {
-      const paths = subNavigationLinks
-        .filter((subNavigationLink) => subNavigationLink.link.url !== undefined)
-        .map((subNavigationLink) => {
-          const splittedLink = subNavigationLink.link.url.split('/')
-          const linkIndex = splittedLink.length - 1
-          return splittedLink[linkIndex]
-        })
-      return paths.some((path) => {
-        return this.$route.path.includes(path)
+      const currentPath = this.$route.path
+      const subLinksUrls = subNavigationLinks.map((link) => link.link.url)
+
+      const isHomePage = currentPath === '/'
+      if (isHomePage) return false
+
+      return subLinksUrls.find((link) => {
+        return link.endsWith(currentPath) || link.endsWith(currentPath + '/')
       })
     },
   },


### PR DESCRIPTION
## :unicorn: Problème

Des items menus de premiers niveaux étaient affichés actifs sans raison.

![image](https://github.com/1024pix/pix-site/assets/7335131/5bf31a0f-3de1-44ad-943b-9bd7bbba68cd)


## :robot: Proposition

Revoir le fonctionnement de la méthode `subIsActive`.


## :100: Pour tester

- Aller sur la RA et naviguer dans des pages.
- Vérifier que l'item de menu actif est toujours celui souhaité.
