### PR TITLE
[FEATURE] Améliorer le style des formulaires easiware (PIX-10806)

### DIFF
--- a/components/EasiwareForm.vue
+++ b/components/EasiwareForm.vue
@@ -31,5 +31,6 @@ export default {
   padding: 40px;
   display: flex;
   justify-content: center;
+  background-color: #452d9d;
 }
 </style>

--- a/services/easiware.js
+++ b/services/easiware.js
@@ -31,117 +31,150 @@ export function create(params) {
     </div>
   `
   targetElementForForm.innerHTML +=
-    '<div id="easiformarea"></div>' +
     '<div class="easiformWaiting" id="easiformWaiting">' +
     '<div class="easiformWaitingCont" id="easiformWaitingCont"><div class="easiformWaitingMsg" id="easiformWaitingMsg"></div></div>' +
     `<style type="text/css">
-      #test {
-    color: red;
-  }
-
-  /*Style globale appliqué sur la zone qui encapsule le formulaire*/
-#easiformarea {
-    margin: 20px;
+:root {
+--pix-neutral-900: #122647;
+--pix-neutral-60: #5E6C84;
+--pix-error-5: #FBECEC;
+--pix-error-70: #952E2E;
+--pix-error-500: #D24140;
+--pix-neutral-45: #5E6C84;
+--pix-primary-50: #613FDD;
+--pix-primary-700: #452d9d;
+--pix-primary-900: #291a5d;
 }
 
-/*Style générique pour les balises span et div de la zone easiformarea*/
-#easiformarea > form > div {
-    position: relative;
-    display: table;
-    margin-bottom: 15px;
-}
-#easiformarea span {
-    display: table-cell;
-    vertical-align: top;
-    color : #c561bb;
-}
-#easiformarea span:first-child {
-    width: 180px;
+ #easiformarea {
+  font-family: 'Roboto', Arial, sans-serif;
+  line-height: 1.25;
+  background-color: white;
+  border-radius: 16px;
+  padding:32px;
+  max-width: 34rem;
 }
 
-/*Style pour les titre et les libellés des champs*/
-#easiformarea label {
-    font: 0.88889em / 32px "Avenir45Book", Arial, Verdana, Helvetica, sans-serif;
-    text-transform: uppercase;
+[id^="easi_fielddiv"] {
+  display: flex;
+  flex-wrap: wrap;
 }
 
-.easifilefieldlabel {
-    text-transform: inherit !important;
-    color: black !important;
+[id^="easi_fielddiv"]:not(:first-child) {
+  margin-top: 1rem;
 }
 
-.easifilefielderrormessage {
-color: #f2679e !important;
-}
-
-/*Style du champs de type text, liste déroulante et bloc de text*/
 #easiformarea input[type="text"],
 #easiformarea input[type="number"],
 #easiformarea select,
 #easiformarea textarea {
-    width: 340px;
-    border: 1px solid #bbb;
-    color: #574d4d;
-    font: 0.88889em "Avenir35Light", Arial, Verdana, Helvetica, sans-serif;
-    padding: 0 5px;
+  max-width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--pix-neutral-45);
+  border-radius: 0.25rem;
+  font-size: 1rem;
+  color: var(--pix-neutral-900);
 }
-#easiformarea input[type="text"],
+
 #easiformarea select {
-    height: 32px;
-    line-height: 32px;
-}
-#easiformarea textarea {
-    height: 200px;
-}
-/*Style appliqué à l'étoile des champs obligatoires*/
-#easiformarea .mandatory {
-    position: absolute;
-    left: -10px;
-    top: 5px;
-    color: #e74890;
+  background: url(data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0Ljk1IDEwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2ZmZjt9LmNscy0ye2ZpbGw6IzQ0NDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPmFycm93czwvdGl0bGU+PHJlY3QgY2xhc3M9ImNscy0xIiB3aWR0aD0iNC45NSIgaGVpZ2h0PSIxMCIvPjxwb2x5Z29uIGNsYXNzPSJjbHMtMiIgcG9pbnRzPSIxLjQxIDQuNjcgMi40OCAzLjE4IDMuNTQgNC42NyAxLjQxIDQuNjciLz48cG9seWdvbiBjbGFzcz0iY2xzLTIiIHBvaW50cz0iMy41NCA1LjMzIDIuNDggNi44MiAxLjQxIDUuMzMgMy41NCA1LjMzIi8+PC9zdmc+) no-repeat;
+  background-position: right 5px top;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    appearance: none;
 }
 
-/*Style appliqué au bouton de validation du formulaire*/
-#easiformarea .validatebutton {
-    color: #fff;
-    display: inline-block;
-    font: 1.11111em/38px "Avenir35Light", Arial, Verdana, Helvetica, sans-serif;
-    height: 42px;
-    padding: 0 40px 0 40px;
-    position: relative;
-    background: #e74890;
-    border: none;
-    margin-right: 290px;
-    cursor:pointer;
-    margin-top: 10px;
-}
-#easiformarea .validatebutton:after {
-    font-size: 0.8em;
-    height: 16px;
-    background-color: #dedede;
-}
-#easiformarea .validatebutton:hover {
-    background: #f2006d;
+.mandatory {
+  order: 1;
+  min-width: 0.75em;
+  flex-shrink: 0;
+  color: var(--pix-error-500);
 }
 
-#easiformarea .validatebutton:disabled {
-    background: #574d4d;
-    cursor: unset;
+[id^="easi_labelspan"] {
+  color: var(--pix-neutral-900);
+  order: 2;
+  flex-grow: 1;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
 }
 
-#easiformarea .disabled-validatebutton {
-    background: #574d4d !important;
+[id^="easi_fieldspan"] {
+  order: 4;
+  min-width: 100%;
 }
 
-/*Style appliqué la zone expliquant l'obligation sur les dits champs obligatoires*/
-#easiformarea .mandatoryfieldmention {
-    color: #4a4a4a;
-    font: 0.66667em "Avenir35Light", Arial, Verdana, Helvetica, sans-serif;
-    margin-bottom: 20px;
-    text-transform: uppercase;
+[id^="easi_fieldspan"] > * {
+  min-width: 100%;
 }
 
-/*Style appliqué sur le sablier après la saisie du formulaire*/
+[id^="easi_fielhelpspan"] {
+ order: 3;
+ min-width: 100%;
+ font-size: 0;
+ margin-bottom: 0.5rem;
+}
+
+#easiformKBzone {
+ font-size: 0.875rem;
+  color: var(--pix-neutral-60);
+}
+
+[id^="easi_fielhelpspan"] .easitoolTipText {
+ font-size: 0.875rem;
+  color: var(--pix-neutral-60);
+}
+
+
+.validatebutton {
+  background-color: var(--pix-primary-50);
+  color: white;
+  font-family: 'Roboto', Arial, sans-serif;
+  border-radius: 100px;
+  padding: 1rem 1.5rem;
+  border: 2px solid transparent;
+  font-size: 1.125rem;
+  margin-top: 1.5rem;
+  cursor: pointer;
+}
+
+.validatebutton:hover {
+  background-color: var(--pix-primary-700);
+
+}
+
+.validatebutton:active {
+  background-color: var(--pix-primary-900);
+}
+
+.mandatoryfieldmention {
+  color: var(--pix-neutral-900);
+  margin: 2rem 0;
+}
+
+#fld_CS_StudentBirth {
+  font-family: 'Roboto', Arial, sans-serif;
+  color: var(--pix-neutral-60);
+  text-transform: uppercase;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--pix-neutral-45);
+  border-radius: 0.25rem;
+  font-size: 1rem;
+}
+
+#fld_AttachedFiles {
+  font-family: 'Roboto', Arial, sans-serif;
+  color: var(--pix-neutral-60);
+}
+
+[id^="recaptcha_message"] {
+  color: var(--pix-error-70);
+  background-color: var(--pix-error-5);
+  border: 1px solid var(--pix-error-70);
+  border-radius: 4px;
+  padding: 0.75rem 1rem;
+  font-weight: 500;
+}
 #easiformWaiting {
     display: none;
     position: fixed;
@@ -151,96 +184,6 @@ color: #f2679e !important;
     height: 100%;
     width: 100%;
     background: rgba( 255, 255, 255, .8) 50% 50% no-repeat;
-}
-
-.easiformWaitingCont {
-    width: 100%;
-    height: 100%;
-    display: table;
-}
-
-/*Style appliqué au message d'attente en dessous du sablier */
-.easiformWaitingMsg {
-    color: #000000;
-    text-align: center;
-    display: table-cell;
-    vertical-align: middle;
-    padding-top: 5%; }
-
-/*Style appliqué à la zone globale qui encapsule les propositions de la base de connaissance */
-#easiformKBzone {
-    border-bottom: 1px solid #dedede;
-    width: 520px;
-    font: 0.88889em / 32px "Avenir45Book", Arial, Verdana, Helvetica, sans-serif;
-    text-transform: uppercase;
-    color : #c561bb;
-    margin-bottom: 0px;
-}
-
-/*Style appliqué à la zone qui encapsule que les articles proposés*/
-.easiformKBZoneArticle{
-    /*border-bottom: 1px solid #dedede;*/
-    background-color: rgba(240, 214, 237, 1);
-    cursor: pointer;
-    font-family: sans-serif;
-    font-size: 8pt;
-    color: #574d4d;
-    width: 100%;
-    padding-left: 5px;
-    margin-bottom: 5px;
-}
-
-/*Style appliqué à chaque titre de  la base*/
-.easiformKBZoneTitle {
-    color : #c561bb;
-    font: 0.88889em / 32px "Avenir45Book", Arial, Verdana, Helvetica, sans-serif;
-    text-transform: uppercase;
-}
-
-/*Style appliqué à la zone affichant le message d'information supplémentaire*/
-#easiformarea .additionnalInformation {
- margin-bottom: 20px;
-}
-#easiformarea .additionnalInformation span {
-    width: 100%;
-}
-.easitoolTipButton {
-    padding-left: 10px !important;
-    padding-top: 5px;
-    cursor: help !important;
-    margin-right: 30px;
-}
-
-.easitoolTipButton .easitoolTipText {
-    visibility: hidden;
-    width: 120px;
-    background-color: #574d4d;
-    color: #fff !important;
-    /*text-align: center;*/
-    border-radius: 6px;
-    padding: 5px 0;
-    font: 0.88889em / 32px "Avenir45Book", Arial, Verdana, Helvetica, sans-serif;
-    padding : 5px 0 5px 10px;
-    /* Position the tooltip */
-    position: absolute;
-    z-index: 1;
-}
-
-.easitoolTipButton:hover .easitoolTipText {
-    visibility: visible;
-}
-
-@-webkit-keyframes easirotating {
-    from{
-        -webkit-transform: rotate(0deg);
-    }
-    to{
-        -webkit-transform: rotate(360deg);
-    }
-}
-
-.easirotating {
-    -webkit-animation: easirotating 2s linear infinite;
 }
     </style>` +
     '</div>'


### PR DESCRIPTION
## :christmas_tree: Problème
Le formulaires pour le support proviennent d'un partenaire externe (easiware). De base, ils ne sont pas responsive, et leur design ne convient pas à ce que l'on souhaite avoir.

## :gift: Proposition
Ajouter notre style pix

## :socks: Remarques


## :santa: Pour tester

- support/support-enseignement-secondaire-fr-fr
- support/contact-pix-pro-fr-fr
- support/support-particulier-int
- support/support-eleves-fr-be

Idéalement, il faudra repasser sur tous les formulaires envoyés par easiware et disponibles sur prismic, car on ne peut pas faire confiance au contenu qu'ils nous envoient.
