### PR TITLE
[FEATURE] Créer la page de support (PIX-10837)

### DIFF
--- a/components/SupportPersonaCard.vue
+++ b/components/SupportPersonaCard.vue
@@ -1,0 +1,95 @@
+<template>
+  <article role="article" class="support-persona-card">
+    <!-- TODO: When Nuxt 3 update, switch to a nuxt-link component -->
+    <a class="support-persona-card__link" :href="cardLink">
+      <img
+        v-if="data.icon"
+        :src="data.icon.url"
+        alt=""
+        class="support-persona-card__icon"
+      />
+      <div class="support-persona-card__wrapper">
+        <h3 class="support-persona-card__name">
+          {{ data.name[0].text }}
+        </h3>
+        <p v-if="data.description[0]" class="support-persona-card__description">
+          {{ data.description[0].text }}
+        </p>
+      </div>
+    </a>
+  </article>
+</template>
+
+<script>
+export default {
+  props: {
+    data: {
+      type: Object,
+      required: true,
+    },
+  },
+  computed: {
+    cardLink() {
+      return this.data.faq_link.url
+        ? this.data.faq_link.url
+        : `/support/persona/${this.data.uri}`
+    },
+  },
+}
+</script>
+
+<style lang="scss">
+.support-persona-card {
+  height: 100%;
+}
+
+.support-persona-card__link {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding: 1rem;
+  background-color: white;
+  border: 1px solid transparent;
+  box-shadow: 0px 4px 8px 0px $grey-20;
+  border-radius: 8px;
+
+  &:hover,
+  &:focus {
+    border-color: #613fdd;
+  }
+
+  &:active {
+    background-color: $grey-10;
+    border-color: #613fdd;
+    box-shadow: 0px 4px 8px 0px $grey-30;
+  }
+}
+
+.support-persona-card__name {
+  font-size: 1.25rem;
+  color: $grey-90;
+  margin: 0;
+  padding-bottom: 0.25rem;
+}
+
+.support-persona-card__icon {
+  width: 80px;
+  height: 80px;
+  object-fit: contain;
+  padding: 0.5rem;
+  margin-right: 0.5rem;
+}
+
+.support-persona-card__description {
+  color: $grey-50;
+  font-family: $font-roboto;
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.support-persona-card__wrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+</style>

--- a/config/localization/translations/en.js
+++ b/config/localization/translations/en.js
@@ -79,7 +79,8 @@ export default {
   },
   'skip-link': 'Skip to content',
   back: 'Go back',
-  support : {
-    "persona-subtitle": "Choose who you are?"
-  }
+  support: {
+    title: 'Who are you?',
+    subtitle: 'Find help adapted to your context.',
+  },
 }

--- a/config/localization/translations/en.js
+++ b/config/localization/translations/en.js
@@ -78,4 +78,8 @@ export default {
     'change-locale-switcher-button': 'Change',
   },
   'skip-link': 'Skip to content',
+  back: 'Go back',
+  support : {
+    "persona-subtitle": "Choose who you are?"
+  }
 }

--- a/config/localization/translations/fr-be.js
+++ b/config/localization/translations/fr-be.js
@@ -79,7 +79,8 @@ export default {
   },
   'skip-link': 'Aller au contenu',
   back: 'Retour',
-  support : {
-    "persona-subtitle": "Choisissez qui vous êtes ?"
-  }
+  support: {
+    title: 'Vous êtes ?',
+    subtitle: 'Trouvez de l’aide adapté à votre contexte.',
+  },
 }

--- a/config/localization/translations/fr-be.js
+++ b/config/localization/translations/fr-be.js
@@ -78,4 +78,8 @@ export default {
     'change-locale-switcher-button': 'Changer',
   },
   'skip-link': 'Aller au contenu',
+  back: 'Retour',
+  support : {
+    "persona-subtitle": "Choisissez qui vous êtes ?"
+  }
 }

--- a/config/localization/translations/fr-fr.js
+++ b/config/localization/translations/fr-fr.js
@@ -79,7 +79,8 @@ export default {
   },
   'skip-link': 'Aller au contenu',
   back: 'Retour',
-  support : {
-    "persona-subtitle": "Choisissez qui vous êtes ?"
-  }
+  support: {
+    title: 'Vous êtes ?',
+    subtitle: 'Trouvez de l’aide adapté à votre contexte.',
+  },
 }

--- a/config/localization/translations/fr-fr.js
+++ b/config/localization/translations/fr-fr.js
@@ -78,4 +78,8 @@ export default {
     'change-locale-switcher-button': 'Changer',
   },
   'skip-link': 'Aller au contenu',
+  back: 'Retour',
+  support : {
+    "persona-subtitle": "Choisissez qui vous êtes ?"
+  }
 }

--- a/config/localization/translations/fr.js
+++ b/config/localization/translations/fr.js
@@ -79,7 +79,8 @@ export default {
   },
   'skip-link': 'Aller au contenu',
   back: 'Retour',
-  support : {
-    "persona-subtitle": "Choisissez qui vous êtes ?"
-  }
+  support: {
+    title: 'Vous êtes ?',
+    subtitle: 'Trouvez de l’aide adapté à votre contexte.',
+  },
 }

--- a/config/localization/translations/fr.js
+++ b/config/localization/translations/fr.js
@@ -78,4 +78,8 @@ export default {
     'change-locale-switcher-button': 'Changer',
   },
   'skip-link': 'Aller au contenu',
+  back: 'Retour',
+  support : {
+    "persona-subtitle": "Choisissez qui vous êtes ?"
+  }
 }

--- a/pages/pix-site/_custom-page.vue
+++ b/pages/pix-site/_custom-page.vue
@@ -9,6 +9,9 @@
     <div v-if="type === SLICES_PAGE">
       <prismic-custom-slice-zone :slices="slices" />
     </div>
+    <div v-if="type === SUPPORT_PERSONA_PAGE">
+      <prismic-custom-slice-zone :slices="slices" />
+    </div>
   </div>
 </template>
 

--- a/pages/pix-site/support/_persona.vue
+++ b/pages/pix-site/support/_persona.vue
@@ -17,15 +17,10 @@
         </h1>
       </div>
     </section>
-    <h2 class="persona__subtitle">{{ $t('support.persona-subtitle') }}</h2>
+    <h2 class="persona__subtitle">{{ $t('support.title') }}</h2>
     <ul class="persona__children">
       <li v-for="child in currentPersonaChildren" :key="child.uid">
-        <a :href="child.data.faq_link.url">
-          <img v-if="child.data.icon" :src="child.data.icon.url" alt="" />
-          <h3>
-            {{ child.data.name[0].text }}
-          </h3>
-        </a>
+        <support-persona-card :data="child.data" />
       </li>
     </ul>
   </div>
@@ -33,8 +28,13 @@
 
 <script>
 import { DOCUMENTS } from '~/services/document-fetcher'
+import SupportPersonaCard from '~/components/SupportPersonaCard.vue'
 
 export default {
+  name: 'SupportPersona',
+  components: {
+    SupportPersonaCard,
+  },
   nuxtI18n: {
     paths: {
       en: '/support/persona/:uri',
@@ -74,8 +74,13 @@ export default {
 </script>
 
 <style lang="scss">
+.persona {
+  padding-bottom: 2rem;
+  background-color: $grey-10;
+}
+
 .persona__header {
-  background-color: #613FDD;
+  background-color: #613fdd;
   border-bottom-left-radius: 1rem;
   border-bottom-right-radius: 1rem;
 }
@@ -87,7 +92,7 @@ export default {
   align-items: center;
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem 1rem 3rem 1rem;
+  padding: 1.5rem 1rem 2.5rem 1rem;
   color: white;
 }
 
@@ -99,16 +104,17 @@ export default {
 
 .persona-header__icon {
   filter: brightness(0) invert(1);
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
   width: 60px;
-  height: auto;
+  height: 60px;
+  object-fit: contain;
 }
 
 .persona-header__back-button {
   align-self: flex-start;
   color: white;
   font-family: $font-roboto;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.25rem;
 
   &:hover {
     text-decoration: underline;
@@ -126,10 +132,10 @@ export default {
 
 .persona__children {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(min(400px, 100%), 1fr));
   gap: 1rem;
   max-width: 1280px;
-  margin: 1.5rem auto 2rem;
+  margin: 1.5rem auto 0;
   padding: 0 16px;
   list-style: none;
 

--- a/pages/pix-site/support/_persona.vue
+++ b/pages/pix-site/support/_persona.vue
@@ -1,0 +1,144 @@
+<template>
+  <div class="persona">
+    <section class="persona__header">
+      <div class="persona-header__wrapper">
+        <nuxt-link to="/support" class="persona-header__back-button">
+          <fa icon="arrow-left" />
+          {{ $t('back') }}
+        </nuxt-link>
+        <img
+          v-if="currentPersona.data.icon"
+          class="persona-header__icon"
+          :src="currentPersona.data.icon.url"
+          alt=""
+        />
+        <h1 class="persona-header__title">
+          {{ currentPersona.data.name[0].text }}
+        </h1>
+      </div>
+    </section>
+    <h2 class="persona__subtitle">{{ $t('support.persona-subtitle') }}</h2>
+    <ul class="persona__children">
+      <li v-for="child in currentPersonaChildren" :key="child.uid">
+        <a :href="child.data.faq_link.url">
+          <img v-if="child.data.icon" :src="child.data.icon.url" alt="" />
+          <h3>
+            {{ child.data.name[0].text }}
+          </h3>
+        </a>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+import { DOCUMENTS } from '~/services/document-fetcher'
+
+export default {
+  nuxtI18n: {
+    paths: {
+      en: '/support/persona/:uri',
+      fr: '/support/persona/:uri',
+      'fr-fr': '/support/persona/:uri',
+      'fr-be': '/support/persona/:uri',
+    },
+  },
+  async asyncData({ app, error, route }) {
+    try {
+      const locale = app.i18n.locale || app.i18n.defaultLocale
+      const documents = await app.$prismic.api.query(
+        [
+          app.$prismic.predicates.at(
+            'document.type',
+            DOCUMENTS.SUPPORT_PERSONA_PAGE
+          ),
+        ],
+        { lang: locale }
+      )
+
+      const currentPersona = documents.results.find(
+        (item) => item.uid === route.params.uri
+      )
+
+      const currentPersonaChildren = documents.results.filter((item) => {
+        return item.data.parent_persona.slug === currentPersona.uid
+      })
+
+      return { currentPersona, currentPersonaChildren }
+    } catch (error) {
+      console.error(error)
+      error({ statusCode: 404, message: 'Page not found' })
+    }
+  },
+}
+</script>
+
+<style lang="scss">
+.persona__header {
+  background-color: #613FDD;
+  border-bottom-left-radius: 1rem;
+  border-bottom-right-radius: 1rem;
+}
+
+.persona-header__wrapper {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem 1rem 3rem 1rem;
+  color: white;
+}
+
+.persona-header__title {
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.persona-header__icon {
+  filter: brightness(0) invert(1);
+  margin-bottom: 1.5rem;
+  width: 60px;
+  height: auto;
+}
+
+.persona-header__back-button {
+  align-self: flex-start;
+  color: white;
+  font-family: $font-roboto;
+  margin-bottom: 0.5rem;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.persona__subtitle {
+  margin-top: 2rem;
+  text-align: center;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.3;
+  color: $grey-90;
+}
+
+.persona__children {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  max-width: 1280px;
+  margin: 1.5rem auto 2rem;
+  padding: 0 16px;
+  list-style: none;
+
+  li {
+    padding: 0;
+  }
+
+  li::before {
+    content: none;
+  }
+}
+</style>

--- a/pages/pix-site/support/index.vue
+++ b/pages/pix-site/support/index.vue
@@ -1,22 +1,29 @@
 <template>
-  <div>
-    <nuxt-link
-      v-for="item in personas"
-      :key="item.uri"
-      :to="`persona/${item.uri}`"
-      class="support__title"
-    >
-      <img v-if="item.icon" :src="item.icon.url" alt="" />
-      <h2>{{ item.name[0].text }}</h2>
-      <p>{{ item.description[0].text }}</p>
-    </nuxt-link>
+  <div class="support">
+    <section class="support__header">
+      <div class="support-header__wrapper">
+        <h1 class="support-header__title">
+          {{ $t('support.title') }}
+        </h1>
+        <p class="support-header__subtitle">{{ $t('support.subtitle') }}</p>
+      </div>
+    </section>
+    <ul class="support__personas">
+      <li v-for="item in personas" :key="item.uri">
+        <support-persona-card :data="item" />
+      </li>
+    </ul>
   </div>
 </template>
 <script>
 import { DOCUMENTS } from '~/services/document-fetcher'
+import SupportPersonaCard from '~/components/SupportPersonaCard.vue'
 
 export default {
-  name: 'SupportPersonaPage',
+  name: 'Support',
+  components: {
+    SupportPersonaCard,
+  },
   nuxtI18n: {
     paths: {
       en: '/support',
@@ -52,3 +59,57 @@ export default {
   },
 }
 </script>
+
+<style lang="scss">
+.support {
+  padding-bottom: 2rem;
+  background-color: $grey-10;
+}
+
+.support__header {
+  background-color: #613fdd;
+  border-bottom-left-radius: 1rem;
+  border-bottom-right-radius: 1rem;
+}
+
+.support-header__wrapper {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2.5rem 1rem 2rem;
+  color: white;
+}
+
+.support-header__title {
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.support-header__subtitle {
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.support__personas {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(400px, 100%), 1fr));
+  gap: 1rem;
+  max-width: 1280px;
+  margin: 1.5rem auto 0;
+  padding: 0 16px;
+  list-style: none;
+
+  li {
+    padding: 0;
+  }
+
+  li::before {
+    content: none;
+  }
+}
+</style>

--- a/pages/pix-site/support/index.vue
+++ b/pages/pix-site/support/index.vue
@@ -1,0 +1,55 @@
+<template>
+  <div>
+    <div class="support__title" v-for="(item, index) in personas" :key="`persona-${index}`">
+      <h1>{{item.name[0].text}}</h1>
+    </div>
+  </div>
+</template>
+<script>
+import { DOCUMENTS } from '~/services/document-fetcher'
+
+export default {
+  name: 'SupportPersonaPage',
+  nuxtI18n: {
+    paths: {
+      en: '/support',
+      fr: '/support',
+      'fr-fr': '/support',
+      'fr-be': '/support',
+    },
+  },
+  async asyncData({ app, error, req }) {
+    try {
+      const locale = app.i18n.locale || app.i18n.defaultLocale
+      const documents = await app.$prismic.api.query(
+        [
+          app.$prismic.predicates.at(
+            'document.type',
+            DOCUMENTS.SUPPORT_PERSONA_PAGE
+          ),
+        ],
+        { lang: locale }
+      )
+      const personas = documents.results.filter((persona) => {
+        return !persona.data.parent_persona?.slug
+      }).map((persona) => {
+        return persona.data
+      })
+      console.log({personas})
+      return { personas }
+    } catch (error) {
+      console.error(error)
+      error({ statusCode: 404, message: 'Page not found' })
+    }
+  },
+}
+</script>
+
+<style lang="scss">
+.support {
+  &__title {
+
+  }
+}
+
+</style>

--- a/pages/pix-site/support/index.vue
+++ b/pages/pix-site/support/index.vue
@@ -1,8 +1,15 @@
 <template>
   <div>
-    <div class="support__title" v-for="(item, index) in personas" :key="`persona-${index}`">
-      <h1>{{item.name[0].text}}</h1>
-    </div>
+    <nuxt-link
+      v-for="item in personas"
+      :key="item.uri"
+      :to="`persona/${item.uri}`"
+      class="support__title"
+    >
+      <img v-if="item.icon" :src="item.icon.url" alt="" />
+      <h2>{{ item.name[0].text }}</h2>
+      <p>{{ item.description[0].text }}</p>
+    </nuxt-link>
   </div>
 </template>
 <script>
@@ -30,12 +37,13 @@ export default {
         ],
         { lang: locale }
       )
-      const personas = documents.results.filter((persona) => {
-        return !persona.data.parent_persona?.slug
-      }).map((persona) => {
-        return persona.data
-      })
-      console.log({personas})
+      const personas = documents.results
+        .filter((persona) => {
+          return !persona.data.parent_persona?.slug
+        })
+        .map((persona) => {
+          return { uri: persona.uid, ...persona.data }
+        })
       return { personas }
     } catch (error) {
       console.error(error)
@@ -44,12 +52,3 @@ export default {
   },
 }
 </script>
-
-<style lang="scss">
-.support {
-  &__title {
-
-  }
-}
-
-</style>

--- a/services/document-fetcher.js
+++ b/services/document-fetcher.js
@@ -8,6 +8,7 @@ export const DOCUMENTS = {
   FORM_PAGE: 'form_page',
   EASIWARE_FORM_PAGE: 'easiware_form',
   SLICES_PAGE: 'slices_page',
+  SUPPORT_PERSONA_PAGE: 'support_persona',
   STATISTIQUES: 'statistiques',
 }
 


### PR DESCRIPTION
## :christmas_tree: Problème
La page de support n'était pas créée.

## :gift: Proposition
Gérer le contenu avec Prismic.
Avoir des cartes cliquables qui renvoie vers la page de personas du support.

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Aller sur la page de `/support`. 
Cliquer sur `Enseignement scolaire` et vérifier la présence des enfants.
