### PR TITLE
[REFACTOR] Utiliser une seule page plus adaptable pour gérer la liste des personas support (PIX-10917).

### DIFF
--- a/components/SupportPersonaCard.vue
+++ b/components/SupportPersonaCard.vue
@@ -1,7 +1,7 @@
 <template>
   <article role="article" class="support-persona-card">
     <!-- TODO: When Nuxt 3 update, switch to a nuxt-link component -->
-    <a class="support-persona-card__link" :href="cardLink">
+    <nuxt-link class="support-persona-card__link" :to="cardLink">
       <img
         v-if="data.icon"
         :src="data.icon.url"
@@ -12,11 +12,14 @@
         <h3 class="support-persona-card__name">
           {{ data.name[0].text }}
         </h3>
-        <p v-if="data.description[0]" class="support-persona-card__description">
+        <p
+          v-if="data.description?.[0]"
+          class="support-persona-card__description"
+        >
           {{ data.description[0].text }}
         </p>
       </div>
-    </a>
+    </nuxt-link>
   </article>
 </template>
 
@@ -30,9 +33,7 @@ export default {
   },
   computed: {
     cardLink() {
-      return this.data.faq_link.url
-        ? this.data.faq_link.url
-        : `/support/persona/${this.data.uri}`
+      return this.data.slug ? `/support/persona/${this.data.slug}` : '#'
     },
   },
 }

--- a/pages/pix-site/support/index.vue
+++ b/pages/pix-site/support/index.vue
@@ -9,8 +9,8 @@
       </div>
     </section>
     <ul class="support__personas">
-      <li v-for="item in personas" :key="item.uri">
-        <support-persona-card :data="item" />
+      <li v-for="persona in mainPersonas" :key="persona.uri">
+        <support-persona-card :data="persona" />
       </li>
     </ul>
   </div>
@@ -35,23 +35,17 @@ export default {
   async asyncData({ app, error, req }) {
     try {
       const locale = app.i18n.locale || app.i18n.defaultLocale
-      const documents = await app.$prismic.api.query(
-        [
-          app.$prismic.predicates.at(
-            'document.type',
-            DOCUMENTS.SUPPORT_PERSONA_PAGE
-          ),
-        ],
+
+      const supportPage = await app.$prismic.api.getSingle(
+        DOCUMENTS.SUPPORT_PERSONA_PAGE,
         { lang: locale }
       )
-      const personas = documents.results
-        .filter((persona) => {
-          return !persona.data.parent_persona?.slug
-        })
-        .map((persona) => {
-          return { uri: persona.uid, ...persona.data }
-        })
-      return { personas }
+
+      const mainPersonas = supportPage.data.body.map(
+        (persona) => persona.primary
+      )
+
+      return { mainPersonas }
     } catch (error) {
       console.error(error)
       error({ statusCode: 404, message: 'Page not found' })

--- a/services/document-fetcher.js
+++ b/services/document-fetcher.js
@@ -8,7 +8,7 @@ export const DOCUMENTS = {
   FORM_PAGE: 'form_page',
   EASIWARE_FORM_PAGE: 'easiware_form',
   SLICES_PAGE: 'slices_page',
-  SUPPORT_PERSONA_PAGE: 'support_persona',
+  SUPPORT_PERSONA_PAGE: 'personas_list',
   STATISTIQUES: 'statistiques',
 }
 


### PR DESCRIPTION
## :unicorn: Problème

Ils nous étaient jusqu'alors impossible de gérer de façon manuelle l'ordre d'affichage des personas.

## :robot: Proposition

Utiliser un unique type de contenu Prismic qui permet d'ajouter des élements et des sous-éléments à volonté.
Chacun de ces éléments peut être déplacé.

## :100: Pour tester

- Visiter la page /support et tester la navigation sur "enseignement scolaire"
- Aller voir dans l'admin Prismic pour vérifier que tout est bien conforme aux attentes
