### PR TITLE
[FEATURE] Amélioration des pages de support

### DIFF
--- a/components/EasiwareForm.vue
+++ b/components/EasiwareForm.vue
@@ -1,5 +1,10 @@
 <template>
-  <div id="easiwareform"></div>
+  <section class="easiware-form">
+    <div class="easiware-form__container">
+      <slot></slot>
+      <div id="easiwareform"></div>
+    </div>
+  </section>
 </template>
 
 <script>
@@ -27,10 +32,19 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-#easiwareform {
-  padding: 40px;
+.easiware-form {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  padding: 2.5rem;
   background-color: #452d9d;
+}
+
+.easiware-form__container {
+  max-width: 34rem;
+  padding: 2rem;
+  background: white;
+  border-radius: 16px;
+  line-height: 1.25;
 }
 </style>

--- a/components/SupportContact.vue
+++ b/components/SupportContact.vue
@@ -1,11 +1,8 @@
 <template>
   <div class="support-contact">
     <h2 class="support-contact__title">
-      {{ $t('support.faq.more-help') }}
+      {{ $t('support.faq.contact-title') }}
     </h2>
-    <p class="support-contact__text">
-      {{ $t('support.faq.contact-text') }}
-    </p>
     <nuxt-link :to="contactLink" class="support-contact__link">
       {{ $t('support.faq.contact-cta') }}
     </nuxt-link>
@@ -35,13 +32,9 @@ export default {
 }
 
 .support-contact__title {
-  font-size: 1.75rem;
+  font-size: 1.25rem;
   font-weight: 700;
-  margin: 0;
-}
-
-.support-contact__text {
-  font-size: 1.125rem;
+  margin: 0 0 1rem;
 }
 
 .support-contact__link {
@@ -51,7 +44,7 @@ export default {
   border-radius: 2rem;
   color: white;
   font-size: 0.875rem;
-  font-weight: 700;
+  font-weight: 500;
 
   &:hover {
     background: $blue;

--- a/config/localization/translations/en.js
+++ b/config/localization/translations/en.js
@@ -80,8 +80,6 @@ export default {
   'skip-link': 'Skip to content',
   back: 'Go back',
   support: {
-    title: 'Who are you?',
-    subtitle: 'Find help adapted to your context.',
     faq: {
       'more-help': 'Do you need more help?',
       'contact-text': 'You can contact us',

--- a/config/localization/translations/en.js
+++ b/config/localization/translations/en.js
@@ -84,8 +84,7 @@ export default {
       'required-info': 'All <span>*</span> fields are required',
     },
     faq: {
-      'more-help': 'Do you need more help?',
-      'contact-text': 'You can contact us',
+      'contact-title': "Can't find the answer to your question?",
       'contact-cta': 'Contact the support',
     },
   },

--- a/config/localization/translations/en.js
+++ b/config/localization/translations/en.js
@@ -80,6 +80,9 @@ export default {
   'skip-link': 'Skip to content',
   back: 'Go back',
   support: {
+    form: {
+      'required-info': 'All <span>*</span> fields are required',
+    },
     faq: {
       'more-help': 'Do you need more help?',
       'contact-text': 'You can contact us',

--- a/config/localization/translations/fr-be.js
+++ b/config/localization/translations/fr-be.js
@@ -80,6 +80,10 @@ export default {
   'skip-link': 'Aller au contenu',
   back: 'Retour',
   support: {
+    form: {
+      'required-info':
+        "Tous les champs marqués d'une <span>*</span> sont obligatoires",
+    },
     faq: {
       'more-help': "Besoin de plus d'aide ?",
       'contact-text': 'Vous pouvez nous contacter',

--- a/config/localization/translations/fr-be.js
+++ b/config/localization/translations/fr-be.js
@@ -80,8 +80,6 @@ export default {
   'skip-link': 'Aller au contenu',
   back: 'Retour',
   support: {
-    title: 'Vous êtes ?',
-    subtitle: 'Trouvez de l’aide adapté à votre contexte.',
     faq: {
       'more-help': "Besoin de plus d'aide ?",
       'contact-text': 'Vous pouvez nous contacter',

--- a/config/localization/translations/fr-be.js
+++ b/config/localization/translations/fr-be.js
@@ -85,8 +85,7 @@ export default {
         "Tous les champs marqués d'une <span>*</span> sont obligatoires",
     },
     faq: {
-      'more-help': "Besoin de plus d'aide ?",
-      'contact-text': 'Vous pouvez nous contacter',
+      'contact-title': 'Vous ne trouvez pas la réponse à votre question ?',
       'contact-cta': 'Contacter le support',
     },
   },

--- a/config/localization/translations/fr-fr.js
+++ b/config/localization/translations/fr-fr.js
@@ -80,6 +80,10 @@ export default {
   'skip-link': 'Aller au contenu',
   back: 'Retour',
   support: {
+    form: {
+      'required-info':
+        "Tous les champs marqués d'une <span>*</span> sont obligatoires",
+    },
     faq: {
       'more-help': "Besoin de plus d'aide ?",
       'contact-text': 'Vous pouvez nous contacter',

--- a/config/localization/translations/fr-fr.js
+++ b/config/localization/translations/fr-fr.js
@@ -80,8 +80,6 @@ export default {
   'skip-link': 'Aller au contenu',
   back: 'Retour',
   support: {
-    title: 'Vous êtes ?',
-    subtitle: 'Trouvez de l’aide adapté à votre contexte.',
     faq: {
       'more-help': "Besoin de plus d'aide ?",
       'contact-text': 'Vous pouvez nous contacter',

--- a/config/localization/translations/fr-fr.js
+++ b/config/localization/translations/fr-fr.js
@@ -85,8 +85,7 @@ export default {
         "Tous les champs marqués d'une <span>*</span> sont obligatoires",
     },
     faq: {
-      'more-help': "Besoin de plus d'aide ?",
-      'contact-text': 'Vous pouvez nous contacter',
+      'contact-title': 'Vous ne trouvez pas la réponse à votre question ?',
       'contact-cta': 'Contacter le support',
     },
   },

--- a/config/localization/translations/fr.js
+++ b/config/localization/translations/fr.js
@@ -80,6 +80,10 @@ export default {
   'skip-link': 'Aller au contenu',
   back: 'Retour',
   support: {
+    form: {
+      'required-info':
+        "Tous les champs marqués d'une <span>*</span> sont obligatoires",
+    },
     faq: {
       'more-help': "Besoin de plus d'aide ?",
       'contact-text': 'Vous pouvez nous contacter',

--- a/config/localization/translations/fr.js
+++ b/config/localization/translations/fr.js
@@ -80,8 +80,6 @@ export default {
   'skip-link': 'Aller au contenu',
   back: 'Retour',
   support: {
-    title: 'Vous êtes ?',
-    subtitle: 'Trouvez de l’aide adapté à votre contexte.',
     faq: {
       'more-help': "Besoin de plus d'aide ?",
       'contact-text': 'Vous pouvez nous contacter',

--- a/config/localization/translations/fr.js
+++ b/config/localization/translations/fr.js
@@ -85,8 +85,7 @@ export default {
         "Tous les champs marqués d'une <span>*</span> sont obligatoires",
     },
     faq: {
-      'more-help': "Besoin de plus d'aide ?",
-      'contact-text': 'Vous pouvez nous contacter',
+      'contact-title': 'Vous ne trouvez pas la réponse à votre question ?',
       'contact-cta': 'Contacter le support',
     },
   },

--- a/pages/pix-site/support/_persona-sub-list.vue
+++ b/pages/pix-site/support/_persona-sub-list.vue
@@ -5,7 +5,9 @@
       :icon="currentPersona.icon.url"
       back-link="/support"
     />
-    <h2 class="personas-sub-list__subtitle">{{ $t('support.title') }}</h2>
+    <h2 class="personas-sub-list__subtitle">
+      {{ currentPersona.sub_persona_title[0].text }}
+    </h2>
     <ul class="personas-sub-list__children">
       <li
         v-for="personaChild in currentPersonaChildren"
@@ -92,16 +94,25 @@ export default {
 }
 
 .personas-sub-list__children {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(400px, 100%), 1fr));
-  gap: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   max-width: 1280px;
   margin: 1.5rem auto 0;
-  padding: 0 16px;
+  padding: 0 0.5rem;
   list-style: none;
 
   li {
-    padding: 0;
+    width: 33.33%;
+    padding: 0.5rem;
+
+    @media (max-width: 1280px) {
+      width: min(400px, 50%);
+    }
+
+    @media (max-width: 800px) {
+      width: min(400px, 100%);
+    }
   }
 
   li::before {

--- a/pages/pix-site/support/faq/_faq-persona.vue
+++ b/pages/pix-site/support/faq/_faq-persona.vue
@@ -165,6 +165,8 @@ export default {
   }
 
   a {
+    display: block;
+    padding: 0.125em 0;
     font-size: 1.125rem;
     color: $blue;
 
@@ -239,7 +241,7 @@ export default {
 .faq-persona-posts__secondary-list {
   margin: 0;
   padding: 1.5rem 0;
-  background: #e6f2fe;
+  background: white;
   border-top: 1px solid $grey-22;
 
   .sub-category {
@@ -257,7 +259,7 @@ export default {
 
   a {
     display: block;
-    padding: 0.25rem 1rem;
+    padding: 0.375rem 1rem;
     font-size: 1rem;
     font-weight: 500;
     color: $communication-dark;

--- a/pages/pix-site/support/form/_support-form.vue
+++ b/pages/pix-site/support/form/_support-form.vue
@@ -1,5 +1,22 @@
 <template>
-  <EasiwareForm :solution-id="solution_id" :form-id="form_id"></EasiwareForm>
+  <EasiwareForm
+    :solution-id="supportForm.solution_id"
+    :form-id="supportForm.form_id"
+  >
+    <h1 v-if="supportForm.form_title?.length" class="easiware-form__title">
+      {{ supportForm.form_title?.[0].text }}
+    </h1>
+    <prismic-rich-text
+      v-if="supportForm.form_introduction?.length"
+      :field="supportForm.form_introduction"
+      class="easiware-form__introduction"
+    />
+    <!-- eslint-disable vue/no-v-html -->
+    <p
+      class="easiware-form__required-info"
+      v-html="$t('support.form.required-info')"
+    />
+  </EasiwareForm>
 </template>
 <script>
 import { DOCUMENTS } from '~/services/document-fetcher'
@@ -17,20 +34,14 @@ export default {
   async asyncData({ app, error, route }) {
     try {
       const locale = app.i18n.locale || app.i18n.defaultLocale
-      const documents = await app.$prismic.api.query(
-        [
-          app.$prismic.predicates.at(
-            'document.type',
-            DOCUMENTS.EASIWARE_FORM_PAGE
-          ),
-          app.$prismic.predicates.at(
-            `my.${DOCUMENTS.EASIWARE_FORM_PAGE}.uid`,
-            route.params.slug
-          ),
-        ],
-        { lang: locale }
+      const supportForm = await app.$prismic.api.getByUID(
+        DOCUMENTS.EASIWARE_FORM_PAGE,
+        route.params.slug,
+        {
+          lang: locale,
+        }
       )
-      return documents.results[0].data
+      return { supportForm: supportForm.data }
     } catch (err) {
       console.error(err)
       error({ statusCode: 404, message: 'Page not found' })
@@ -38,3 +49,33 @@ export default {
   },
 }
 </script>
+
+<style lang="scss" scoped>
+.easiware-form__title {
+  margin-bottom: 1em;
+  text-align: center;
+  font-size: 2rem;
+  font-weight: 700;
+  color: $grey-90;
+}
+
+.easiware-form__introduction {
+  margin: -0.5rem 0 2.5rem;
+  color: $grey-60;
+  font-family: $font-roboto;
+}
+
+.easiware-form__required-info {
+  color: $grey-90;
+  font-family: $font-roboto;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+</style>
+
+<style lang="scss">
+.easiware-form__required-info span {
+  font-weight: 500;
+  color: $red;
+}
+</style>

--- a/pages/pix-site/support/index.vue
+++ b/pages/pix-site/support/index.vue
@@ -2,10 +2,18 @@
   <div class="support">
     <section class="support__header">
       <div class="support-header__wrapper">
-        <h1 class="support-header__title">
-          {{ $t('support.title') }}
+        <h1
+          v-if="supportPageData?.header_title?.length"
+          class="support-header__title"
+        >
+          {{ supportPageData?.header_title?.[0].text }}
         </h1>
-        <p class="support-header__subtitle">{{ $t('support.subtitle') }}</p>
+        <p
+          v-if="supportPageData?.['header_sub-title']?.length"
+          class="support-header__subtitle"
+        >
+          {{ supportPageData?.['header_sub-title']?.[0].text }}
+        </p>
       </div>
     </section>
     <ul class="support__personas">
@@ -45,7 +53,10 @@ export default {
         (persona) => persona.primary
       )
 
-      return { mainPersonas }
+      return {
+        supportPageData: supportPage?.data,
+        mainPersonas,
+      }
     } catch (err) {
       console.error({ err })
       error({ statusCode: 404, message: 'Page not found' })
@@ -90,16 +101,25 @@ export default {
 }
 
 .support__personas {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(400px, 100%), 1fr));
-  gap: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   max-width: 1280px;
   margin: 1.5rem auto 0;
-  padding: 0 16px;
+  padding: 0 0.5rem;
   list-style: none;
 
   li {
-    padding: 0;
+    width: 33.33%;
+    padding: 0.5rem;
+
+    @media (max-width: 1280px) {
+      width: min(400px, 50%);
+    }
+
+    @media (max-width: 800px) {
+      width: min(400px, 100%);
+    }
   }
 
   li::before {

--- a/services/easiware.js
+++ b/services/easiware.js
@@ -49,10 +49,6 @@ export function create(params) {
  #easiformarea {
   font-family: 'Roboto', Arial, sans-serif;
   line-height: 1.25;
-  background-color: white;
-  border-radius: 16px;
-  padding:32px;
-  max-width: 34rem;
 }
 
 [id^="easi_fielddiv"] {


### PR DESCRIPTION
## :unicorn: Problème

Quelques retouches étaient à apporter sur les nouvelles pages de support.

## :robot: Proposition

1. **Page Persona list**
    * Rendre administrable le header
    * Centrer les blocs 

2. **Page Sub persona**
    * Centrer les blocs 
    * Rendre administrable le texte (Vous etes)

3. **Page FAQ** 
    * Changer le fond bleu en fond blanc dans les rubriques

4. **Page Formulaire**
    * Ajouter un titre et un texte à mettre sous le titre administrables dans Prismic

5. **Bloc contact**
    * Modifier le titre et ne plus afficher de sous-texte

## :100: Pour tester

Aller sur la RA et suivre ce chemin :
- page `/support`
  - ✅ Le bloc de la deuxième ligne est censé être centré (vérifier que tout fonctionne bien aussi en responsive) 
- Cliquer sur "Enseignement scolaire"
  - ✅ Les 2 blocs sont centrés sur la page
- Cliquer sur "Collégien ou lycéen"
  - ✅ Vérifier que le contenu des accordéons a bien un fond blanc
- En bas de la page, cliquer sur le lien du bloc "Contacter le support" (qui a le nouveau titre)
  - ✅ Le formulaire a un titre, une introduction et l'indication des champs requis
