### PR TITLE
[BUGFIX] Permettre de revenir sur .org après avoir été sur .fr depuis .org

### DIFF
--- a/pix-site/components/LocaleChoice.vue
+++ b/pix-site/components/LocaleChoice.vue
@@ -9,7 +9,7 @@
         :key="locale.code"
         class="locale-link"
         :href="`${locale.domain}/${locale.code === 'fr-fr' ? '' : locale.code}`"
-        @click="updateLocale(locale.code)"
+        @click="locale.code !== 'fr-fr' && updateLocale(locale.code)"
       >
         <img class="locale-link__icon" :src="'/images/' + locale.icon" alt="" />
         <span class="locale-link__text">{{ locale.name }}</span>

--- a/pix-site/components/LocaleSwitcher.vue
+++ b/pix-site/components/LocaleSwitcher.vue
@@ -74,7 +74,6 @@
           <a
             :href="`${ domainFr || ''}/`"
             :aria-current="localeProperties.code === frFrLocale.code && 'page'"
-            @click="updateLocaleCookie(frFrLocale.code)"
           >
             <img :src="`/images/${frFrLocale.icon}`" alt="" />
             <span>{{ frFrLocale.name }}</span>


### PR DESCRIPTION
## :unicorn: Problème
Lorsque nous choisissons "France" depuis le locale-switcher ou locale-choice, nous settons un cookie `fr-fr` sur le domain `.org`. Quand l'utilisateur revient sur `.org` il est alors redirigé vers `.org/fr-fr` ce qui n'existe pas.

## :robot: Proposition
Ne pas mettre en place de coookie `fr-fr`.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Aller sur `.org/`
- Choisir `FRANCE` , être redirigé vers `.fr`
- Retourner sur `.org/` et voir la page de choix de locale