### PR TITLE
[BUGFIX] Ajouter le script manquant matomo-start-event

### DIFF
--- a/pix-pro/public/scripts/start-matoto-event.js
+++ b/pix-pro/public/scripts/start-matoto-event.js
@@ -1,0 +1,8 @@
+// eslint-disable-next-line no-var,no-use-before-define
+var _mtm = _mtm || []
+
+if (document.querySelector('script[data-matomo-debug-mode="true"]')) {
+  _mtm.push(['enableDebugMode'])
+}
+
+_mtm.push({ 'mtm.startTime': new Date().getTime(), event: 'mtm.Start' })

--- a/pix-site/public/scripts/start-matoto-event.js
+++ b/pix-site/public/scripts/start-matoto-event.js
@@ -1,0 +1,8 @@
+// eslint-disable-next-line no-var,no-use-before-define
+var _mtm = _mtm || []
+
+if (document.querySelector('script[data-matomo-debug-mode="true"]')) {
+  _mtm.push(['enableDebugMode'])
+}
+
+_mtm.push({ 'mtm.startTime': new Date().getTime(), event: 'mtm.Start' })


### PR DESCRIPTION
## :unicorn: Problème
Il manquait le script start-matomo-event.js dans le projet suite à la migration vers Nuxt 3.

## :robot: Proposition
L'ajouter
## :rainbow: Remarques
RAS

## :100: Pour tester
- Vérifier dans la console de la RA qu'il n'y a plus d'erreurs.
