### PR TITLE
[BUGFIX] Rétablir les bannières des hotnews

### DIFF
--- a/shared/components/HotNewsBanner.vue
+++ b/shared/components/HotNewsBanner.vue
@@ -13,35 +13,28 @@
   </div>
 </template>
 
-<script>
-import { documentFetcher } from "@shared/services/document-fetcher";
+<script setup>
+import { ref } from "vue";
+const { client, filter } = usePrismic();
+const { locale: i18nLocale } = useI18n();
 
-export default {
-  name: "HotNewsBanner",
-  data() {
-    return {
-      isOpen: true,
-      hotNews: null,
-    };
-  },
-  async fetch() {
-    const hotNews = await documentFetcher(
-      this.$prismic,
-      this.$i18n
-    ).findHotNewsBanner();
+const { customPrismicRichTextSerializer } = usePrismicRichTextSerializer();
+const isOpen = ref(true);
 
-    this.hotNews = hotNews?.data?.description;
-  },
-  setup() {
-    const { customPrismicRichTextSerializer } = usePrismicRichTextSerializer();
-    return { customPrismicRichTextSerializer };
-  },
-  methods: {
-    closeBanner() {
-      this.isOpen = false;
-    },
-  },
-};
+const { data: hotNews } = await useAsyncData(async () => {
+  const hotNews = await client.get({
+    filters: [
+      filter.at("document.type", 'hot_news'),
+    ],
+    lang: i18nLocale.value,
+  });
+
+  return hotNews?.results[0].data.description
+});
+
+const closeBanner = () => {
+  isOpen.value = false;
+}
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
## :unicorn: Problème
Les bannières HotNews ne s'affichent pas, car utilisent l'ancienne API de Prismic

## :robot: Proposition
Migrer vers les composants v3, et utiliser la nouvelle API Prismic

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Voir la bannière sur la RA