### PR TITLE
[BUGFIX] Ordonner les actualités par le champ date des articles (PIX-11389).

### DIFF
--- a/shared/components/slices/LatestNews.vue
+++ b/shared/components/slices/LatestNews.vue
@@ -1,31 +1,12 @@
 <template>
-  <section
-    v-if="latestNews.length"
-    :id="`slice-${indexForId}`"
-    class="latest-news"
-  >
-    <prismic-rich-text
-      v-if="shouldDisplayTitle && hasTitle"
-      class="latest-news__title"
-      :field="slice.primary.latest_news_title"
-    />
-    <prismic-rich-text
-      v-else
-      class="sr-only"
-      :field="slice.primary.latest_news_title"
-    />
+  <section v-if="latestNews.length" :id="`slice-${indexForId}`" class="latest-news">
+    <prismic-rich-text v-if="shouldDisplayTitle && hasTitle" class="latest-news__title"
+      :field="slice.primary.latest_news_title" />
+    <prismic-rich-text v-else class="sr-only" :field="slice.primary.latest_news_title" />
     <ul class="latest-news__list">
-      <news-item-card
-        v-for="(item, index) in latestNews"
-        :key="`item-${index}`"
-        :slice="item.data"
-        :uid="item.uid"
-      />
+      <news-item-card v-for="(item, index) in latestNews" :key="`item-${index}`" :slice="item.data" :uid="item.uid" />
     </ul>
-    <nuxt-link
-      class="latest-news__link-to"
-      :to="localePath(`/${t('news-page-prefix')}`, i18nLocale)"
-    >
+    <nuxt-link class="latest-news__link-to" :to="localePath(`/${t('news-page-prefix')}`, i18nLocale)">
       {{ slice.primary.latest_news_redirection_link_text }}
     </nuxt-link>
   </section>
@@ -51,6 +32,10 @@ const props = defineProps({
 const latestNews = await client.getAllByType("news_item", {
   lang: i18nLocale.value,
   limit: 3,
+  orderings: {
+    field: "my.news_item.date",
+    direction: 'desc',
+  },
 });
 
 /* Computed */

--- a/shared/pages/news/index.vue
+++ b/shared/pages/news/index.vue
@@ -14,12 +14,7 @@
       </h2>
       <ul class="news__list">
         <template v-if="newsItems && newsItems.length">
-          <news-item-card
-            v-for="(item, index) in newsItems"
-            :key="`item-${index}`"
-            :slice="item.data"
-            :uid="item.uid"
-          />
+          <news-item-card v-for="(item, index) in newsItems" :key="`item-${index}`" :slice="item.data" :uid="item.uid" />
         </template>
         <template v-else>
           <p>{{ t("news-page-no-news") }}</p>
@@ -28,6 +23,7 @@
     </main>
   </div>
 </template>
+
 <script setup>
 const { client } = usePrismic();
 const { locale: i18nLocale, t } = useI18n();
@@ -50,6 +46,10 @@ useHead({
 /* Fetch news items */
 const { data: newsItems } = await useAsyncData(() => {
   return client.getAllByType("news_item", {
+    orderings: {
+      field: "my.news_item.date",
+      direction: 'desc',
+    },
     lang: i18nLocale.value,
   });
 });
@@ -57,6 +57,7 @@ const { data: newsItems } = await useAsyncData(() => {
 
 <style lang="scss">
 .news {
+
   h1,
   h2,
   h3,


### PR DESCRIPTION
## :unicorn: Problème
La liste des articles n'était pas triée par le champ date spécifique des articles.

## :robot: Proposition
Utiliser le champ date pour trier la liste des articles affichés (page /actualites et page d'accueil).

## ℹ️  Remarque
Ne pas prêter attention au formatage Prettier

## :100: Pour tester
Visualiser les articles en RA et vérifier que les dates sont bien dans un ordre décroissant.
