### PR TITLE
[FEATURE] Modifier le libellé du choix fr-BE sur la page d'accueil de pix.org (PIX-11226)

### DIFF
--- a/pix-site/i18n.config.ts
+++ b/pix-site/i18n.config.ts
@@ -24,7 +24,7 @@ const reachableLocales = [
   {
     code: "fr-be",
     file: "fr-be.js",
-    name: "Fédération Wallonie-Bruxelles",
+    name: "Belgique (Français)",
     icon: "flag-be.svg",
     domain: process.env.DOMAIN_ORG
   }

--- a/shared/translations/en.js
+++ b/shared/translations/en.js
@@ -5,15 +5,7 @@ export default {
       "international-label": "International languages list"
     },
     locales: {
-      fr: "International FR",
-      "fr-fr": "France",
-      en: "International EN",
-      "fr-be": "Fédération Wallonie-Bruxelles",
-      france: "France",
-      english: "English",
-      french: "Français",
       international: "International",
-      fwb: "Fédération Wallonie-Bruxelles",
       "contact-digital-mediation": {
         "page-title": "Information request",
         "form-id": "28758"

--- a/shared/translations/fr-be.js
+++ b/shared/translations/fr-be.js
@@ -5,15 +5,7 @@ export default {
       "international-label": "Liste des sites internationaux"
     },
     locales: {
-      fr: "International FR",
-      "fr-fr": "France",
-      en: "International EN",
-      "fr-be": "Fédération Wallonie-Bruxelles",
-      france: "France",
-      english: "English",
-      french: "Français",
-      international: "International",
-      fwb: "Fédération Wallonie-Bruxelles"
+      international: "International"
     }
   },
   "contact-digital-mediation": {

--- a/shared/translations/fr-fr.js
+++ b/shared/translations/fr-fr.js
@@ -5,15 +5,7 @@ export default {
       "international-label": "Liste des sites internationaux"
     },
     locales: {
-      fr: "International FR",
-      "fr-fr": "France",
-      en: "International EN",
-      "fr-be": "Fédération Wallonie-Bruxelles",
-      france: "France",
-      english: "English",
-      french: "Français",
-      international: "International",
-      fwb: "Fédération Wallonie-Bruxelles"
+      international: "International"
     }
   },
   "contact-digital-mediation": {

--- a/shared/translations/fr.js
+++ b/shared/translations/fr.js
@@ -5,15 +5,7 @@ export default {
       "international-label": "Liste des sites internationaux"
     },
     locales: {
-      fr: "International FR",
-      "fr-fr": "France",
-      en: "International EN",
-      "fr-be": "Fédération Wallonie-Bruxelles",
-      france: "France",
-      english: "English",
-      french: "Français",
-      international: "International",
-      fwb: "Fédération Wallonie-Bruxelles"
+      international: "International"
     }
   },
   "contact-digital-mediation": {


### PR DESCRIPTION
## :unicorn: Problème
Avec l'arrivée d'une nouvelle locale pour les belges néerlandophones, nous devons renommer le choix de la locale pour les belges francophones.

## :robot: Proposition
Modifier `Fédération Wallonie Bruxelles` pour `Belgique (Français)`.

## :rainbow: Remarques
Des clés de traduction ont été supprimées car depuis la migration en Nuxt3, les valeurs des codes et des noms des différentes locales sont récupérées depuis le fichier de configuration de l'I18n `pix-site/pix-site/i18n.config.ts`.

## :100: Pour tester

1. Se rendre sur la page des choix de locale de Pix Site en domaine .org (supprimer vos cookies)
2. Vérifier que le libellé de la locale `fr-BE` est bien `Belgique (Français)`
3. Cliquer sur cette locale
4. Arrivée sur la page d'accueil, vérifier dans locale switcher, présent dans la barre de navigation, que le libellé de la locale `fr-BE` est bien `Belgique (Français)`