### PR TITLE
[FEATURE] Ajouter sur la page de choix de locale, l'option "België (Nederlands)" (PIX-11227)

### DIFF
--- a/pix-site/i18n.config.ts
+++ b/pix-site/i18n.config.ts
@@ -27,6 +27,13 @@ const reachableLocales = [
     name: "Belgique (Français)",
     icon: "flag-be.svg",
     domain: process.env.DOMAIN_ORG
+  },
+  {
+    code: "nl-be",
+    file: "nl-be.js",
+    name: "België (Nederlands)",
+    icon: "flag-be.svg",
+    domain: process.env.DOMAIN_ORG
   }
 ];
 

--- a/shared/components/slices/NavigationGroup.vue
+++ b/shared/components/slices/NavigationGroup.vue
@@ -11,7 +11,7 @@
           :key="`link-${index}`"
           class="navigation-group-link"
         >
-          <nuxt-link :to="getEnvironmentUrl(link.link_url.url)">
+          <nuxt-link v-if="link.link_url?.url" :to="getEnvironmentUrl(link.link_url.url)">
             <prismic-rich-text :field="link.link_name" />
           </nuxt-link>
         </li>

--- a/shared/pages/locale-home.vue
+++ b/shared/pages/locale-home.vue
@@ -15,6 +15,7 @@ defineI18nRoute({
     fr: "/",
     "fr-fr": "/",
     "fr-be": "/",
+    "nl-be": "/"
   },
 });
 

--- a/shared/translations/nl-be.js
+++ b/shared/translations/nl-be.js
@@ -1,0 +1,86 @@
+export default {
+  "locale-switcher": {
+    button: {
+      "main-label": "Choix de la langue",
+      "international-label": "Liste des sites internationaux"
+    },
+    locales: {
+      fr: "International FR",
+      "fr-fr": "France",
+      en: "International EN",
+      "nl-be": "Fédération Wallonie-Bruxelles",
+      france: "France",
+      english: "English",
+      french: "Français",
+      international: "International",
+      fwb: "Fédération Wallonie-Bruxelles"
+    }
+  },
+  "contact-digital-mediation": {
+    "page-title": "Demande d'information",
+    "form-id": "24665"
+  },
+  "higher-education-establishment-registration": {
+    "page-title": "Demande d’espace Pix Orga",
+    "form-id": "22367"
+  },
+  "pix-certification-application": {
+    "page-title": "Demande d'agrément comme centre de certification Pix",
+    "form-id": "23331"
+  },
+  "pix-orga-registration": {
+    "page-title": "Demande d'information",
+    "form-id": "22370"
+  },
+  "pix-orga-higher-school-registration": {
+    "page-title": "Finalisez votre demande d'espace Pix Orga",
+    "form-id": "22797"
+  },
+  "news-page-prefix": "actualites",
+  "news-page-title": "Actualités",
+  "news-page-title-level-two": "Liste des actualités",
+  "news-page-no-news": "Il n’y a pas encore d'actualités",
+  announcement: "Annonce",
+  engineering: "Ingénierie",
+  event: "Événement",
+  feature: "Nouveauté",
+  society: "Société",
+  form: {
+    "not-supported":
+      "Votre navigateur ne supporte pas les iframes. Le formulaire de contact ne peut pas être affiché. Merci d'utiliser une autre méthode de contact (téléphone, fax, etc.)"
+  },
+  "page-titles": {
+    "contact-digital-mediation": "Demande d'information | Pix",
+    "higher-education-establishment-registration":
+      "Demande d'espace | Pix Orga sup",
+    news: "Actualités | Pix",
+    "pix-certification-application":
+      "Demande d'agrément comme centre de certification | Pix",
+    "pix-orga-higher-school-registration":
+      "Finaliser la demande d'espace | Pix Orga sup",
+    "pix-orga-registration": "Demande d'information | Pix pro",
+    support: "Support | Pix"
+  },
+  "preview-page-load": "Chargement de la page de prévisualisation...",
+  "home-page-url": `${process.env.DOMAIN_ORG}/nl-be/`,
+  "error-content": `
+    <p>Oups ! Un problème est survenu, mais pas de panix !</p>
+    <p>Vous pouvez revenir sur la
+    <a href="${process.env.DOMAIN_FR}/nl-be/">page d'accueil</a>.
+    <br/>Si vous avez besoin d’aide, vous pouvez consulter le
+    <a href="https://support.pix.org/fr/support/home">support</a>.
+    </p>`,
+  "locale-suggestion-banner-text": `Vous semblez ne pas être en France. Voulez-vous accéder au <a href="${process.env.DOMAIN_ORG}">site Pix international</a> ?`,
+  "skip-link": "Aller au contenu",
+  "burger-menu": {
+    name: "Navigation principale",
+    open: "Ouvrir le menu",
+    close: "Fermer le menu",
+    "open-category": "Ouvrir la catégorie",
+    "close-category": "Fermer la catégorie",
+    "open-locale-switcher": "Ouvrir le changement de langue",
+    "close-locale-switcher": "Fermer le changement de langue",
+    "change-locale-switcher": "Changer la langue",
+    "change-locale-switcher-button": "Changer"
+  }
+};


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, il n'est pas possible de choisir la locale **België (Nederlands)** _(nl-BE)_.

## :robot: Proposition

Ajouter sur la page de choix de locale l'option **België (Nederlands)**.

## :rainbow: Remarques

RAS

## :100: Pour tester

#### Via la RA

1. Ouvrir la page https://site-pr619.review.pix.org/
2. Si vous avez déjà un cookie nommé locale, il faudra le supprimer et revenir sur la page https://site-pr619.review.pix.org/
3. Constater l'affichage de l'option België (Nederlands)

#### En local

1. Lancer la commande `npm run dev` dans le dossier `pix-site/pix-site`
2. S'assurer que votre fichier `.env` soit complet
3. Ouvrir la page http://localhost:7000
4. Si vous avez déjà un cookie nommé locale, il faudra le supprimer et revenir sur la page http://localhost:7000
5. Constater l'affichage de l'option België (Nederlands)