### PR TITLE
[FEATURE] Ajouter le choix nl-BE dans le locale switcher version desktop sur pix site (PIX-11228)

### DIFF
--- a/pix-site/components/LocaleSwitcher.vue
+++ b/pix-site/components/LocaleSwitcher.vue
@@ -68,6 +68,19 @@
           </a>
         </li>
         <li
+          v-if="nlBeLocale"
+          :class="{ active: localeProperties.code === nlBeLocale.code }"
+        >
+          <a
+            :href="`${ domainOrg || ''}/nl-be`"
+            :aria-current="localeProperties.code === nlBeLocale.code && 'page'"
+            @click="updateLocaleCookie(nlBeLocale.code)"
+          >
+            <img :src="`/images/${nlBeLocale.icon}`" alt="" />
+            <span>{{ nlBeLocale.name }}</span>
+          </a>
+        </li>
+        <li
           v-if="frFrLocale"
           :class="{ active: localeProperties.code === frFrLocale.code }"
         >
@@ -97,6 +110,7 @@ const frLocale = reachableLocales.find((l) => l.code === "fr");
 const enLocale = reachableLocales.find((l) => l.code === "en");
 const frFrLocale = reachableLocales.find((l) => l.code === "fr-fr");
 const frBeLocale = reachableLocales.find((l) => l.code === "fr-be");
+const nlBeLocale = reachableLocales.find((l) => l.code === "nl-be");
 
 const buttonRef = ref(null);
 const languagesMenuRef = ref(null);


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il n'est pas possible de choisir la locale België (Nederlands) (nl-BE) dans le locale switcher.

## :robot: Proposition
Ajouter dans le locale switcher l'option België (Nederlands).

## :rainbow: Remarques
RAS.

## :100: Pour tester
### Via la RA

1. Ouvrir la page https://site-pr620.review.pix.org/
2. Si vous avez déjà un cookie nommé locale, il faudra le supprimer et revenir sur la page https://site-pr620.review.pix.org/
3. Sélectionnez l'option België (Nederlands)
4. Arrivez sur la page d'accueil, constatez que  l'option België (Nederlands) est présente dans le locale switcher

### En local

1. Lancer la commande npm run dev dans le dossier pix-site/pix-site
2. S'assurer que votre fichier .env soit complet
3. Ouvrir la page http://localhost:7000/
4. Si vous avez déjà un cookie nommé locale, il faudra le supprimer et revenir sur la page http://localhost:7000/
5. Sélectionnez l'option België (Nederlands)
6. Arrivez sur la page d'accueil, constatez que  l'option België (Nederlands) est présente dans le locale switcher

