### PR TITLE
[BUGFIX] Rétablir la preview Prismic (PIX-11390).

### DIFF
--- a/pix-pro/services/get-routes-to-generate.js
+++ b/pix-pro/services/get-routes-to-generate.js
@@ -31,12 +31,10 @@ async function getRoutesInPage(prismicClient, page, locales) {
     ({ code }) => code
   )
 
-  const filteredRoutesPromise = results
+  const routes = results
     .filter(({ uid }) => Boolean(uid))
     .filter(({ lang }) => localesToBuild.includes(lang))
     .map(linkResolver)
-
-  const routes = await Promise.all(filteredRoutesPromise)
 
   return { totalPages, routes }
 }

--- a/pix-site/services/get-routes-to-generate.js
+++ b/pix-site/services/get-routes-to-generate.js
@@ -30,12 +30,10 @@ async function getRoutesInPage(prismicClient, page, locales) {
     ({ code }) => code
   )
 
-  const filteredRoutesPromise = results
+  const routes = results
     .filter(({ uid }) => Boolean(uid))
     .filter(({ lang }) => localesToBuild.includes(lang))
     .map(linkResolver)
-
-  const routes = await Promise.all(filteredRoutesPromise)
 
   return { totalPages, routes }
 }

--- a/shared/components/NewsItemPost.vue
+++ b/shared/components/NewsItemPost.vue
@@ -31,6 +31,7 @@
 
 <script setup>
 import { useDateFormat } from "@vueuse/core";
+const { locale: i18nLocale } = useI18n();
 
 const { customPrismicRichTextSerializer } = usePrismicRichTextSerializer();
 

--- a/shared/nuxt.config.ts
+++ b/shared/nuxt.config.ts
@@ -36,6 +36,7 @@ const config = {
     clientConfig: {
       accessToken: process.env.PRISMIC_API_TOKEN,
     },
+    linkResolver: '../shared/services/link-resolver.js',
   },
   runtimeConfig: {
     public: {

--- a/shared/services/link-resolver.js
+++ b/shared/services/link-resolver.js
@@ -1,12 +1,33 @@
 import { DOCUMENTS, TAGS } from './document-fetcher'
+import * as en from '../translations/en.js'
+import * as fr from '../translations/fr.js'
+import * as frBe from '../translations/fr-be.js'
+import * as frFr from '../translations/fr-fr.js'
 
-export async function linkResolver(doc) {
+const newsPagePrefixes = {
+  en:
+    en.default['news-page-prefix'].body?.static ||
+    en.default['news-page-prefix'].b?.s ||
+    en.default['news-page-prefix'],
+  fr:
+    fr.default['news-page-prefix'].body?.static ||
+    fr.default['news-page-prefix'].b?.s ||
+    fr.default['news-page-prefix'],
+  'fr-be':
+    frBe.default['news-page-prefix'].body?.static ||
+    frBe.default['news-page-prefix'].b?.s ||
+    frBe.default['news-page-prefix'],
+  'fr-fr':
+    frFr.default['news-page-prefix'].body?.static ||
+    frFr.default['news-page-prefix'].b?.s ||
+    frFr.default['news-page-prefix'],
+}
+
+export function linkResolver(doc) {
   const locale = doc.lang !== 'fr-fr' ? `/${doc.lang}` : ''
 
-  const translations = await import(`../translations/${doc.lang}.js`)
-
-  const { default: { 'news-page-prefix': newsPagePrefix } } = translations
   if (doc.type === DOCUMENTS.NEWS_ITEM) {
+    const newsPagePrefix = newsPagePrefixes[doc.lang]
     return `${locale}/${newsPagePrefix}/${doc.uid}`
   }
   if (doc.tags?.includes(TAGS.INDEX)) {

--- a/shared/tests/services/link-resolver.test.js
+++ b/shared/tests/services/link-resolver.test.js
@@ -21,9 +21,9 @@ describe('linkResolver', () => {
   ]
 
   testCases.forEach(({ lang, uid, expectedUrl }) => {
-    test(`it should return ${expectedUrl}`, async () => {
+    test(`it should return ${expectedUrl}`, () => {
       // when
-      const result = await linkResolver({ type: 'anything', lang, uid })
+      const result = linkResolver({ type: 'anything', lang, uid })
 
       // then
       expect(result).toEqual(expectedUrl)
@@ -50,9 +50,9 @@ describe('linkResolver', () => {
     ]
 
     testCases.forEach(({ lang, uid, expectedUrl }) => {
-      test(`it should add prefix for lang ${lang}`, async () => {
+      test(`it should add prefix for lang ${lang}`, () => {
         // when
-        const result = await linkResolver({ type: DOCUMENTS.NEWS_ITEM, lang, uid })
+        const result = linkResolver({ type: DOCUMENTS.NEWS_ITEM, lang, uid })
 
         // then
         expect(result).toEqual(expectedUrl)
@@ -80,9 +80,9 @@ describe('linkResolver', () => {
     ]
 
     testCases.forEach(({ tags, lang, expectedUrl }) => {
-      test(`it should return root url for lang ${lang} when one of tag is index`, async () => {
+      test(`it should return root url for lang ${lang} when one of tag is index`, () => {
         // when
-        const result = await linkResolver({ tags, lang })
+        const result = linkResolver({ tags, lang })
 
         // then
         expect(result).toEqual(expectedUrl)


### PR DESCRIPTION
## :unicorn: Problème
Les preview prismic ne fonctionnent plus depuis la migration Nuxt3.

## :robot: Proposition
Corriger le bug en ajoutant:
- Dans nuxt.config.ts une propriété linkResolver dans l'objet prismic qui pointe vers le fichier correspondant
- En faisant du rétro engineering, on s'est rendu compte que la preview Prismic nécessite  la fonction `linkResolver(doc)` synchrone à cause du fonctionnement des preview Prismic (voir le [code](https://github.com/prismicio/prismic-client/blob/master/src/createClient.ts#L1490) correspondant).

## :rainbow: Remarques
RAS

## :100: Pour tester
- Vérifier que l'app fonctionne bien
- Vérifier que la preview fonctionne sur la RA.
