### PR TITLE
[TECH] Remplacer l'utilisation du terme "language" par "locale" (PIX-11456)

### DIFF
--- a/pix-pro/components/LocaleSwitcher.vue
+++ b/pix-pro/components/LocaleSwitcher.vue
@@ -4,18 +4,18 @@
       <button
         ref="buttonRef"
         class="locale-switcher__button"
-        @click="toggleLanguagesMenu"
-        @keyup.esc="isLanguagesMenuVisible && toggleLanguagesMenu()"
+        @click="toggleLocalesMenu"
+        @keyup.esc="isLocalesMenuVisible && toggleLocalesMenu()"
         :aria-label="t('locale-switcher.button.main-label')"
         aria-haspopup="menu"
-        :aria-expanded="isLanguagesMenuVisible"
+        :aria-expanded="isLocalesMenuVisible"
       >
         <img :src="`/images/${localeProperties.icon}`" alt="" />
         <span>{{ localeProperties.name }}</span>
       </button>
       <ul
-        v-show="isLanguagesMenuVisible"
-        ref="languagesMenuRef"
+        v-show="isLocalesMenuVisible"
+        ref="localesMenuRef"
         class="locale-switcher__languages-menu"
       >
         <li>
@@ -27,7 +27,7 @@
             <img :src="`/images/${frLocale.icon}`" alt="" />
             <span>{{ t("locale-switcher.locales.international") }}</span>
           </button>
-          <ul v-show="isInternationalLanguagesVisible" class="sub-menu">
+          <ul v-show="isInternationalLocalesVisible" class="sub-menu">
             <li
               v-if="frLocale"
               :class="{ active: localeProperties.code === frLocale.code }"
@@ -85,25 +85,25 @@ const enLocale = reachableLocales.find((l) => l.code === "en");
 const frFrLocale = reachableLocales.find((l) => l.code === "fr-fr");
 
 const buttonRef = ref(null);
-const languagesMenuRef = ref(null);
-const isLanguagesMenuVisible = ref(false);
-const isInternationalLanguagesVisible = ref(false);
+const localesMenuRef = ref(null);
+const isLocalesMenuVisible = ref(false);
+const isInternationalLocalesVisible = ref(false);
 
 const config = useAppConfig();
 const domainFr = config.domainFr;
 const domainOrg = config.domainOrg;
 
-function toggleLanguagesMenu() {
-  isLanguagesMenuVisible.value = !isLanguagesMenuVisible.value;
+function toggleLocalesMenu() {
+  isLocalesMenuVisible.value = !isLocalesMenuVisible.value;
 
-  if (!isLanguagesMenuVisible.value) {
-    isInternationalLanguagesVisible.value = false;
+  if (!isLocalesMenuVisible.value) {
+    isInternationalLocalesVisible.value = false;
   }
 }
 
 function toggleInternationalLanguages() {
-  isInternationalLanguagesVisible.value =
-    !isInternationalLanguagesVisible.value;
+  isInternationalLocalesVisible.value =
+    !isInternationalLocalesVisible.value;
 }
 
 function updateLocaleCookie(localeCode) {
@@ -111,10 +111,10 @@ function updateLocaleCookie(localeCode) {
 }
 
 onClickOutside(
-  languagesMenuRef,
+  localesMenuRef,
   () => {
-    if (isLanguagesMenuVisible.value) {
-      toggleLanguagesMenu();
+    if (isLocalesMenuVisible.value) {
+      toggleLocalesMenu();
     }
   },
   { ignore: [buttonRef] }

--- a/pix-site/components/LocaleSwitcher.vue
+++ b/pix-site/components/LocaleSwitcher.vue
@@ -4,30 +4,30 @@
       <button
         ref="buttonRef"
         class="locale-switcher__button"
-        @click="toggleLanguagesMenu"
-        @keyup.esc="isLanguagesMenuVisible && toggleLanguagesMenu()"
+        @click="toggleLocalesMenu"
+        @keyup.esc="isLocalesMenuVisible && toggleLocalesMenu()"
         :aria-label="t('locale-switcher.button.main-label')"
         aria-haspopup="menu"
-        :aria-expanded="isLanguagesMenuVisible"
+        :aria-expanded="isLocalesMenuVisible"
       >
         <img :src="`/images/${localeProperties.icon}`" alt="" />
         <span>{{ localeProperties.name }}</span>
       </button>
       <ul
-        v-show="isLanguagesMenuVisible"
-        ref="languagesMenuRef"
+        v-show="isLocalesMenuVisible"
+        ref="localesMenuRef"
         class="locale-switcher__languages-menu"
       >
         <li>
           <button
             class="sub-menu-toggler"
-            @click="toggleInternationalLanguages"
+            @click="toggleInternationalLocales"
             :aria-label="t('locale-switcher.button.international-label')"
           >
             <img :src="`/images/${frLocale.icon}`" alt="" />
             <span>{{ t("locale-switcher.locales.international") }}</span>
           </button>
-          <ul v-show="isInternationalLanguagesVisible" class="sub-menu">
+          <ul v-show="isInternationalLocalesVisible" class="sub-menu">
             <li
               v-if="frLocale"
               :class="{ active: localeProperties.code === frLocale.code }"
@@ -113,25 +113,25 @@ const frBeLocale = reachableLocales.find((l) => l.code === "fr-be");
 const nlBeLocale = reachableLocales.find((l) => l.code === "nl-be");
 
 const buttonRef = ref(null);
-const languagesMenuRef = ref(null);
-const isLanguagesMenuVisible = ref(false);
-const isInternationalLanguagesVisible = ref(false);
+const localesMenuRef = ref(null);
+const isLocalesMenuVisible = ref(false);
+const isInternationalLocalesVisible = ref(false);
 
 const config = useAppConfig();
 const domainFr = config.domainFr;
 const domainOrg = config.domainOrg;
 
-function toggleLanguagesMenu() {
-  isLanguagesMenuVisible.value = !isLanguagesMenuVisible.value;
+function toggleLocalesMenu() {
+  isLocalesMenuVisible.value = !isLocalesMenuVisible.value;
 
-  if (!isLanguagesMenuVisible.value) {
-    isInternationalLanguagesVisible.value = false;
+  if (!isLocalesMenuVisible.value) {
+    isInternationalLocalesVisible.value = false;
   }
 }
 
-function toggleInternationalLanguages() {
-  isInternationalLanguagesVisible.value =
-    !isInternationalLanguagesVisible.value;
+function toggleInternationalLocales() {
+  isInternationalLocalesVisible.value =
+    !isInternationalLocalesVisible.value;
 }
 
 function updateLocaleCookie(localeCode) {
@@ -139,10 +139,10 @@ function updateLocaleCookie(localeCode) {
 }
 
 onClickOutside(
-  languagesMenuRef,
+  localesMenuRef,
   () => {
-    if (isLanguagesMenuVisible.value) {
-      toggleLanguagesMenu();
+    if (isLocalesMenuVisible.value) {
+      toggleLocalesMenu();
     }
   },
   { ignore: [buttonRef] }


### PR DESCRIPTION
## :unicorn: Problème
Sur le site vitrine, nous gérons des locales et non des langues. Pour éviter la confusion, il est préférable d'utiliser le terme "locale" dans le code.

## :robot: Proposition
Remplacer le terme "language" par "locale" dans les fichiers : 

- `pix-site/pix-site/components/LocaleSwitcher.vue`
- `pix-site/pix-pro/components/LocaleSwitcher.vue`

## :rainbow: Remarques
RAS.

## :100: Pour tester
Faire un tour sur les sites vitrine (pix-site et pix-pro) et vérifier que le choix des locales sur la page d'accueil et le sélecteur de locales fonctionnent toujours correctement.