### PR TITLE
[BUGFIX] Ne pas afficher la page d'accueil (= page de choix de locale) si l'utilisateur a déjà  une locale (PIX-11497)

### DIFF
--- a/shared/pages/index.vue
+++ b/shared/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <locale-choice />
+  <locale-choice v-if="!locale"/>
 </template>
 
 <script setup>
@@ -10,11 +10,12 @@ definePageMeta({
   layout: 'empty',
 })
 
+const { localeCookie } = useLocaleCookie();
+const locale = localeCookie.value;
 onBeforeMount(() => {
-  const { localeCookie } = useLocaleCookie();
   const router = useRouter();
-  if (localeCookie.value) {
-    return router.replace(`/${localeCookie.value}/`);
+  if (locale) {
+    return router.replace(`/${locale}/`);
   }
 })
 </script>


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu’un utilisateur ayant déjà une locale se rend sur la page https://pix.org/ , il passe brièvement par la page d’accueil avant d'être redirigé vers la page attendue, ce qui produit un effet de clignotement.

## :robot: Proposition
Empêcher l'affichage de la page d'accueil si l'utilisateur a déjà une locale.

## :rainbow: Remarques
RAS

## :100: Pour tester 
- Lancer l'application pix-site
- Aller sur http://localhost:7000/
- Constater que la page d'accueil (= page de sélection de locale) s'affiche
- Choisir une locale
- Constater que la page http://localhost:7000/{locale} s'affiche
- Retourner sur http://localhost:7000/
- Constater que la page d'accueil ne s'affiche plus et que la page http://localhost:7000/{locale} s'affiche à nouveau
