### PR TITLE
[BUGFIX] Corriger les erreurs de pages Support pour les locales internationales

### DIFF
--- a/shared/components/Support/SupportContact.vue
+++ b/shared/components/Support/SupportContact.vue
@@ -3,21 +3,24 @@
     <h2 class="support-contact__title">
       {{ t('support.faq.contact-title') }}
     </h2>
-    <nuxt-link :to="contactLink" class="support-contact__link">
+    <nuxt-link :to="formUrl" class="support-contact__link">
       {{ t('support.faq.contact-cta') }}
     </nuxt-link>
   </div>
 </template>
 
 <script setup>
-const { t } = useI18n();
+const { locale: i18nLocale, t } = useI18n();
 
-defineProps({
-  contactLink: {
+const props = defineProps({
+  contactFormId: {
     type: String,
     required: true,
   },
 })
+
+const urlLocale = i18nLocale.value === 'fr-fr' ? '' : `/${i18nLocale.value}`
+const formUrl = `${urlLocale}/support/form/${props.contactFormId}`
 </script>
 
 <style scoped lang="scss">

--- a/shared/pages/support/faq/[faq-persona].vue
+++ b/shared/pages/support/faq/[faq-persona].vue
@@ -41,7 +41,7 @@
           </li>
         </ul>
       </section>
-      <support-contact v-if="data.contactForm" :contact-link="`/support/form/${data.contactForm.uid}`" />
+      <support-contact v-if="data.contactForm" :contact-form-id="data.contactForm.uid" />
     </div>
   </div>
 </template>
@@ -78,7 +78,7 @@ const { data } = await useAsyncData(async () => {
     const queryPosts = await client.getAllByType('support__faq_post', { lang: i18nLocale.value })
 
     const contactForm = queryPersona.data.contact_form_link.id
-      ? await client.getByID(queryPersona.data.contact_form_link.id)
+      ? await client.getByID(queryPersona.data.contact_form_link.id, { lang: i18nLocale.value })
       : null
 
     return {

--- a/shared/pages/support/faq/[faq-post].vue
+++ b/shared/pages/support/faq/[faq-post].vue
@@ -5,7 +5,7 @@
     <section class="faq-post__content-wrapper">
       <h1 class="faq-post__title">{{ data.content.title[0].text }}</h1>
       <prismic-rich-text class="faq-post__content" :field="data.content.content" />
-      <support-contact v-if="data.contactForm" :contact-link="`/support/form/${data.contactForm.uid}`" />
+      <support-contact v-if="data.contactForm" :contact-form-id="data.contactForm.uid" />
     </section>
   </div>
 </template>
@@ -46,7 +46,7 @@ const { data } = await useAsyncData(async () => {
     )
 
     const contactForm = document.data.contact_form_link.id
-      ? await client.getByID(document.data.contact_form_link.id)
+      ? await client.getByID(document.data.contact_form_link.id, { lang: i18nLocale.value })
       : null
 
     return {


### PR DESCRIPTION
## :unicorn: Problème

Certaines nouvelles pages du support ne fonctionnent pas bien.
Ex: https://pix.org/fr/support/particulier/centre-daide-pour-les-particuliers

## :robot: Proposition

Corriger les pages des locales internationales.

## :100: Pour tester

Regarder la même page sur la RA : https://site-pr630.review.pix.org/fr/support/particulier/centre-daide-pour-les-particuliers
