### PR TITLE
[FEATURE] Ajout du néerlandais sur Pix Site (PIX-11338)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - run:
           name: Test
           command: |
-            npm run test
+            npm test
 
   test-pix-site:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           paths:
             - .
 
-  test:
+  test-shared:
     executor:
       name: node-docker
     working_directory: ~/pix-site/shared
@@ -51,6 +51,33 @@ jobs:
           name: Test
           command: |
             npm run test
+
+  test-pix-site:
+    executor:
+      name: node-docker
+    working_directory: ~/pix-site/pix-site
+    steps:
+      - attach_workspace:
+          at: ~/pix-site
+      - run: cat package*.json > cachekey
+      - restore_cache:
+          keys:
+            - v1-pix-site-pix-site-npm-{{ checksum "cachekey" }}
+      - run:
+          name: Install dependencies
+          command: |
+            npm ci
+      - save_cache:
+          key: v1-pix-site-pix-site-npm-{{ checksum "cachekey" }}
+          paths:
+            - ~/.npm
+      - run:
+          name: Test
+          environment:
+            SITE: pix-site
+            SITE_DOMAIN: 'ORG'
+          command: |
+            npm test
 
   e2e-pix-site:
     executor:
@@ -96,7 +123,12 @@ workflows:
       - checkout:
           context: pix-site
 
-      - test:
+      - test-shared:
+          context: pix-site
+          requires:
+            - checkout
+
+      - test-pix-site:
           context: pix-site
           requires:
             - checkout

--- a/pix-pro/components/LocaleSwitcher.vue
+++ b/pix-pro/components/LocaleSwitcher.vue
@@ -4,18 +4,18 @@
       <button
         ref="buttonRef"
         class="locale-switcher__button"
-        @click="toggleLanguagesMenu"
-        @keyup.esc="isLanguagesMenuVisible && toggleLanguagesMenu()"
+        @click="toggleLocalesMenu"
+        @keyup.esc="isLocalesMenuVisible && toggleLocalesMenu()"
         :aria-label="t('locale-switcher.button.main-label')"
         aria-haspopup="menu"
-        :aria-expanded="isLanguagesMenuVisible"
+        :aria-expanded="isLocalesMenuVisible"
       >
         <img :src="`/images/${localeProperties.icon}`" alt="" />
         <span>{{ localeProperties.name }}</span>
       </button>
       <ul
-        v-show="isLanguagesMenuVisible"
-        ref="languagesMenuRef"
+        v-show="isLocalesMenuVisible"
+        ref="localesMenuRef"
         class="locale-switcher__languages-menu"
       >
         <li>
@@ -27,7 +27,7 @@
             <img :src="`/images/${frLocale.icon}`" alt="" />
             <span>{{ t("locale-switcher.locales.international") }}</span>
           </button>
-          <ul v-show="isInternationalLanguagesVisible" class="sub-menu">
+          <ul v-show="isInternationalLocalesVisible" class="sub-menu">
             <li
               v-if="frLocale"
               :class="{ active: localeProperties.code === frLocale.code }"
@@ -85,25 +85,25 @@ const enLocale = reachableLocales.find((l) => l.code === "en");
 const frFrLocale = reachableLocales.find((l) => l.code === "fr-fr");
 
 const buttonRef = ref(null);
-const languagesMenuRef = ref(null);
-const isLanguagesMenuVisible = ref(false);
-const isInternationalLanguagesVisible = ref(false);
+const localesMenuRef = ref(null);
+const isLocalesMenuVisible = ref(false);
+const isInternationalLocalesVisible = ref(false);
 
 const config = useAppConfig();
 const domainFr = config.domainFr;
 const domainOrg = config.domainOrg;
 
-function toggleLanguagesMenu() {
-  isLanguagesMenuVisible.value = !isLanguagesMenuVisible.value;
+function toggleLocalesMenu() {
+  isLocalesMenuVisible.value = !isLocalesMenuVisible.value;
 
-  if (!isLanguagesMenuVisible.value) {
-    isInternationalLanguagesVisible.value = false;
+  if (!isLocalesMenuVisible.value) {
+    isInternationalLocalesVisible.value = false;
   }
 }
 
 function toggleInternationalLanguages() {
-  isInternationalLanguagesVisible.value =
-    !isInternationalLanguagesVisible.value;
+  isInternationalLocalesVisible.value =
+    !isInternationalLocalesVisible.value;
 }
 
 function updateLocaleCookie(localeCode) {
@@ -111,10 +111,10 @@ function updateLocaleCookie(localeCode) {
 }
 
 onClickOutside(
-  languagesMenuRef,
+  localesMenuRef,
   () => {
-    if (isLanguagesMenuVisible.value) {
-      toggleLanguagesMenu();
+    if (isLocalesMenuVisible.value) {
+      toggleLocalesMenu();
     }
   },
   { ignore: [buttonRef] }

--- a/pix-site/components/LocaleChoice.vue
+++ b/pix-site/components/LocaleChoice.vue
@@ -23,7 +23,6 @@
 import { reachableLocales } from "../i18n.config.ts";
 
 const { setLocaleCookie } = useLocaleCookie();
-const { locales, defaultLocale } = useI18n();
 
 function updateLocale(localeCode) {
   setLocaleCookie(localeCode);

--- a/pix-site/components/LocaleSwitcher.vue
+++ b/pix-site/components/LocaleSwitcher.vue
@@ -4,30 +4,30 @@
       <button
         ref="buttonRef"
         class="locale-switcher__button"
-        @click="toggleLanguagesMenu"
-        @keyup.esc="isLanguagesMenuVisible && toggleLanguagesMenu()"
+        @click="toggleLocalesMenu"
+        @keyup.esc="isLocalesMenuVisible && toggleLocalesMenu()"
         :aria-label="t('locale-switcher.button.main-label')"
         aria-haspopup="menu"
-        :aria-expanded="isLanguagesMenuVisible"
+        :aria-expanded="isLocalesMenuVisible"
       >
         <img :src="`/images/${localeProperties.icon}`" alt="" />
         <span>{{ localeProperties.name }}</span>
       </button>
       <ul
-        v-show="isLanguagesMenuVisible"
-        ref="languagesMenuRef"
+        v-show="isLocalesMenuVisible"
+        ref="localesMenuRef"
         class="locale-switcher__languages-menu"
       >
         <li>
           <button
             class="sub-menu-toggler"
-            @click="toggleInternationalLanguages"
+            @click="toggleInternationalLocales"
             :aria-label="t('locale-switcher.button.international-label')"
           >
             <img :src="`/images/${frLocale.icon}`" alt="" />
             <span>{{ t("locale-switcher.locales.international") }}</span>
           </button>
-          <ul v-show="isInternationalLanguagesVisible" class="sub-menu">
+          <ul v-show="isInternationalLocalesVisible" class="sub-menu">
             <li
               v-if="frLocale"
               :class="{ active: localeProperties.code === frLocale.code }"
@@ -113,25 +113,25 @@ const frBeLocale = reachableLocales.find((l) => l.code === "fr-be");
 const nlBeLocale = reachableLocales.find((l) => l.code === "nl-be");
 
 const buttonRef = ref(null);
-const languagesMenuRef = ref(null);
-const isLanguagesMenuVisible = ref(false);
-const isInternationalLanguagesVisible = ref(false);
+const localesMenuRef = ref(null);
+const isLocalesMenuVisible = ref(false);
+const isInternationalLocalesVisible = ref(false);
 
 const config = useAppConfig();
 const domainFr = config.domainFr;
 const domainOrg = config.domainOrg;
 
-function toggleLanguagesMenu() {
-  isLanguagesMenuVisible.value = !isLanguagesMenuVisible.value;
+function toggleLocalesMenu() {
+  isLocalesMenuVisible.value = !isLocalesMenuVisible.value;
 
-  if (!isLanguagesMenuVisible.value) {
-    isInternationalLanguagesVisible.value = false;
+  if (!isLocalesMenuVisible.value) {
+    isInternationalLocalesVisible.value = false;
   }
 }
 
-function toggleInternationalLanguages() {
-  isInternationalLanguagesVisible.value =
-    !isInternationalLanguagesVisible.value;
+function toggleInternationalLocales() {
+  isInternationalLocalesVisible.value =
+    !isInternationalLocalesVisible.value;
 }
 
 function updateLocaleCookie(localeCode) {
@@ -139,10 +139,10 @@ function updateLocaleCookie(localeCode) {
 }
 
 onClickOutside(
-  languagesMenuRef,
+  localesMenuRef,
   () => {
-    if (isLanguagesMenuVisible.value) {
-      toggleLanguagesMenu();
+    if (isLocalesMenuVisible.value) {
+      toggleLocalesMenu();
     }
   },
   { ignore: [buttonRef] }

--- a/pix-site/components/LocaleSwitcher.vue
+++ b/pix-site/components/LocaleSwitcher.vue
@@ -68,6 +68,19 @@
           </a>
         </li>
         <li
+          v-if="nlBeLocale"
+          :class="{ active: localeProperties.code === nlBeLocale.code }"
+        >
+          <a
+            :href="`${ domainOrg || ''}/nl-be`"
+            :aria-current="localeProperties.code === nlBeLocale.code && 'page'"
+            @click="updateLocaleCookie(nlBeLocale.code)"
+          >
+            <img :src="`/images/${nlBeLocale.icon}`" alt="" />
+            <span>{{ nlBeLocale.name }}</span>
+          </a>
+        </li>
+        <li
           v-if="frFrLocale"
           :class="{ active: localeProperties.code === frFrLocale.code }"
         >
@@ -97,6 +110,7 @@ const frLocale = reachableLocales.find((l) => l.code === "fr");
 const enLocale = reachableLocales.find((l) => l.code === "en");
 const frFrLocale = reachableLocales.find((l) => l.code === "fr-fr");
 const frBeLocale = reachableLocales.find((l) => l.code === "fr-be");
+const nlBeLocale = reachableLocales.find((l) => l.code === "nl-be");
 
 const buttonRef = ref(null);
 const languagesMenuRef = ref(null);

--- a/pix-site/i18n.config.ts
+++ b/pix-site/i18n.config.ts
@@ -24,7 +24,7 @@ const reachableLocales = [
   {
     code: "fr-be",
     file: "fr-be.js",
-    name: "Fédération Wallonie-Bruxelles",
+    name: "Belgique (Français)",
     icon: "flag-be.svg",
     domain: process.env.DOMAIN_ORG
   }

--- a/pix-site/i18n.config.ts
+++ b/pix-site/i18n.config.ts
@@ -27,6 +27,13 @@ const reachableLocales = [
     name: "Belgique (Français)",
     icon: "flag-be.svg",
     domain: process.env.DOMAIN_ORG
+  },
+  {
+    code: "nl-be",
+    file: "nl-be.js",
+    name: "België (Nederlands)",
+    icon: "flag-be.svg",
+    domain: process.env.DOMAIN_ORG
   }
 ];
 

--- a/pix-site/package-lock.json
+++ b/pix-site/package-lock.json
@@ -15,6 +15,7 @@
         "@nuxtjs/prismic": "^3.0.2",
         "@playwright/test": "^1.38.1",
         "@slicemachine/adapter-nuxt": "^0.3.16",
+        "@testing-library/vue": "^8.0.2",
         "@types/node": "^20.8.2",
         "@vue/test-utils": "^2.4.4",
         "@vueuse/core": "^10.4.1",
@@ -4018,6 +4019,150 @@
         "node": ">=14.15.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@testing-library/dom/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
+    },
+    "node_modules/@testing-library/dom/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/vue": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/vue/-/vue-8.0.2.tgz",
+      "integrity": "sha512-A8wWX+qQn0o0izpQWnGCpwQt8wAdpsVP8vPP2h5Q/jcGhZ5yKXz9PPUqhQv+45LTFaWlyRf8bArTVaB/KFFd5A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "@testing-library/dom": "^9.3.3",
+        "@vue/test-utils": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": ">= 3",
+        "vue": ">= 3"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
@@ -4069,6 +4214,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -5110,6 +5261,31 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/aria-query": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "dev": true,
+      "dependencies": {
+        "deep-equal": "^2.0.5"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+      "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -6612,6 +6788,44 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "dev": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deep-equal/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -6782,6 +6996,12 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -7053,6 +7273,32 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-get-iterator/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
     },
     "node_modules/esbuild": {
       "version": "0.20.1",
@@ -7710,6 +7956,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gauge": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
@@ -8011,6 +8266,15 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-flag": {
@@ -8548,6 +8812,20 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/internal-slot": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.0",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/io-ts": {
       "version": "2.2.21",
       "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.21.tgz",
@@ -8681,12 +8959,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+      "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -8698,6 +9004,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-buffer": {
@@ -8757,6 +9079,21 @@
       "dev": true,
       "dependencies": {
         "hasown": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8868,6 +9205,15 @@
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
       "dev": true
     },
+    "node_modules/is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -8897,6 +9243,21 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-path-inside": {
@@ -8941,6 +9302,46 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-ssh": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.0.tgz",
@@ -8962,6 +9363,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-typed-array": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
@@ -8972,6 +9403,28 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9547,6 +10000,15 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -13755,6 +14217,24 @@
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "dev": true
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
+      "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "set-function-name": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/rehype-stringify": {
       "version": "9.0.4",
       "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-9.0.4.tgz",
@@ -14253,6 +14733,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -14732,6 +15227,18 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
       "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
       "dev": true
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "dev": true,
+      "dependencies": {
+        "internal-slot": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/streamx": {
       "version": "2.16.1",
@@ -17110,6 +17617,37 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dev": true,
+      "dependencies": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-typed-array": {

--- a/pix-site/package.json
+++ b/pix-site/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "build": "npm run generate",
     "dev": "nuxt dev",
+    "dev:site:fr": "SITE=pix-site SITE_DOMAIN=FR PORT=6001 DOMAIN_FR=http://localhost:6001 DOMAIN_ORG=http://localhost:7000 nuxt dev",
+    "dev:site:org": "SITE=pix-site SITE_DOMAIN=ORG PORT=7000 DOMAIN_FR=http://localhost:6001 DOMAIN_ORG=http://localhost:7000 nuxt dev",
     "generate-fr": "SITE_DOMAIN=FR nuxt generate && cp -R ./.output/public ./build/fr ",
     "generate-org": "SITE_DOMAIN=ORG nuxt generate && cp -R ./.output/public  ./build/org ",
     "generate": "rm -rf ./build && mkdir build && npm run generate-fr && npm run generate-org",

--- a/pix-site/package.json
+++ b/pix-site/package.json
@@ -27,6 +27,7 @@
     "@nuxtjs/prismic": "^3.0.2",
     "@playwright/test": "^1.38.1",
     "@slicemachine/adapter-nuxt": "^0.3.16",
+    "@testing-library/vue": "^8.0.2",
     "@types/node": "^20.8.2",
     "@vue/test-utils": "^2.4.4",
     "@vueuse/core": "^10.4.1",

--- a/pix-site/tests/integration/components/LocaleChoice.test.ts
+++ b/pix-site/tests/integration/components/LocaleChoice.test.ts
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/vue'
+
+import LocaleChoice from "~/components/LocaleChoice.vue";
+import { reachableLocales } from "~/i18n.config.ts";
+
+describe('LocaleChoice', () => {
+  beforeEach(() => {
+    render(LocaleChoice);
+  })
+
+  test('displays a link for each locale', () => {
+    // then
+    const links = screen.getAllByRole('link');
+    expect(links.length).equals(5);
+  })
+
+  test('displays the name of each locale', () => {
+    // then
+    reachableLocales.forEach(locale => {
+      expect(screen.findByText(locale.name)).toBeTruthy();
+    })
+  })
+})

--- a/pix-site/tests/integration/components/LocaleSwitcher.test.ts
+++ b/pix-site/tests/integration/components/LocaleSwitcher.test.ts
@@ -1,0 +1,66 @@
+import { render, screen, fireEvent } from '@testing-library/vue'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+import LocaleSwitcher from "~/components/LocaleSwitcher.vue";
+
+const localeProperties = { code: 'fr-fr', name: 'Français', icon: 'fr' }
+
+mockNuxtImport('useI18n', () => {
+  return () => {
+    return { localeProperties, t: (str) => str }
+  }
+})
+
+describe('LocaleSwitcher', () => {
+  beforeEach(() => {
+    render(LocaleSwitcher);
+  })
+
+  test('displays as a button', () => {
+    // then
+    const localesMenuButton = screen.getByRole('button', { name: 'locale-switcher.button.main-label' });
+    expect(localesMenuButton).toBeTruthy();
+  })
+
+  describe('locales menu button', () => {
+    test('is a clickable button which displays a menu', async () => {
+      // given
+      const localesMenuButton = screen.getByRole('button', { name: 'locale-switcher.button.main-label' });
+
+      // when
+      await fireEvent.click(localesMenuButton);
+
+      // then
+      const internationalLanguagesButton = screen.getByRole('button', { name: 'locale-switcher.button.international-label' });
+      expect(internationalLanguagesButton).toBeTruthy();
+
+      const frFrLink = screen.getByRole('link', { name: 'France' });
+      expect(frFrLink).toBeTruthy();
+
+      const frBeLink = screen.getByRole('link', { name: 'Belgique (Français)' });
+      expect(frBeLink).toBeTruthy();
+
+      const frNlLink = screen.getByRole('link', { name: 'België (Nederlands)' });
+      expect(frNlLink).toBeTruthy();
+    })
+  })
+
+  describe('international locales menu button', () => {
+    test('is a clickable button which displays a sub-menu', async () => {
+      // given
+      const localesMenuButton = screen.getByRole('button', { name: 'locale-switcher.button.main-label' });
+      await fireEvent.click(localesMenuButton);
+      const internationalLanguagesButton = screen.getByRole('button', { name: 'locale-switcher.button.international-label' });
+
+      // when
+      await fireEvent.click(internationalLanguagesButton);
+
+      // then
+      const frLink = screen.getByRole('link', { name: 'Français' });
+      expect(frLink).toBeTruthy();
+
+      const enLink = screen.getByRole('link', { name: 'English' });
+      expect(enLink).toBeTruthy();
+    })
+  })
+})

--- a/shared/components/slices/NavigationGroup.vue
+++ b/shared/components/slices/NavigationGroup.vue
@@ -11,7 +11,7 @@
           :key="`link-${index}`"
           class="navigation-group-link"
         >
-          <nuxt-link :to="getEnvironmentUrl(link.link_url.url)">
+          <nuxt-link v-if="link.link_url?.url" :to="getEnvironmentUrl(link.link_url.url)">
             <prismic-rich-text :field="link.link_name" />
           </nuxt-link>
         </li>

--- a/shared/composables/useLocaleCookie.ts
+++ b/shared/composables/useLocaleCookie.ts
@@ -6,10 +6,11 @@ export default function useLocaleCookie() {
   });
 
   function setLocaleCookie(
-    selectedLocale: string,
+    locale: string,
     callback?: Function
   ): void {
-    localeCookie.value = selectedLocale;
+    const localeCanonicalName = Intl.getCanonicalLocales(locale)?.[0]
+    localeCookie.value = localeCanonicalName;
     if (callback) callback();
   }
 

--- a/shared/pages/index.vue
+++ b/shared/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <locale-choice />
+  <locale-choice v-if="!locale"/>
 </template>
 
 <script setup>
@@ -10,11 +10,12 @@ definePageMeta({
   layout: 'empty',
 })
 
+const { localeCookie } = useLocaleCookie();
+const locale = localeCookie.value;
 onBeforeMount(() => {
-  const { localeCookie } = useLocaleCookie();
   const router = useRouter();
-  if (localeCookie.value) {
-    return router.replace(`/${localeCookie.value}/`);
+  if (locale) {
+    return router.replace(`/${locale}/`);
   }
 })
 </script>

--- a/shared/pages/locale-home.vue
+++ b/shared/pages/locale-home.vue
@@ -15,6 +15,7 @@ defineI18nRoute({
     fr: "/",
     "fr-fr": "/",
     "fr-be": "/",
+    "nl-be": "/"
   },
 });
 

--- a/shared/pages/news/[slug].vue
+++ b/shared/pages/news/[slug].vue
@@ -21,6 +21,7 @@ defineI18nRoute({
     fr: "/actualites/[slug]",
     "fr-fr": "/actualites/[slug]",
     "fr-be": "/actualites/[slug]",
+    "nl-be": "/actualites/[slug]",
   },
 });
 

--- a/shared/pages/news/index.vue
+++ b/shared/pages/news/index.vue
@@ -35,6 +35,7 @@ defineI18nRoute({
     fr: "/actualites",
     "fr-fr": "/actualites",
     "fr-be": "/actualites",
+    "nl-be": "/actualites",
   },
 });
 

--- a/shared/pages/support/[persona-sub-list].vue
+++ b/shared/pages/support/[persona-sub-list].vue
@@ -24,7 +24,8 @@ defineI18nRoute({
     en: '/support/[parent_persona_name]',
     fr: '/support/[parent_persona_name]',
     'fr-fr': '/support/[parent_persona_name]',
-    'fr-be': '/support/[parent_persona_name]'
+    'fr-be': '/support/[parent_persona_name]',
+    'nl-be': '/support/[parent_persona_name]',
   }
 })
 

--- a/shared/pages/support/faq/[faq-persona].vue
+++ b/shared/pages/support/faq/[faq-persona].vue
@@ -58,6 +58,7 @@ defineI18nRoute({
     fr: '/support/[parent_persona]/[current_persona]',
     'fr-fr': '/support/[parent_persona]/[current_persona]',
     'fr-be': '/support/[parent_persona]/[current_persona]',
+    'nl-be': '/support/[parent_persona]/[current_persona]',
   },
 });
 

--- a/shared/pages/support/faq/[faq-post].vue
+++ b/shared/pages/support/faq/[faq-post].vue
@@ -22,6 +22,7 @@ defineI18nRoute({
     fr: '/support/[parent_persona]/[current_persona]/[post_uid]',
     'fr-fr': '/support/[parent_persona]/[current_persona]/[post_uid]',
     'fr-be': '/support/[parent_persona]/[current_persona]/[post_uid]',
+    'nl-be': '/support/[parent_persona]/[current_persona]/[post_uid]',
   },
 });
 

--- a/shared/pages/support/form/[support-form].vue
+++ b/shared/pages/support/form/[support-form].vue
@@ -21,6 +21,7 @@ defineI18nRoute({
     fr: '/support/form/[slug]',
     'fr-fr': '/support/form/[slug]',
     'fr-be': '/support/form/[slug]',
+    'nl-be': '/support/form/[slug]',
   },
 });
 

--- a/shared/pages/support/index.vue
+++ b/shared/pages/support/index.vue
@@ -29,6 +29,7 @@ defineI18nRoute({
     fr: '/support',
     'fr-fr': '/support',
     'fr-be': '/support',
+    'nl-be': '/support',
   },
 });
 

--- a/shared/tests/composables/useLocaleCookie.test.ts
+++ b/shared/tests/composables/useLocaleCookie.test.ts
@@ -34,15 +34,30 @@ describe("#useLocaleCookie", () => {
       });
     });
 
-    test('sets cookie with the value passed in parameter', () => {
-      // given
-      const { localeCookie, setLocaleCookie } = useLocaleCookie();
+    describe('when passed argument is a locale in BCP 47 canonical format', () => {
+      test('sets the cookie with the value', () => {
+        // given
+        const { localeCookie, setLocaleCookie } = useLocaleCookie();
 
-      // when
-      setLocaleCookie('nl-BE');
+        // when
+        setLocaleCookie('nl-BE');
 
-      // then
-      expect(localeCookie.value).toEqual('nl-BE');
+        // then
+        expect(localeCookie.value).toEqual('nl-BE');
+      })
+    })
+
+    describe('when passed argument is a locale not in BCP 47 canonical format', () => {
+      test('sets the cookie with a normalized value', () => {
+        // given
+        const { localeCookie, setLocaleCookie } = useLocaleCookie();
+
+        // when
+        setLocaleCookie('nl-be');
+
+        // then
+        expect(localeCookie.value).toEqual('nl-BE');
+      })
     })
   })
 })

--- a/shared/translations/en.js
+++ b/shared/translations/en.js
@@ -5,20 +5,12 @@ export default {
       'international-label': 'International languages list',
     },
     locales: {
-      fr: 'International FR',
-      'fr-fr': 'France',
-      en: 'International EN',
-      'fr-be': 'Fédération Wallonie-Bruxelles',
-      france: 'France',
-      english: 'English',
-      french: 'Français',
-      international: 'International',
-      fwb: 'Fédération Wallonie-Bruxelles',
-      'contact-digital-mediation': {
-        'page-title': 'Information request',
-        'form-id': '28758',
-      },
-    },
+      international: "International",
+      "contact-digital-mediation": {
+        "page-title": "Information request",
+        "form-id": "28758"
+      }
+    }
   },
   'higher-education-establishment-registration': {
     'page-title': 'Pix Orga workspace request',

--- a/shared/translations/fr-be.js
+++ b/shared/translations/fr-be.js
@@ -5,16 +5,8 @@ export default {
       'international-label': 'Liste des sites internationaux',
     },
     locales: {
-      fr: 'International FR',
-      'fr-fr': 'France',
-      en: 'International EN',
-      'fr-be': 'Fédération Wallonie-Bruxelles',
-      france: 'France',
-      english: 'English',
-      french: 'Français',
-      international: 'International',
-      fwb: 'Fédération Wallonie-Bruxelles',
-    },
+      international: "International"
+    }
   },
   'contact-digital-mediation': {
     'page-title': "Demande d'information",

--- a/shared/translations/fr-fr.js
+++ b/shared/translations/fr-fr.js
@@ -5,16 +5,8 @@ export default {
       'international-label': 'Liste des sites internationaux',
     },
     locales: {
-      fr: 'International FR',
-      'fr-fr': 'France',
-      en: 'International EN',
-      'fr-be': 'Fédération Wallonie-Bruxelles',
-      france: 'France',
-      english: 'English',
-      french: 'Français',
-      international: 'International',
-      fwb: 'Fédération Wallonie-Bruxelles',
-    },
+      international: "International"
+    }
   },
   'contact-digital-mediation': {
     'page-title': "Demande d'information",

--- a/shared/translations/fr.js
+++ b/shared/translations/fr.js
@@ -5,16 +5,8 @@ export default {
       'international-label': 'Liste des sites internationaux',
     },
     locales: {
-      fr: 'International FR',
-      'fr-fr': 'France',
-      en: 'International EN',
-      'fr-be': 'Fédération Wallonie-Bruxelles',
-      france: 'France',
-      english: 'English',
-      french: 'Français',
-      international: 'International',
-      fwb: 'Fédération Wallonie-Bruxelles',
-    },
+      international: "International"
+    }
   },
   'contact-digital-mediation': {
     'page-title': "Demande d'information",

--- a/shared/translations/nl-be.js
+++ b/shared/translations/nl-be.js
@@ -5,15 +5,7 @@ export default {
       "international-label": "Liste des sites internationaux"
     },
     locales: {
-      fr: "International FR",
-      "fr-fr": "France",
-      en: "International EN",
-      "nl-be": "Fédération Wallonie-Bruxelles",
-      france: "France",
-      english: "English",
-      french: "Français",
       international: "International",
-      fwb: "Fédération Wallonie-Bruxelles"
     }
   },
   "contact-digital-mediation": {

--- a/shared/translations/nl-be.js
+++ b/shared/translations/nl-be.js
@@ -1,0 +1,86 @@
+export default {
+  "locale-switcher": {
+    button: {
+      "main-label": "Choix de la langue",
+      "international-label": "Liste des sites internationaux"
+    },
+    locales: {
+      fr: "International FR",
+      "fr-fr": "France",
+      en: "International EN",
+      "nl-be": "Fédération Wallonie-Bruxelles",
+      france: "France",
+      english: "English",
+      french: "Français",
+      international: "International",
+      fwb: "Fédération Wallonie-Bruxelles"
+    }
+  },
+  "contact-digital-mediation": {
+    "page-title": "Demande d'information",
+    "form-id": "24665"
+  },
+  "higher-education-establishment-registration": {
+    "page-title": "Demande d’espace Pix Orga",
+    "form-id": "22367"
+  },
+  "pix-certification-application": {
+    "page-title": "Demande d'agrément comme centre de certification Pix",
+    "form-id": "23331"
+  },
+  "pix-orga-registration": {
+    "page-title": "Demande d'information",
+    "form-id": "22370"
+  },
+  "pix-orga-higher-school-registration": {
+    "page-title": "Finalisez votre demande d'espace Pix Orga",
+    "form-id": "22797"
+  },
+  "news-page-prefix": "actualites",
+  "news-page-title": "Actualités",
+  "news-page-title-level-two": "Liste des actualités",
+  "news-page-no-news": "Il n’y a pas encore d'actualités",
+  announcement: "Annonce",
+  engineering: "Ingénierie",
+  event: "Événement",
+  feature: "Nouveauté",
+  society: "Société",
+  form: {
+    "not-supported":
+      "Votre navigateur ne supporte pas les iframes. Le formulaire de contact ne peut pas être affiché. Merci d'utiliser une autre méthode de contact (téléphone, fax, etc.)"
+  },
+  "page-titles": {
+    "contact-digital-mediation": "Demande d'information | Pix",
+    "higher-education-establishment-registration":
+      "Demande d'espace | Pix Orga sup",
+    news: "Actualités | Pix",
+    "pix-certification-application":
+      "Demande d'agrément comme centre de certification | Pix",
+    "pix-orga-higher-school-registration":
+      "Finaliser la demande d'espace | Pix Orga sup",
+    "pix-orga-registration": "Demande d'information | Pix pro",
+    support: "Support | Pix"
+  },
+  "preview-page-load": "Chargement de la page de prévisualisation...",
+  "home-page-url": `${process.env.DOMAIN_ORG}/nl-be/`,
+  "error-content": `
+    <p>Oups ! Un problème est survenu, mais pas de panix !</p>
+    <p>Vous pouvez revenir sur la
+    <a href="${process.env.DOMAIN_FR}/nl-be/">page d'accueil</a>.
+    <br/>Si vous avez besoin d’aide, vous pouvez consulter le
+    <a href="https://support.pix.org/fr/support/home">support</a>.
+    </p>`,
+  "locale-suggestion-banner-text": `Vous semblez ne pas être en France. Voulez-vous accéder au <a href="${process.env.DOMAIN_ORG}">site Pix international</a> ?`,
+  "skip-link": "Aller au contenu",
+  "burger-menu": {
+    name: "Navigation principale",
+    open: "Ouvrir le menu",
+    close: "Fermer le menu",
+    "open-category": "Ouvrir la catégorie",
+    "close-category": "Fermer la catégorie",
+    "open-locale-switcher": "Ouvrir le changement de langue",
+    "close-locale-switcher": "Fermer le changement de langue",
+    "change-locale-switcher": "Changer la langue",
+    "change-locale-switcher-button": "Changer"
+  }
+};


### PR DESCRIPTION
## :unicorn: Problème

Les sites vitrines ne disposent pas encore de localisation pour le public néerlandophone de Belgique.

## :robot: Proposition

* Ajouter la locale `nl-BE` sur la page d'accueil de pix.org
* Ajouter la locale `nl-BE` dans le composant locale-switcher affiché sur toutes les pages

Cette PR est marquée comme **Blocked** de manière à ne la merger que lorsque l’ordre de déploiement sera donné !

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Tester dans toutes les RA que les comportements, les textes sont bien ceux attendus et qu'il n'y a pas de régressions
2. Tester que les différentes locales sont affichées de la même manière en grande taille d'écran (version bureau) et en petite taille d'écran (version mobile)
3. Une fois que le cookie `locale` a été positionné à une valeur dont il faut se souvenir, se rendre sur https://site-pr631.review.pix.org/ et vérifier qu'on est bien redirigé vers la page de la bonne locale. Cette étape sert à valider que le site est bien capable de gérer la valeur du cookie.
