### PR TITLE
[BUGFIX] Corriger le format de stockage du cookie locale pour que sa valeur soit dans la forme canonique du format BCP 47 (PIX-11418)

### DIFF
--- a/shared/composables/useLocaleCookie.ts
+++ b/shared/composables/useLocaleCookie.ts
@@ -6,10 +6,11 @@ export default function useLocaleCookie() {
   });
 
   function setLocaleCookie(
-    selectedLocale: string,
+    locale: string,
     callback?: Function
   ): void {
-    localeCookie.value = selectedLocale;
+    const localeCanonicalName = Intl.getCanonicalLocales(locale)?.[0]
+    localeCookie.value = localeCanonicalName;
     if (callback) callback();
   }
 

--- a/shared/tests/composables/useLocaleCookie.test.ts
+++ b/shared/tests/composables/useLocaleCookie.test.ts
@@ -34,15 +34,30 @@ describe("#useLocaleCookie", () => {
       });
     });
 
-    test('sets cookie with the value passed in parameter', () => {
-      // given
-      const { localeCookie, setLocaleCookie } = useLocaleCookie();
+    describe('when passed argument is a locale in BCP 47 canonical format', () => {
+      test('sets the cookie with the value', () => {
+        // given
+        const { localeCookie, setLocaleCookie } = useLocaleCookie();
 
-      // when
-      setLocaleCookie('nl-BE');
+        // when
+        setLocaleCookie('nl-BE');
 
-      // then
-      expect(localeCookie.value).toEqual('nl-BE');
+        // then
+        expect(localeCookie.value).toEqual('nl-BE');
+      })
+    })
+
+    describe('when passed argument is a locale not in BCP 47 canonical format', () => {
+      test('sets the cookie with a normalized value', () => {
+        // given
+        const { localeCookie, setLocaleCookie } = useLocaleCookie();
+
+        // when
+        setLocaleCookie('nl-be');
+
+        // then
+        expect(localeCookie.value).toEqual('nl-BE');
+      })
     })
   })
 })


### PR DESCRIPTION
## :unicorn: Problème

Suite à la migration Nuxt3 du site vitrine, la valeur du cookie locale n’est plus écrite dans la forme canonique du format BCP 47. Concrètement on a des valeurs comme `fr-be`, alors qu'on devrait avoir `fr-BE` comme décrit dans https://github.com/1024pix/pix/blob/dev/docs/adr/0040-locales-languages.md

## :robot: Proposition

Utiliser la fonction `Intl.getCanonicalLocales` pour normaliser la valeur avant de la stocker dans le cookie, comme décrit dans https://github.com/1024pix/pix/blob/dev/docs/adr/0040-locales-languages.md

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Sélectionner successivement les différents choix de locales,aussi bien à partir du composant locale-choice qu'à partir du composant locale-switcher,  et vérifier la valeur dans le cookie suivant ce qui est décrit ci-dessous. Cette étape sert à valider que la valeur du cookie est bien écrite suivant la forme canonique du format BCP 47.
   * `English` → `en`
   * `Français` → `fr`
   * `Belgique (Français)` → `fr-BE`
   * `België (Nederlands)` → `nl-BE`
2. Une fois que le cookie `locale` a été positionné à une valeur dont il faut se souvenir, se rendre sur https://site-pr632.review.pix.org/ et vérifier qu'on est bien redirigé vers la page de la bonne locale. Cette étape sert à valider que le site est bien capable de gérer la valeur du cookie lorsqu'elle a la forme canonique du format BCP 47.