### PR TITLE
[FEATURE] Ajouter un bloc d'embed dans le type slice-page (PIX-11234).

### DIFF
--- a/shared/components/PrismicCustomSliceZone.vue
+++ b/shared/components/PrismicCustomSliceZone.vue
@@ -2,10 +2,7 @@
   <div class="slice-zone">
     <section v-for="(slice, index) in slices" :key="`slice-${index}`">
       <template v-if="slice.slice_type === 'rich_text'">
-        <prismic-rich-text
-          :field="slice.primary.text"
-          :serializer="customPrismicRichTextSerializer"
-        />
+        <prismic-rich-text :field="slice.primary.text" :serializer="customPrismicRichTextSerializer" />
       </template>
       <template v-if="slice.slice_type === 'banner'">
         <slices-page-banner :slice="slice" :index-for-id="index" />
@@ -21,6 +18,9 @@
       </template>
       <template v-if="slice.slice_type === 'latest_news'">
         <slices-latest-news :slice="slice" :index-for-id="index" />
+      </template>
+      <template v-if="slice.slice_type === 'embed'">
+        <slices-embed :src="slice.primary.iframe_link" />
       </template>
       <!-- <template v-if="slice.slice_type === 'stat'">
         <slices-stat :slice="slice" :index-for-id="index" />

--- a/shared/components/slices/Embed.vue
+++ b/shared/components/slices/Embed.vue
@@ -1,0 +1,22 @@
+<template>
+  <iframe class="slice-embed" :src="src" />
+</template>
+
+<script setup>
+defineProps({
+  src: {
+    type: String,
+    required: true
+  }
+})
+</script>
+
+<style lang="scss">
+.slice-embed {
+  display: block;
+  width: min(1080px, calc(100vw - 32px));
+  height: auto;
+  aspect-ratio: 16/9;
+  margin: 0 auto 64px;
+}
+</style>


### PR DESCRIPTION
## :unicorn: Problème

L'équipe communication a parfois besoin d'ajouter des embeds sur les sites.

## :robot: Proposition

Ajouter une slice "embed".

## :100: Pour tester

Visualiser la page [/trouver-une-session](https://site-pr636.review.pix.fr/preview?token=https://pix-site.prismic.io/previews/ZflfkxIAACsAMrqL:Ze7nFRAAAKICtalf?websitePreviewId=Ze7siRAAACQAtcII&documentId=X3zVfRMAACUARs4j) en preview fr-fr.
Aller sur l'édition de la page sur Prismic et cliquer sur :

![image](https://github.com/1024pix/pix-site/assets/7335131/cbf648b8-b413-48dc-96ab-ed58ede27586)

✅ Aller tout en bas de la page pour visualiser la carte.

