### PR TITLE
[BUGFIX] Corriger la preview Prismic sur les fragments de documents (PIX-11601)

### DIFF
--- a/shared/services/link-resolver.js
+++ b/shared/services/link-resolver.js
@@ -49,12 +49,12 @@ export function linkResolver(doc) {
     return `${locale}/support/form/${doc.uid}`;
   }
 
-  // Hompepage
+  // Homepage
   if (doc.tags?.includes(TAGS.INDEX)) {
     return `${locale}/`;
   }
 
-  return `${locale}/${doc.uid}`;
+  return `${locale}/${doc.uid ?? ''}`;
 }
 
 export default linkResolver;

--- a/shared/tests/services/link-resolver.test.js
+++ b/shared/tests/services/link-resolver.test.js
@@ -88,5 +88,22 @@ describe('linkResolver', () => {
         expect(result).toEqual(expectedUrl);
       });
     });
+
+    describe("when document does not have 'tags', 'type' and 'uid'", () => {
+      test('it returns locale root url', () => {
+        // given
+        const locale = 'nl-be';
+        const doc = {
+          lang: locale,
+        };
+
+        // when
+        const result = linkResolver(doc);
+
+        // then
+        const expectedUrl = `/${locale}/`;
+        expect(result).toEqual(expectedUrl);
+      });
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement la preview Prismic ne fonctionne pas sur les documents qui sont des fragments (ex: footer, nav...).
Elle retourne un `undefined` dans l'url

## :robot: Proposition
Faire fonctionner la preview sur ces documents en corrigeant ce comportement.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Se connecter à Prismic
- Se mettre sur la locale `French France`
- Aller sur les détails du document nav Pix V2
- Cliquer sur le bouton Preview the page en bas à gauche de la page

### Reproduire le bug 
- Sélectionner `Integration` dans la liste des preview
- Constater que l'url généré a un path en `/undefined` et que la page ne s'affiche pas correctement

### Fix
- Sélectionner `PR 637 fr` dans la liste des preview
- Constater que l'url généré a un path en `/` et que la home s'affiche bien.
