### PR TITLE
[BUGFIX] Afficher complètement le sélecteur de langue sur la version mobile (PIX-11644)

### DIFF
--- a/pix-site/package.json
+++ b/pix-site/package.json
@@ -10,6 +10,8 @@
     "dev": "nuxt dev",
     "dev:site:fr": "SITE=pix-site SITE_DOMAIN=FR PORT=6001 DOMAIN_FR=http://localhost:6001 DOMAIN_ORG=http://localhost:7000 nuxt dev",
     "dev:site:org": "SITE=pix-site SITE_DOMAIN=ORG PORT=7000 DOMAIN_FR=http://localhost:6001 DOMAIN_ORG=http://localhost:7000 nuxt dev",
+    "dev:host:site:fr": "SITE=pix-site SITE_DOMAIN=FR PORT=6001 DOMAIN_FR=http://localhost:6001 DOMAIN_ORG=http://localhost:7000 nuxt dev --host",
+    "dev:host:site:org": "SITE=pix-site SITE_DOMAIN=ORG PORT=7000 DOMAIN_FR=http://localhost:6001 DOMAIN_ORG=http://localhost:7000 nuxt dev --host",
     "generate-fr": "SITE_DOMAIN=FR nuxt generate && cp -R ./.output/public ./build/fr ",
     "generate-org": "SITE_DOMAIN=ORG nuxt generate && cp -R ./.output/public  ./build/org ",
     "generate": "rm -rf ./build && mkdir build && npm run generate-fr && npm run generate-org",

--- a/shared/components/BurgerMenu/BurgerMenu.vue
+++ b/shared/components/BurgerMenu/BurgerMenu.vue
@@ -169,6 +169,7 @@ const toggleLocaleSwitcher = async () => {
   display: flex;
   flex-direction: column;
   width: 20rem;
+  height: 100vh;
   height: 100svh;
   background-color: $white;
   overflow-y: auto;

--- a/shared/components/BurgerMenu/BurgerMenu.vue
+++ b/shared/components/BurgerMenu/BurgerMenu.vue
@@ -169,7 +169,7 @@ const toggleLocaleSwitcher = async () => {
   display: flex;
   flex-direction: column;
   width: 20rem;
-  height: 100vh;
+  height: 100svh;
   background-color: $white;
   overflow-y: auto;
 }


### PR DESCRIPTION
## :unicorn: Problème

Sur la version mobile de Pix Site (tablette ou smartphone), le sélecteur de locale est présent mais pas visible pour permettre le changement de locale par un utilisateur.

<img src="https://github.com/1024pix/pix-site/assets/6919604/dcb36ad0-3f2e-4401-bcf9-5e00256030be" width="100">
<img src="https://github.com/1024pix/pix-site/assets/6919604/15b1c4eb-229d-47fb-b7da-ba1e68312d6e" width="100">

Cela est dû au fonctionnement de l'unité CSS `vh` qui ne convient pas avec fonctionnement des navigateurs mobile. Les navigateurs mobile ont 2 états d'affichage : **complète** ou **réduite**.

Lorsque l'on se trouve en haut de page, l'interface du navigateur mobile est complète _(ex: UI navigateur 15px, contenu 85px -- pour une taille d'écran de 100px)_.

Lorsque l'on commence à se déplacer vers le bas de la page, l'interface du navigateur mobile se réduit (ex: UI navigateur 10px, contenu 90px -- pour une taille d'écran de 100px).

L'unité `vh` va se baser sur la taille du contenu pour le calcul. Cela implique dans notre exemple que pour une taille d'écran de 100px, nous aurons 15px pour l'interface du navigateur et 90px pour le contenu, d'où le faite que le sélecteur de locale n'est pas affiché.

## :robot: Proposition

Utiliser une autre unité `svh` (s pour small), qui va se baser sur la plus grande taille de l'interface du navigateur et la plus petite taille du contenu.

- https://www.w3.org/TR/2021/WD-css-values-4-20211016/#small-viewport-percentage-units
- https://developer.mozilla.org/en-US/docs/Web/CSS/length#relative_length_units_based_on_viewport

## :rainbow: Remarques

RAS

## :100: Pour tester

#### Sur la RA

1. Aller sur Pix Site
2. Ouvrir votre console développeur
3. Activer le mode mobile (responsive design) - disponible sur Chrome et Firefox
4. Choisir un appareil mobile
5. Cliquer sur le burger menu
6. Constater l'affichage du sélecteur de locale
7. Changer l'orientation de l'appareil mobile
8. Constater l'affichage du sélecteur de locale

#### En local

1. Aller dans le dossier pix-site du repo pix-site
2. Exécuter la commande `npm run dev:host:site:org`
3. Choisir une locale
4. Suivre les étapes 2 à 8 de la partie RA ci-dessus

Avec l'option `--host` utilisé dans la commande npm `dev:host:site:org` vous pouvez faire vos tests sur des appareils mobile comme un iPhone, iPad, smartphone Android et tablette Android se trouvant sur votre réseau.