### PR TITLE
[BUGFIX] Réparer le prerender des pages enfants du centre d'aide

### DIFF
--- a/pix-pro/services/get-routes-to-generate.js
+++ b/pix-pro/services/get-routes-to-generate.js
@@ -21,10 +21,16 @@ export const getRoutesToGenerate = async function ({ locales }) {
 }
 
 async function getRoutesInPage(prismicClient, page, locales) {
+  const supportPageFilter = [
+    prismic.filter.not("document.type", "support__faq_post"),
+    prismic.filter.not("document.type", "support__persona_faq")
+  ];
+
   const { results, total_pages: totalPages } = await prismicClient.get({
     filters: [
       prismic.filter.at('document.tags', ['pix-pro']),
       prismic.filter.not('document.tags', ['fragment']),
+      ...supportPageFilter
     ],
     pageSize: 100,
     page,

--- a/pix-site/nuxt.config.ts
+++ b/pix-site/nuxt.config.ts
@@ -1,17 +1,9 @@
 import { getRoutesToGenerate } from "./services/get-routes-to-generate";
 import i18nConfig from "./i18n.config";
-
 export default async () => {
+  const routes = process.env.NODE_ENV !== 'test' ? await getRoutesToGenerate({ locales: i18nConfig.locales }) : [];
   return defineNuxtConfig({
       extends: ["../shared"],
-      hooks: {
-        async 'nitro:config' (nitroConfig) {
-          if (process.env.NODE_ENV === 'test') return;
-          const routes = await getRoutesToGenerate({ locales: i18nConfig.locales });
-          // @ts-ignore
-          nitroConfig.prerender.routes = routes;
-        },
-      },
       devServer: {
         port: Number(process.env.PORT) || 7000
       },
@@ -26,6 +18,7 @@ export default async () => {
       nitro: {
         prerender: {
           crawlLinks: false,
+          routes
         },
         devProxy: {
           "/geolocate": {
@@ -42,5 +35,4 @@ export default async () => {
 if (!process.env.SITE) {
   throw new Error("Missing SITE environment variable");
 }
-
 

--- a/pix-site/services/get-routes-to-generate.js
+++ b/pix-site/services/get-routes-to-generate.js
@@ -15,10 +15,17 @@ export const getRoutesToGenerate = async function({ locales }) {
 };
 
 async function getRoutesInPage(prismicClient, page, locales) {
+
+  const supportPageFilter = [
+    prismic.filter.not("document.type", "support__faq_post"),
+    prismic.filter.not("document.type", "support__persona_faq")
+  ];
+
   const { results, total_pages: totalPages } = await prismicClient.get({
       filters: [
         prismic.filter.at("document.tags", ["pix-site"]),
-        prismic.filter.not("document.tags", ["fragment"])
+        prismic.filter.not("document.tags", ["fragment"]),
+        ...supportPageFilter
       ],
       pageSize: 100,
       page,

--- a/shared/services/link-resolver.js
+++ b/shared/services/link-resolver.js
@@ -45,22 +45,6 @@ export function linkResolver(doc) {
     })
   }
 
-  if (doc.type === 'support__persona_faq') {
-    const urls = new Set()
-
-    doc.data.popular_posts.forEach(({ post }) => {
-      urls.add(`${locale}/support/post/${doc.uid}/${post.uid}`)
-    })
-
-    doc.data.body
-      .flatMap((category) => category.items)
-      .forEach(({ post }) => {
-        urls.add(`${locale}/support/post/${doc.uid}/${post.uid}`)
-      })
-
-    return [...urls]
-  }
-
   if (doc.type === 'easiware_form') {
     return `${locale}/support/form/${doc.uid}`
   }


### PR DESCRIPTION
## :unicorn: Problème

Le build ne fonctionnait plus sur les pages supports lorsque le tag "pix-site" ou "pix-pro" était activé sur ces pages.

## :robot: Proposition

Ne plus prendre en compte les pages de type `support__faq_post` et `support__persona_faq` dans le build.
Elles ne seront plus pré-rendues mais s'afficheront quand même.

## :rainbow: Remarques

Tant que ces pages ne sont pas indexées (exclues dans le `robots.txt`), ce n'est pas gênant.
Mais on traitera dans un second temps ces pages-là dans le `link-resolver` pour qu'elles soient pré-rendues.

## :100: Pour tester

- En RA, sur pix-site en Fr-fr, naviguer dans `/support`, dans le centre de certification et aller jusqu'au post, puis jusqu'au formulaire. 
