### PR TITLE
[BUGFIX] Réparer le lien pour passer sur le site international (PIX-11655)

### DIFF
--- a/pix-site/layouts/default.vue
+++ b/pix-site/layouts/default.vue
@@ -2,7 +2,7 @@
   <div id='app' class='app-viewport'>
     <skip-link />
     <hot-news-banner />
-    <locale-suggestion-banner :is-open='showBanner' @handleCloseBanner='closeLocaleSuggestionBanner' />
+    <locale-suggestion-banner :is-open='showBanner' :domain-org='domainOrg' @handleCloseBanner='closeLocaleSuggestionBanner' />
     <navigation-slice-zone />
     <main id='main' role='main' tabindex='-1'>
       <slot />
@@ -17,6 +17,9 @@ import { ref } from 'vue'
 const showBanner = ref(false)
 const { origin } = useRequestURL()
 
+const config = useAppConfig()
+const domainOrg = config.domainOrg
+
 useHead({
   titleTemplate: (titleChunk) => {
     return titleChunk ? `${titleChunk} | Pix` : 'Pix'
@@ -24,8 +27,8 @@ useHead({
 })
 
 onMounted(async () => {
-  // const { showOutOfFranceBanner } = useShowOutOfFranceBanner();
-  // showBanner.value = await showOutOfFranceBanner(origin, $fetch);
+  const { showOutOfFranceBanner } = useShowOutOfFranceBanner();
+  showBanner.value = await showOutOfFranceBanner(origin, $fetch);
 })
 
 const closeLocaleSuggestionBanner = () => {

--- a/shared/components/LocaleSuggestionBanner.vue
+++ b/shared/components/LocaleSuggestionBanner.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="isOpen" class="locale-suggestion-banner">
     <!-- eslint-disable-next-line vue/no-v-html -->
-    <p v-html="$t('locale-suggestion-banner-text')"></p>
+    <p v-html="$t('locale-suggestion-banner-text', {domainOrgUrl: domainOrg})"></p>
     <img
       class="close"
       src="/images/close-icon.svg"
@@ -19,6 +19,10 @@ export default {
       required: true,
       type: Boolean,
       default: false,
+    },
+    domainOrg: {
+      required: true,
+      type: String,
     },
   },
 }

--- a/shared/composables/useShowOutOfFranceBanner.ts
+++ b/shared/composables/useShowOutOfFranceBanner.ts
@@ -39,7 +39,6 @@ export default function useShowOutOfFranceBanner() {
 
 
     const country = await _getUserCountryFromGeolocationService(baseUrl, useFetch);
-    console.log({country});
 
     if (!country) return false;
 

--- a/shared/translations/en.js
+++ b/shared/translations/en.js
@@ -61,7 +61,7 @@ export default {
     <br/>If you need help, you can check out the
     <a href="https://support.pix.org/en/support/home">support</a>.
     </p>`,
-  'locale-suggestion-banner-text': `You don't seem to be in France. Do you want to access the <a href="${process.env.DOMAIN_ORG}">Pix international website</a>?`,
+  'locale-suggestion-banner-text': `You don't seem to be in France. Do you want to access the <a href="{domainOrgUrl}">Pix international website</a>?`,
   'skip-link': 'Skip to content',
   'burger-menu': {
     name: 'Main Navigation',

--- a/shared/translations/fr-be.js
+++ b/shared/translations/fr-be.js
@@ -62,7 +62,7 @@ export default {
     <br/>Si vous avez besoin d’aide, vous pouvez consulter le
     <a href="https://support.pix.org/fr/support/home">support</a>.
     </p>`,
-  'locale-suggestion-banner-text': `Vous semblez ne pas être en France. Voulez-vous accéder au <a href="${process.env.DOMAIN_ORG}">site Pix international</a> ?`,
+  'locale-suggestion-banner-text': `Vous semblez ne pas être en France. Voulez-vous accéder au <a href="{domainOrgUrl}">site Pix international</a> ?`,
   'skip-link': 'Aller au contenu',
   'burger-menu': {
     name: 'Navigation principale',

--- a/shared/translations/fr-fr.js
+++ b/shared/translations/fr-fr.js
@@ -62,7 +62,7 @@ export default {
     <br/>Si vous avez besoin d’aide, vous pouvez consulter le
     <a href="https://support.pix.org/fr/support/home">support</a>.
     </p>`,
-  'locale-suggestion-banner-text': `Vous semblez ne pas être en France. Voulez-vous accéder au <a href="${process.env.DOMAIN_ORG}">site Pix international</a> ?`,
+  'locale-suggestion-banner-text': `Vous semblez ne pas être en France. Voulez-vous accéder au <a href="{domainOrgUrl}">site Pix international</a> ?`,
   'skip-link': 'Aller au contenu',
   'burger-menu': {
     name: 'Navigation principale',

--- a/shared/translations/fr.js
+++ b/shared/translations/fr.js
@@ -62,7 +62,7 @@ export default {
     <br/>Si vous avez besoin d’aide, vous pouvez consulter le
     <a href="https://support.pix.org/fr/support/home">support</a>.
     </p>`,
-  'locale-suggestion-banner-text': `Vous semblez ne pas être en France. Voulez-vous accéder au <a href="${process.env.DOMAIN_ORG}">site Pix international</a> ?`,
+  'locale-suggestion-banner-text': `Vous semblez ne pas être en France. Voulez-vous accéder au <a href="{domainOrgUrl}">site Pix international</a> ?`,
   'skip-link': 'Aller au contenu',
   'burger-menu': {
     name: 'Navigation principale',

--- a/shared/translations/nl-be.js
+++ b/shared/translations/nl-be.js
@@ -62,7 +62,7 @@ export default {
     <br/>Si vous avez besoin d’aide, vous pouvez consulter le
     <a href="https://support.pix.org/fr/support/home">support</a>.
     </p>`,
-  "locale-suggestion-banner-text": `Vous semblez ne pas être en France. Voulez-vous accéder au <a href="${process.env.DOMAIN_ORG}">site Pix international</a> ?`,
+  "locale-suggestion-banner-text": `Vous semblez ne pas être en France. Voulez-vous accéder au <a href="{domainOrgUrl}">site Pix international</a> ?`,
   "skip-link": "Aller au contenu",
   "burger-menu": {
     name: "Navigation principale",


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu’on est sur le domaine .fr et que nous sommes hors de France, alors s’affiche un bandeau qui invite à basculer sur le domaine .org. Le lien dans ce bandeau n’est pas fonctionnel. Il redirige vers le domaine .fr.

![Screenshot 2024-03-21 at 12 46 24](https://github.com/1024pix/pix-site/assets/6919604/22cdab36-2cc4-4a04-b7f3-4026395a3001)


## :robot: Proposition

Faire en sorte que le lien du bandeau soit celui du domaine .org (*.pix.org)

## :rainbow: Remarques

RAS

## :100: Pour tester

Si vous n'êtes pas hors de France, vous devez utiliser un VPN.

1. Être hors de France
2. Aller sur le site vitrine du domaine .fr
3. Constater l'affichage d'un bandeau vous proposant de basculer sur le domaine .org
4. Cliquer sur le lien du bandeau
5. Constater l'affichage
    - Soit de la page d'accueil car vous aviez un cookie déjà présent (locale)
    - Soit de la page de choix de locale
