### PR TITLE
[TECH]Rediriger les pages pix.fr vers supports.pix.org

### DIFF
--- a/pix-site/servers.conf.erb
+++ b/pix-site/servers.conf.erb
@@ -67,6 +67,7 @@ server {
 
   rewrite ^/en-gb(.*)$ /en$1 permanent;
   rewrite ^/(aide|help)$ https://support.pix.org redirect;
+  rewrite ^/support/(enseignement-scolaire|enseignement-superieur|mediation-numerique|centre-de-certification|professionnel)$ https://support.pix.org redirect;
   rewrite ^/employeurs$ https://pro.pix.fr redirect;
 
   error_page 400 401 403 404 418 500 502 503 504 /404.html;


### PR DESCRIPTION
## :unicorn: Problème
Dans le chantier de sortie des nouvelles pages du support, il va falloir modifier les redirection de [support.pix.fr](http://support.pix.fr/) /org vers les nouvelles pages.
Par contre, dans un premier temps, certaines pages doivent rediriger sur l’ancien lien.

## :robot: Proposition
pour les redirections à mettre en place, voici la liste des liens qui doivent pointer vers https://support.pix.org/ :

https://pix.fr/support/enseignement-scolaire

https://pix.fr/support/enseignement-superieur

https://pix.fr/support/mediation-numerique

https://pix.fr/support/centre-de-certification

https://pix.fr/support/professionnel



Modifier ce fichier pour rajouter les redirections
https://github.com/1024pix/pix-site/blob/dev/pix-site/servers.conf.erb

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
