### PR TITLE
[TECH] : Delete enseignement-scolaire/enseignant-ou-personnel-de-direction redirection to support.pix.org

### DIFF
--- a/pix-site/servers.conf.erb
+++ b/pix-site/servers.conf.erb
@@ -67,7 +67,7 @@ server {
 
   rewrite ^/en-gb(.*)$ /en$1 permanent;
   rewrite ^/(aide|help)$ https://support.pix.org redirect;
-  rewrite ^/support/(enseignement-scolaire/enseignant-ou-personnel-de-direction|enseignement-superieur|mediation-numerique|centre-de-certification|professionnel)$ https://support.pix.org redirect;
+  rewrite ^/support/(enseignement-superieur|mediation-numerique|centre-de-certification|professionnel)$ https://support.pix.org redirect;
   rewrite ^/employeurs$ https://pro.pix.fr redirect;
 
   error_page 400 401 403 404 418 500 502 503 504 /404.html;


### PR DESCRIPTION
## :unicorn: Problème
Pour lancer le centre d'aide pour l'enseignement secondaire il faut supprimer la redirection de enseignement-scolaire/enseignant-ou-personnel-de-direction vers support.pix.org

## :robot: Proposition
Modifier le fichier servers.conf.erb en supprimant la redirection

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
plus de redirection vers support.pix.org