### PR TITLE
[TECH] Initial Dockerfile to host pix-site in scaleway

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+**/node_modules
+*~
+*.bak
+*.swp
+.cache/
+tmp/
+temp/
+.npm/
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,39 @@
+ARG SITE=pix-site
+
 FROM node:18.20-alpine AS build-stage
 
-RUN apk update  \
-  && apk add ruby
+ARG SITE
+COPY ${SITE}/package-lock.json /code/${SITE}/package-lock.json
+COPY ${SITE}/package.json /code/${SITE}/package.json
 
-COPY pix-site code/pix-site
-COPY shared code/shared
-
-ENV SITE=pix-site
+COPY shared /code/shared
 
 WORKDIR /code/shared
-RUN npm install
 
-WORKDIR ../pix-site
-RUN npm install
+RUN npm ci
+
+WORKDIR /code/${SITE}
+
+RUN npm ci
+
+RUN ls /code/
+RUN ls /code/
+COPY ${SITE}/ /code/${SITE}
+
 RUN npm run build
 
+FROM nginx:1.26.0-alpine AS run-stage
+ARG SITE
+
 ENV PORT=80
-RUN erb servers.conf.erb > nginx.conf
+ENV NGINX_GEOAPI_UPSTREAM_HOST=localhost
 
-FROM nginx:alpine AS run-stage
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+ && ln -sf /dev/stderr /var/log/nginx/error.log
 
-COPY --from=build-stage /code/pix-site/build /app/build/
-COPY --from=build-stage /code/pix-site/nginx.conf /etc/nginx/conf.d/pix-site.conf
-
-RUN chown -R nginx:nginx /app/
-RUN mv /etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf.backup
+COPY --from=build-stage /code/${SITE}/build /usr/share/nginx/html 
+COPY ${SITE}/nginx/templates /etc/nginx/templates
+COPY ${SITE}/nginx/includes /etc/nginx/includes
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:18.20-alpine AS build-stage
+
+RUN apk update  \
+  && apk add ruby
+
+COPY pix-site code/pix-site
+COPY shared code/shared
+
+ENV SITE=pix-site
+
+WORKDIR /code/shared
+RUN npm install
+
+WORKDIR ../pix-site
+RUN npm install
+RUN npm run build
+
+ENV PORT=80
+RUN erb servers.conf.erb > nginx.conf
+
+FROM nginx:alpine AS run-stage
+
+COPY --from=build-stage /code/pix-site/build /app/build/
+COPY --from=build-stage /code/pix-site/nginx.conf /etc/nginx/conf.d/pix-site.conf
+
+RUN chown -R nginx:nginx /app/
+RUN mv /etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf.backup
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,44 @@
 ARG SITE=pix-site
-
 FROM node:18.20-alpine AS build-stage
-
 ARG SITE
+
+# Copy des packages.json 
 COPY ${SITE}/package-lock.json /code/${SITE}/package-lock.json
 COPY ${SITE}/package.json /code/${SITE}/package.json
 
-COPY shared /code/shared
+COPY shared/package-lock.json /code/shared/package-lock.json
+COPY shared/package.json /code/shared/package.json
 
 WORKDIR /code/shared
 
+# Installation des nodes_modules 
 RUN npm ci
 
 WORKDIR /code/${SITE}
 
 RUN npm ci
 
-RUN ls /code/
-RUN ls /code/
+# Copy du code
+COPY shared /code/shared
 COPY ${SITE}/ /code/${SITE}
+
+# Build de l'application 
 
 RUN npm run build
 
 FROM nginx:1.26.0-alpine AS run-stage
 ARG SITE
 
-ENV PORT=80
-ENV NGINX_GEOAPI_UPSTREAM_HOST=localhost
-
+# Prise en compte des logs nginx avec Alpine 
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
  && ln -sf /dev/stderr /var/log/nginx/error.log
 
+ENV PORT=80
+ENV NGINX_GEOAPI_UPSTREAM_HOST=localhost
+
+# Récupération du build et de la configuration 
 COPY --from=build-stage /code/${SITE}/build /usr/share/nginx/html 
 COPY ${SITE}/nginx/templates /etc/nginx/templates
 COPY ${SITE}/nginx/includes /etc/nginx/includes
 
-EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,45 @@
+# Installation
+
+## Builpack
+
+Ce projet est compatible avec les buildpacks de scalingo.
+Deux répertoires 
+- pix-site
+- pix-pro
+
+## Docker
+
+Un dockerfile est diposible à la racine du projet, pour pix-site et pix-pro
+
+### Build pix-site
+
+```
+docker build \
+--build-arg "DOMAIN_FR=localhost:8080" \
+--build-arg "DOMAIN_ORG=localhost:8080" \
+--build-arg "SITE=pix-site" \
+-t pix-site .
+```
+### Run pix-site
+
+```
+docker run -ti -p 8080:80 pix-site
+
+```
+
+### Build pix-pro
+
+```
+docker build \
+--build-arg "DOMAIN_FR=localhost:8080" \
+--build-arg "DOMAIN_ORG=localhost:8080" \
+--build-arg "SITE=pix-pro" \
+-t pix-pro .
+```
+
+### Run pix-pro
+
+```
+docker run -ti -p 8080:80 pix-pro
+
+```

--- a/pix-pro/nginx/includes/rewrites.conf
+++ b/pix-pro/nginx/includes/rewrites.conf
@@ -1,0 +1,3 @@
+rewrite ^/en-gb(.*)$ /en$1 permanent;
+rewrite ^/(aide|help)$ https://support.pix.org redirect;
+rewrite ^/employeurs$ https://pro.pix.fr redirect;

--- a/pix-pro/nginx/templates/default.conf.template
+++ b/pix-pro/nginx/templates/default.conf.template
@@ -9,17 +9,14 @@ log_format keyvalue
   ' duration=${request_time}s'
   ' bytes=$bytes_sent'
   ' referer="$http_referer"'
-  ' user_agent="$http_user_agent"'<%#
-    To allow dynamic logging format for nginx,
-    create a json that contains the key/value pairs
-    you want to add to nginx logging.
-    For the logs to be correctly parsed, use the nginx_logger_version parameter.
-    For example:
-    ADDITIONAL_NGINX_LOGS='{"nginx_logger_version":"1", "my_custom_header":"$http_my_custom_header"}'
-  %><%
-    require 'json';
-    JSON.parse(ENV['ADDITIONAL_NGINX_LOGS']||'{}').each do |nginx_key,value| %>
-  ' <%= nginx_key %>="<%= value %>"'<% end %>;
+  ' user_agent="$http_user_agent"'
+  ' nginx_logger_version="1"'
+  ' bln_ja3="$http_bln_ssl_ja3_hash"'
+  ' bln_fate="$http_bln_request_fate"'
+  ' bln_fate_action="$http_bln_request_fate_action"'
+  ' bln_debug_path="$http_bln_debug_path"'
+  ' cookie_locale="$cookie_locale"'
+  ' nuxt-version="3"';
 
 # In order to avoid logging access twice per request
 # it is necessary to turn off the top-level (e.g. http) buildpack default access_log
@@ -28,16 +25,15 @@ access_log off;
 
 port_in_redirect off;
 
-<% if ENV['NGINX_GEOAPI_UPSTREAM_HOST'] %>
 upstream api {
-  server <%= ENV['NGINX_GEOAPI_UPSTREAM_HOST'] %>:443 max_fails=<%= ENV['NGINX_GEOAPI_UPSTREAM_MAX_FAILS'] || 3 %> fail_timeout=<%= ENV['NGINX_GEOAPI_UPSTREAM_FAIL_TIMEOUT'] || '5s' %>;
+  server ${NGINX_GEOAPI_UPSTREAM_HOST}:443 max_fails=3 fail_timeout=5s;
 }
-<% end %>
 
 server {
-  access_log logs/access.log keyvalue;
+  error_log /dev/stderr info;
+  access_log /dev/stdout keyvalue;
 
-  listen <%= ENV['PORT'] %>;
+  listen ${PORT};
 
   server_name ~(?<extension>(fr|org))$;
   if ($extension = '') {
@@ -48,14 +44,14 @@ server {
     set $extension 'org';
   }
 
-<% if ENV['NGINX_GEOAPI_UPSTREAM_HOST'] %>
+
   location /geolocate {
     proxy_pass https://api/me;
     proxy_redirect default;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host <%= ENV['NGINX_GEOAPI_UPSTREAM_HOST'] %>;
+    proxy_set_header Host ${NGINX_GEOAPI_UPSTREAM_HOST};
   }
-<% end %>
+
 
   charset utf-8;
 
@@ -63,9 +59,9 @@ server {
   gzip off;
 
   # Serve from dist/pix.fr or dist/pix.org depending on the extension
-  root /app/build/$extension;
+  root /usr/share/nginx/html/$extension;
 
-  include /app/nginx/includes/rewrites.conf;
+  include includes/rewrites.conf;
 
   error_page 400 401 403 404 418 500 502 503 504 /404.html;
 

--- a/pix-site/nginx/includes/rewrites.conf
+++ b/pix-site/nginx/includes/rewrites.conf
@@ -1,0 +1,4 @@
+rewrite ^/en-gb(.*)$ /en$1 permanent;
+rewrite ^/(aide|help)$ https://support.pix.org redirect;
+rewrite ^/support/(enseignement-superieur|mediation-numerique|centre-de-certification|professionnel)$ https://support.pix.org redirect;
+rewrite ^/employeurs$ https://pro.pix.fr redirect;

--- a/pix-site/nginx/templates/default.conf.template
+++ b/pix-site/nginx/templates/default.conf.template
@@ -9,17 +9,14 @@ log_format keyvalue
   ' duration=${request_time}s'
   ' bytes=$bytes_sent'
   ' referer="$http_referer"'
-  ' user_agent="$http_user_agent"'<%#
-    To allow dynamic logging format for nginx,
-    create a json that contains the key/value pairs
-    you want to add to nginx logging.
-    For the logs to be correctly parsed, use the nginx_logger_version parameter.
-    For example:
-    ADDITIONAL_NGINX_LOGS='{"nginx_logger_version":"1", "my_custom_header":"$http_my_custom_header"}'
-  %><%
-    require 'json';
-    JSON.parse(ENV['ADDITIONAL_NGINX_LOGS']||'{}').each do |nginx_key,value| %>
-  ' <%= nginx_key %>="<%= value %>"'<% end %>;
+  ' user_agent="$http_user_agent"'
+  ' nginx_logger_version="1"'
+  ' bln_ja3="$http_bln_ssl_ja3_hash"'
+  ' bln_fate="$http_bln_request_fate"'
+  ' bln_fate_action="$http_bln_request_fate_action"'
+  ' bln_debug_path="$http_bln_debug_path"'
+  ' cookie_locale="$cookie_locale"'
+  ' nuxt-version="3"';
 
 # In order to avoid logging access twice per request
 # it is necessary to turn off the top-level (e.g. http) buildpack default access_log
@@ -28,16 +25,15 @@ access_log off;
 
 port_in_redirect off;
 
-<% if ENV['NGINX_GEOAPI_UPSTREAM_HOST'] %>
 upstream api {
-  server <%= ENV['NGINX_GEOAPI_UPSTREAM_HOST'] %>:443 max_fails=<%= ENV['NGINX_GEOAPI_UPSTREAM_MAX_FAILS'] || 3 %> fail_timeout=<%= ENV['NGINX_GEOAPI_UPSTREAM_FAIL_TIMEOUT'] || '5s' %>;
+  server ${NGINX_GEOAPI_UPSTREAM_HOST}:443 max_fails=3 fail_timeout=5s;
 }
-<% end %>
 
 server {
-  # access_log logs/access.log keyvalue;
+  error_log /dev/stderr info;
+  access_log /dev/stdout;
 
-  listen <%= ENV['PORT'] %>;
+  listen ${PORT};
 
   server_name ~(?<extension>(fr|org))$;
   if ($extension = '') {
@@ -48,14 +44,13 @@ server {
     set $extension 'org';
   }
 
-<% if ENV['NGINX_GEOAPI_UPSTREAM_HOST'] %>
+
   location /geolocate {
     proxy_pass https://api/me;
     proxy_redirect default;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host <%= ENV['NGINX_GEOAPI_UPSTREAM_HOST'] %>;
+    proxy_set_header Host pix-geoapi-production.osc-secnum-fr1.scalingo.io;
   }
-<% end %>
 
   charset utf-8;
 
@@ -63,9 +58,9 @@ server {
   gzip off;
 
   # Serve from dist/pix.fr or dist/pix.org depending on the extension
-  root /app/build/$extension;
+  root /usr/share/nginx/html/$extension;
 
-  include /app/nginx/includes/rewrites.conf;
+  include includes/rewrites.conf;
 
   error_page 400 401 403 404 418 500 502 503 504 /404.html;
 

--- a/pix-site/nginx/templates/default.conf.template
+++ b/pix-site/nginx/templates/default.conf.template
@@ -1,3 +1,5 @@
+# Fichier de configuration template utilisé uniquement pour Docker
+
 log_format keyvalue
   'method=$request_method'
   ' path="$request_uri"'
@@ -49,7 +51,7 @@ server {
     proxy_pass https://api/me;
     proxy_redirect default;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host pix-geoapi-production.osc-secnum-fr1.scalingo.io;
+    proxy_set_header Host ${NGINX_GEOAPI_UPSTREAM_HOST};
   }
 
   charset utf-8;

--- a/pix-site/servers.conf.erb
+++ b/pix-site/servers.conf.erb
@@ -35,7 +35,7 @@ upstream api {
 <% end %>
 
 server {
-  # access_log logs/access.log keyvalue;
+  access_log logs/access.log keyvalue;
 
   listen <%= ENV['PORT'] %>;
 

--- a/pix-site/servers.conf.erb
+++ b/pix-site/servers.conf.erb
@@ -35,7 +35,7 @@ upstream api {
 <% end %>
 
 server {
-  access_log logs/access.log keyvalue;
+  # access_log logs/access.log keyvalue;
 
   listen <%= ENV['PORT'] %>;
 


### PR DESCRIPTION
## :unicorn: Problème
Les applications de ce repo ne sont pas déployable sur un autre hébergeur utilisant des images docker

## :robot: Proposition

Ajouter un Dockerfile générique qui nous permet de build les 2 sites en image Docker.

## :rainbow: Remarques

> La configuration ne fonctionne pas totalement en local si on utilise un port custom (ex localhost:8080)


> On a modifié la configuration Nginx pour utiliser les templates nginx de Docker pour rendre cette configuration plus propre.



## :100: Pour tester

```sh
docker build --build-arg SITE=pix-site -t pix-image . 

docker run -ti -p 8080:80 pix-site 
```


CI en vert > Validation que Scalingo fonctionne toujours 