### PR TITLE
[BUGFIX] Afficher la liste complète des locales disponibles sur mobile (PIX-12477)

### DIFF
--- a/pix-pro/components/LocaleSwitcher.vue
+++ b/pix-pro/components/LocaleSwitcher.vue
@@ -59,10 +59,9 @@
 import { reachableLocales } from '../i18n.config';
 import { onClickOutside } from '@vueuse/core';
 
-const { getEnvironmentUrl } = useEnvironmentUrl();
 const { setLocaleCookie } = useLocaleCookie();
 
-const { localeProperties, locales, t } = useI18n();
+const { localeProperties, t } = useI18n();
 
 const frLocale = reachableLocales.find((l) => l.code === 'fr');
 const enLocale = reachableLocales.find((l) => l.code === 'en');

--- a/pix-pro/nuxt.config.ts
+++ b/pix-pro/nuxt.config.ts
@@ -1,5 +1,5 @@
 import { getRoutesToGenerate } from './services/get-routes-to-generate';
-import i18nConfig from './i18n.config';
+import i18nConfig, { reachableLocales } from './i18n.config';
 
 export default async () => {
   return defineNuxtConfig({
@@ -19,6 +19,7 @@ export default async () => {
     runtimeConfig: {
       public: {
         site: 'https://pro.pix.',
+        availableLocales: reachableLocales,
       },
     },
     nitro: {

--- a/pix-site/components/LocaleSwitcher.vue
+++ b/pix-site/components/LocaleSwitcher.vue
@@ -79,10 +79,9 @@
 import { reachableLocales } from '../i18n.config';
 import { onClickOutside } from '@vueuse/core';
 
-const { getEnvironmentUrl } = useEnvironmentUrl();
 const { setLocaleCookie } = useLocaleCookie();
 
-const { localeProperties, locales, t } = useI18n();
+const { localeProperties, t } = useI18n();
 
 const frLocale = reachableLocales.find((l) => l.code === 'fr');
 const enLocale = reachableLocales.find((l) => l.code === 'en');

--- a/pix-site/nuxt.config.ts
+++ b/pix-site/nuxt.config.ts
@@ -1,7 +1,9 @@
 import { getRoutesToGenerate } from './services/get-routes-to-generate';
-import i18nConfig from './i18n.config';
+import i18nConfig, { reachableLocales } from './i18n.config';
+
 export default async () => {
   const routes = process.env.NODE_ENV !== 'test' ? await getRoutesToGenerate({ locales: i18nConfig.locales }) : [];
+
   return defineNuxtConfig({
     extends: ['../shared'],
     devServer: {
@@ -13,6 +15,7 @@ export default async () => {
         site: 'https://pix.',
         siteDomain: process.env.SITE_DOMAIN,
         formKeysToMap: process.env.FORM_KEYS_TO_MAP || null,
+        availableLocales: reachableLocales,
       },
     },
     nitro: {

--- a/shared/components/BurgerMenu/BurgerMenuLocalesList.vue
+++ b/shared/components/BurgerMenu/BurgerMenuLocalesList.vue
@@ -16,14 +16,14 @@
       {{ localeProperties.name }}
     </button>
     <ul ref="localeSwitcher" class="burger-menu-locales-list__items" tabindex="0">
-      <li v-for="locale in locales" :key="locale.code">
+      <li v-for="locale in availableLocales" :key="locale.code">
         <a
-          :href="getEnvironmentUrl(`${locale.domain || ''}/${locale.code}`)"
+          :href="getEnvironmentUrl(`${locale.domain || ''}/${locale.code === frFrLocale.code ? '' : locale.code}`)"
           :aria-current="localeProperties.code === locale.code && 'page'"
           @click="updateLocaleCookie(locale.code)"
         >
           <img :src="`/images/${locale.icon}`" alt="" />
-          {{ locale.name }}
+          <span>{{ locale.name }}</span>
         </a>
       </li>
     </ul>
@@ -33,8 +33,12 @@
 <script setup>
 const { getEnvironmentUrl } = useEnvironmentUrl();
 const { setLocaleCookie } = useLocaleCookie();
+const runtimeConfig = useRuntimeConfig();
+const { localeProperties, t } = useI18n();
 
-const { localeProperties, locales, t } = useI18n();
+const availableLocales = runtimeConfig.public.availableLocales;
+
+const frFrLocale = availableLocales.find((l) => l.code === 'fr-fr');
 
 const props = defineProps({
   isLocaleSwitcherOpen: {


### PR DESCRIPTION
## :unicorn: Problème

Lorsque l’utilisateur utilise un mobile et se trouve sur le domaine .fr, le _locale switcher_ affiche uniquement France comme locale disponible. Le problème se pose également sur le domaine .org, le _locale switcher_ n'affiche pas la locale France.

En principe, toutes les locales doivent être affichées. L’objectif serait d’afficher l’intégralité des locales.

## :robot: Proposition

Afficher toute la liste des locales disponibles sur les domaines .fr et .org du site.

## :rainbow: Remarques

RAS

## :100: Pour tester

#### Domaine .org

1. Ouvrir un nouvel onglet sur le domaine *.pix.org 
2. Reduire la taille d'affiche de cet onglet pour obtenir un aperçu mobile
3. Cliquer sur le _Burger Menu_
4. Changer la locale
5. Constater l'affichage de toute la liste des locales disponibles

#### Domaine .fr

1. Ouvrir un nouvel onglet sur le domaine *.pix.fr
2. Reduire la taille d'affiche de cet onglet pour obtenir un aperçu mobile
3. Cliquer sur le _Burger Menu_
4. Changer la locale
5. Constater l'affichage de toute la liste des locales disponibles