### PR TITLE
[BUGFIX] Rendre accessible le cookie "locale" pour tous les sous domaines pix.org  (PIX-12448)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,8 @@ jobs:
           name: Lint
           command: |
             npm run lint
-  
-  
+
+
   test-shared:
     executor:
       name: node-docker
@@ -75,6 +75,9 @@ jobs:
             - ~/.npm
       - run:
           name: Test
+          environment:
+            DOMAIN_FR: 'https://example.fr'
+            DOMAIN_ORG: 'https://example.org'
           command: |
             npm test
 
@@ -102,6 +105,8 @@ jobs:
           environment:
             SITE: pix-site
             SITE_DOMAIN: 'ORG'
+            DOMAIN_FR: 'https://example.fr'
+            DOMAIN_ORG: 'https://example.org'
           command: |
             npm test
 

--- a/pix-site/tests/integration/components/LocaleSwitcher.test.ts
+++ b/pix-site/tests/integration/components/LocaleSwitcher.test.ts
@@ -10,6 +10,19 @@ mockNuxtImport('useI18n', () => {
     return { localeProperties, t: (str) => str };
   };
 });
+mockNuxtImport('useAppConfig', () => {
+  return () => ({
+    domainFr: 'https://example.fr',
+    domainOrg: 'https://example.org',
+  });
+});
+mockNuxtImport('useRuntimeConfig', () => {
+  return () => ({
+    public: {
+      siteDomain: 'ORG',
+    },
+  });
+});
 
 describe('LocaleSwitcher', () => {
   beforeEach(() => {

--- a/shared/composables/useLocaleCookie.ts
+++ b/shared/composables/useLocaleCookie.ts
@@ -4,6 +4,11 @@ export default function useLocaleCookie() {
   const domainFrUrl = new URL(appConfig.domainFr);
   const domainOrgUrl = new URL(appConfig.domainOrg);
 
+  const previousLocaleCookie = useCookie('locale', {
+    maxAge: 31536000,
+    sameSite: 'strict',
+  });
+
   const localeCookie = useCookie('locale', {
     domain: runtimeConfig.public.siteDomain === 'ORG' ? domainOrgUrl.hostname : domainFrUrl.hostname,
     maxAge: 31536000,
@@ -12,6 +17,9 @@ export default function useLocaleCookie() {
 
   function setLocaleCookie(locale: string, callback?: Function): void {
     const localeCanonicalName = Intl.getCanonicalLocales(locale)?.[0];
+    if (previousLocaleCookie.value) {
+      previousLocaleCookie.value = null;
+    }
     localeCookie.value = localeCanonicalName;
     if (callback) callback();
   }

--- a/shared/composables/useLocaleCookie.ts
+++ b/shared/composables/useLocaleCookie.ts
@@ -1,5 +1,11 @@
 export default function useLocaleCookie() {
+  const appConfig = useAppConfig();
+  const runtimeConfig = useRuntimeConfig();
+  const domainFrUrl = new URL(appConfig.domainFr);
+  const domainOrgUrl = new URL(appConfig.domainOrg);
+
   const localeCookie = useCookie('locale', {
+    domain: runtimeConfig.public.siteDomain === 'ORG' ? domainOrgUrl.hostname : domainFrUrl.hostname,
     maxAge: 31536000,
     sameSite: 'strict',
   });

--- a/shared/nuxt.config.ts
+++ b/shared/nuxt.config.ts
@@ -8,9 +8,9 @@ const config = {
     },
   },
   appConfig: {
-    site: process.env.SITE,
     domainFr: process.env.DOMAIN_FR,
     domainOrg: process.env.DOMAIN_ORG,
+    site: process.env.SITE,
   },
   alias: {
     '@shared': resolve(__dirname, '../shared'),

--- a/shared/tests/composables/useLocaleCookie.test.ts
+++ b/shared/tests/composables/useLocaleCookie.test.ts
@@ -8,6 +8,19 @@ mockNuxtImport('useCookie', () => {
     value: '',
   });
 });
+mockNuxtImport('useAppConfig', () => {
+  return () => ({
+    domainFr: 'https://example.fr',
+    domainOrg: 'https://example.org',
+  });
+});
+mockNuxtImport('useRuntimeConfig', () => {
+  return () => ({
+    public: {
+      siteDomain: 'ORG',
+    },
+  });
+});
 
 describe('#useLocaleCookie', () => {
   test('returns a locale cookie and a "setLocaleCookie" function', () => {


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu’un utilisateur arrive https://pix.org/ et sélectionne une locale, un cookie locale est crée avec comme domaine [pix.org](http://pix.org/) et non `.pix.org`.

Cela empêche les applications, se trouvant sur le domaine .org (ex: [app.pix.org](http://app.pix.org/), [orga.pix.org](http://orga.pix.org/)…) de lire le contenu de ce cookie.

<img width="350" alt="Capture d’écran 2024-05-06 à 16 03 40" src="https://github.com/1024pix/pix-site/assets/6919604/38b362e0-1590-4bcc-8903-b6ec42d00925">

## :robot: Proposition

Modifier le domaine du cookie pour que les sous domaines de `pix.org` soit pris en compte.

## :rainbow: Remarques

Si un cookie est déjà présent mais avec le domaine par défaut défini par le navigateur, ce dernier sera supprimé.

## :100: Pour tester

1. Aller sur le domaine .org du site
2. Choisir une locale
3. Vérifier dans les cookies du navigateur qu'une entrée `locale` a été ajouté et associé au domaine `.<hostname>`
