### PR TITLE
[BUGFIX] Améliorer le style de la grille de statistiques présentes en accueil (PIX-12737).

### DIFF
--- a/shared/assets/scss/components/slices/statistics.scss
+++ b/shared/assets/scss/components/slices/statistics.scss
@@ -6,7 +6,9 @@
 
 .statistics__wrapper {
   display: flex;
-  flex-direction: column;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 32px;
   margin-bottom: 24px;
 
   &:last-child {
@@ -16,20 +18,13 @@
 
 .statistics-wrapper {
   &__item {
-    height: 196px;
-    width: 100%;
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin-bottom: 32px;
-
-    &:last-child {
-      margin-right: 0;
-      margin-bottom: 32px;
-    }
+    min-width: min(300px, 90vw);
 
     img {
-      max-height: 65px;
+      height: 80px;
     }
   }
 }
@@ -56,19 +51,17 @@
   }
 
   &__title h3 {
-    width: 293px;
     color: $grey-90;
     text-align: center;
     font-size: 2rem;
     letter-spacing: 0;
     line-height: 43px;
     font-weight: $font-semi-bold;
-    margin-top: 17px;
+    margin-top: 12px;
   }
 
   &__description {
     text-align: center;
-    width: 293px;
     color: $grey-45;
     font-size: 1.25rem;
     letter-spacing: 0;
@@ -77,26 +70,6 @@
 
     p {
       margin: 0;
-    }
-  }
-}
-
-@include device-is('tablet') {
-  .statistics__wrapper {
-    flex-direction: row;
-  }
-}
-
-@include device-is('large-screen') {
-  .statistics__wrapper {
-    padding: 0 98px;
-    max-width: 1920px;
-    margin: 0 auto 24px;
-  }
-
-  .statistics-wrapper {
-    &__item {
-      margin-bottom: 61px;
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème

Les picto ne s'affichent plus sur les multipleblocks "statistics"

## :robot: Proposition

Améliorer le style de la slice pour avoir une meilleur grille responsive

## :100: Pour tester

https://site-pr659.review.pix.fr/#slice-11
