### PR TITLE
[BUGFIX] Enlever l'appel Prismic pour récupérer les dernières actualités en production (PIX-12739)

### DIFF
--- a/shared/components/slices/LatestNews.vue
+++ b/shared/components/slices/LatestNews.vue
@@ -32,13 +32,15 @@ const props = defineProps({
 });
 
 /* Fetch last news */
-const latestNews = await client.getAllByType('news_item', {
-  lang: i18nLocale.value,
-  limit: 3,
-  orderings: {
-    field: 'my.news_item.date',
-    direction: 'desc',
-  },
+const { data: latestNews } = await useAsyncData(async () => {
+  return await client.getAllByType('news_item', {
+    lang: i18nLocale.value,
+    limit: 3,
+    orderings: {
+      field: 'my.news_item.date',
+      direction: 'desc',
+    },
+  });
 });
 
 /* Computed */


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, à chaque arrivée sur [pix.fr/pix.org](http://pix.fr/pix.org), un appel vers Prismic se fait pour récupérer les dernières actualités.
Cela n’est pas normal, car le build en SSG (Static Site Generation) est censé générer tout le contenu statique nécessaire pour afficher toutes les pages en production.

## :robot: Proposition
Enlever l’appel en production en récupérant, uniquement à la construction des pages statiques, la liste des dernières actualités du site vitrine.

## :rainbow: Remarques
RAS

## :100: Pour tester
### Reproduire le bug en production
- Ouvrir la console navigateur => onglet Network
- Aller sur pix.fr 
- Constater qu'un appel vers l'API Prismic `/api/v2/documents/search?q=[[at(document.type, "news_item")]]`

### Tester la correction
- Ouvrir la console navigateur => onglet Network
- Aller sur la RA https://site-pr660.review.pix.fr/
- Vérifier que l'appel `/api/v2/documents/search?q=[[at(document.type, "news_item")]]` n'est plus visible dans la console !
