### PR TITLE
[BUGFIX] Rendre les formulaires support multilingues(PIX-12765).

### DIFF
--- a/shared/components/EasiwareForm.vue
+++ b/shared/components/EasiwareForm.vue
@@ -25,7 +25,6 @@ onMounted(() => {
   createEasiwareForm({
     solutionId: props.solutionId,
     formId: props.formId,
-    language: 'fr',
     elementToBuildIn: 'easiwareform',
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Les champs de formulaire support s'affichent en français même dans une page d'une autre langue ([voir exemple](https://pro.pix.org/en/support/form/contact-pix-pro)).

## :robot: Proposition

Ne plus forcer la langue du formulaire.

## :100: Pour tester

- Formulaire `.fr` : https://site-pr669.review.pix.fr/support/form/support-eleves
- Formulaire PRO `.fr` : https://pro-pr669.review.pix.fr/support/form/support-eleves
- Formulaire `.org/fr` : https://site-pr669.review.pix.org/fr/support/form/contactez-le-support-pix
- Formulaire PRO `.org/fr` : https://pro-pr669.review.pix.org/fr/support/form/contactez-le-support-pix
- Formulaire `.org/en` :  https://site-pr669.review.pix.org/en/support/form/contact-pix-pro
- Formulaire PRO `.org/en` :  https://pro-pr669.review.pix.org/en/support/form/contact-pix-pro
