### PR TITLE
[BUGFIX] Ne pas rappatrier les assets de `images.prismic.io` sur Pix Pro

### DIFF
--- a/pix-pro/nuxt.config.ts
+++ b/pix-pro/nuxt.config.ts
@@ -16,6 +16,9 @@ export default async () => {
       port: 7001,
     },
     modules: ['@nuxtjs/prismic', '@nuxtjs/i18n', '@vueuse/nuxt', 'nuxt-image-prismic-fix'],
+    image: {
+      domains: ['pix-site.cdn.prismic.io', 'storage.gra.cloud.ovh.net', 'prismic-io.s3.amazonaws.com'],
+    },
     runtimeConfig: {
       public: {
         site: 'https://pro.pix.',

--- a/pix-site/nuxt.config.ts
+++ b/pix-site/nuxt.config.ts
@@ -10,6 +10,14 @@ export default async () => {
       port: Number(process.env.PORT) || 7000,
     },
     modules: ['@nuxtjs/prismic', '@nuxtjs/i18n', '@vueuse/nuxt', 'nuxt-image-prismic-fix'],
+    image: {
+      domains: [
+        'pix-site.cdn.prismic.io',
+        'storage.gra.cloud.ovh.net',
+        'prismic-io.s3.amazonaws.com',
+        'images.prismic.io',
+      ],
+    },
     runtimeConfig: {
       public: {
         site: 'https://pix.',

--- a/shared/nuxt.config.ts
+++ b/shared/nuxt.config.ts
@@ -31,14 +31,6 @@ const config = {
     'pages:extend': filterNuxtPages,
   },
   modules: ['@nuxt/test-utils/module'],
-  image: {
-    domains: [
-      'pix-site.cdn.prismic.io',
-      'storage.gra.cloud.ovh.net',
-      'prismic-io.s3.amazonaws.com',
-      'images.prismic.io',
-    ],
-  },
   prismic: {
     endpoint: 'pix-site',
     clientConfig: {


### PR DESCRIPTION
## :unicorn: Problème
Suite à #668, les assets de `images.prismic.io` sont toutes cassées sur Pix Pro.

## :robot: Proposition
Ne pas rapatrier les assets de `images.prismic.io` pour Pix Pro.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier qu'il n'y a pas de 404 sur la RA home de Pix Pro.
