### PR TITLE
[BUGFIX] Ne pas rappatrier les assets de `images.prismic.io` du tout

### DIFF
--- a/pix-site/nuxt.config.ts
+++ b/pix-site/nuxt.config.ts
@@ -11,12 +11,7 @@ export default async () => {
     },
     modules: ['@nuxtjs/prismic', '@nuxtjs/i18n', '@vueuse/nuxt', 'nuxt-image-prismic-fix'],
     image: {
-      domains: [
-        'pix-site.cdn.prismic.io',
-        'storage.gra.cloud.ovh.net',
-        'prismic-io.s3.amazonaws.com',
-        'images.prismic.io',
-      ],
+      domains: ['pix-site.cdn.prismic.io', 'storage.gra.cloud.ovh.net', 'prismic-io.s3.amazonaws.com'],
     },
     runtimeConfig: {
       public: {

--- a/shared/components/NewsItemCard.vue
+++ b/shared/components/NewsItemCard.vue
@@ -2,7 +2,10 @@
   <li class="news-item-card">
     <nuxt-link class="news-item-card__link" :to="localePath(`/${t('news-page-prefix')}/${props.uid}`, i18nLocale)">
       <div v-if="slice.illustration?.url" class="news-item-card__header">
-        <div class="news-item-card__illustration" :style="`background-image: url(${slice.illustration.url})`"></div>
+        <div
+          class="news-item-card__illustration"
+          :style="`background-image: url(${img(slice.illustration.url)})`"
+        ></div>
       </div>
 
       <div class="news-item-card__body">
@@ -29,6 +32,8 @@ import { useDateFormat } from '@vueuse/core';
 
 const { locale: i18nLocale, t } = useI18n();
 const localePath = useLocalePath();
+
+const img = useImage();
 
 const props = defineProps({
   slice: {


### PR DESCRIPTION
## :unicorn: Problème
Avec #668 et #670, on a essayé d'éviter les problèmes liés aux assets `images.prismic.io` qu'on essaye de mettre dans notre build. Finalement on est toujours embêtés.

## :robot: Proposition
Complètement s'en passer pour le moment.

Ça fait passer le nombre de requêtes hors `xx.review.pix.fr` à 4 contre 3 avant.

<img width="1496" alt="image" src="https://github.com/1024pix/pix-site/assets/5855339/eebadc51-3776-4047-b94f-bce1cbfd9b4f">

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier qu'on a plus de 404 sur des images liés à `images.prismic.io` sur pix-site.
