### PR TITLE
[BUGFIX] Télécharger tous les assets disponibles

### DIFF
--- a/pix-pro/nuxt.config.ts
+++ b/pix-pro/nuxt.config.ts
@@ -17,7 +17,12 @@ export default async () => {
     },
     modules: ['@nuxtjs/prismic', '@nuxtjs/i18n', '@vueuse/nuxt', 'nuxt-image-prismic-fix'],
     image: {
-      domains: ['pix-site.cdn.prismic.io', 'storage.gra.cloud.ovh.net', 'prismic-io.s3.amazonaws.com'],
+      domains: [
+        'pix-site.cdn.prismic.io',
+        'storage.gra.cloud.ovh.net',
+        'prismic-io.s3.amazonaws.com',
+        'images.prismic.io',
+      ],
     },
     runtimeConfig: {
       public: {

--- a/pix-pro/package-lock.json
+++ b/pix-pro/package-lock.json
@@ -21,7 +21,7 @@
         "focus-trap": "^7.5.4",
         "happy-dom": "^13.6.2",
         "nuxt": "^3.7.3",
-        "nuxt-image-prismic-fix": "^1.7.1",
+        "nuxt-image-prismic-fix": "^1.7.2",
         "prismic-dom": "^2.2.7",
         "sass": "^1.67.0",
         "slice-machine-ui": "^1.14.0",
@@ -10698,9 +10698,9 @@
       }
     },
     "node_modules/nuxt-image-prismic-fix": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/nuxt-image-prismic-fix/-/nuxt-image-prismic-fix-1.7.1.tgz",
-      "integrity": "sha512-lghPhrvNvn3yS6C7FX9lU201CNlKHuEX6mMDMQZjlRoVXHn4nXPB3Pii8CCIVx/vR7gcgzAC/OLq9CqzwBhBNg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/nuxt-image-prismic-fix/-/nuxt-image-prismic-fix-1.7.2.tgz",
+      "integrity": "sha512-/t3/GgJNgmvbYGsRdMp5u1jeUd2IU6gYioc3kONeghtLkeC4AkA5iSEjgXd9/xv8F96kkqP26nT8PmA8kKjFuw==",
       "dev": true,
       "dependencies": {
         "@nuxt/kit": "^3.12.1",

--- a/pix-pro/package.json
+++ b/pix-pro/package.json
@@ -31,7 +31,7 @@
     "focus-trap": "^7.5.4",
     "happy-dom": "^13.6.2",
     "nuxt": "^3.7.3",
-    "nuxt-image-prismic-fix": "^1.7.1",
+    "nuxt-image-prismic-fix": "^1.7.2",
     "prismic-dom": "^2.2.7",
     "sass": "^1.67.0",
     "slice-machine-ui": "^1.14.0",

--- a/pix-site/nuxt.config.ts
+++ b/pix-site/nuxt.config.ts
@@ -11,7 +11,12 @@ export default async () => {
     },
     modules: ['@nuxtjs/prismic', '@nuxtjs/i18n', '@vueuse/nuxt', 'nuxt-image-prismic-fix'],
     image: {
-      domains: ['pix-site.cdn.prismic.io', 'storage.gra.cloud.ovh.net', 'prismic-io.s3.amazonaws.com'],
+      domains: [
+        'pix-site.cdn.prismic.io',
+        'storage.gra.cloud.ovh.net',
+        'prismic-io.s3.amazonaws.com',
+        'images.prismic.io',
+      ],
     },
     runtimeConfig: {
       public: {

--- a/pix-site/package-lock.json
+++ b/pix-site/package-lock.json
@@ -24,7 +24,7 @@
         "focus-trap": "^7.5.4",
         "happy-dom": "^13.6.2",
         "nuxt": "^3.7.3",
-        "nuxt-image-prismic-fix": "^1.7.1",
+        "nuxt-image-prismic-fix": "^1.7.2",
         "playwright": "^1.39.0",
         "prismic-dom": "^2.2.7",
         "sass": "^1.67.0",
@@ -12153,9 +12153,9 @@
       }
     },
     "node_modules/nuxt-image-prismic-fix": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/nuxt-image-prismic-fix/-/nuxt-image-prismic-fix-1.7.1.tgz",
-      "integrity": "sha512-lghPhrvNvn3yS6C7FX9lU201CNlKHuEX6mMDMQZjlRoVXHn4nXPB3Pii8CCIVx/vR7gcgzAC/OLq9CqzwBhBNg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/nuxt-image-prismic-fix/-/nuxt-image-prismic-fix-1.7.2.tgz",
+      "integrity": "sha512-/t3/GgJNgmvbYGsRdMp5u1jeUd2IU6gYioc3kONeghtLkeC4AkA5iSEjgXd9/xv8F96kkqP26nT8PmA8kKjFuw==",
       "dev": true,
       "dependencies": {
         "@nuxt/kit": "^3.12.1",

--- a/pix-site/package.json
+++ b/pix-site/package.json
@@ -40,7 +40,7 @@
     "focus-trap": "^7.5.4",
     "happy-dom": "^13.6.2",
     "nuxt": "^3.7.3",
-    "nuxt-image-prismic-fix": "^1.7.1",
+    "nuxt-image-prismic-fix": "^1.7.2",
     "playwright": "^1.39.0",
     "prismic-dom": "^2.2.7",
     "sass": "^1.67.0",


### PR DESCRIPTION
## :unicorn: Problème
Lorsque des params sont passés au serveur h3, le serveur ne veut pas les gérer et l'url est skippé ce qui fait que l'asset n'est pas téléchargé

## :robot: Proposition
Sur notre fork nous retirons les params envoyé au h3 et par conséquent à Prismic cela peut donc avoir des impacts sur les tailles d'images demandés  https://github.com/1024pix/nuxt-image/commit/7f6025dc623d04993b57763c90938aed9c28fa12

Le vrai correctif aurait été de faire en sorte que le h3 accepte et transfère les params à voir plus tard 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
