### PR TITLE
[FEATURE] Réduire la taille des assets

### DIFF
--- a/shared/components/NewsItemCard.vue
+++ b/shared/components/NewsItemCard.vue
@@ -4,7 +4,7 @@
       <div v-if="slice.illustration?.url" class="news-item-card__header">
         <div
           class="news-item-card__illustration"
-          :style="`background-image: url(${img(slice.illustration.url)})`"
+          :style="`background-image: url(${img(slice.illustration.url, { width: 340 })})`"
         ></div>
       </div>
 

--- a/shared/components/slices/Article.vue
+++ b/shared/components/slices/Article.vue
@@ -52,6 +52,7 @@
         :src="content.article_background.url"
         :alt="content.article_background.alt || ''"
         :role="!!content.article_background.alt ? undefined : 'presentation'"
+        width="960"
         class="article__secondary-content article-secondary-content__background"
       />
       <nuxt-img
@@ -59,6 +60,7 @@
         :src="content.article_image.url"
         :alt="content.article_image.alt || ''"
         :role="!!content.article_image.alt ? undefined : 'presentation'"
+        width="960"
         class="article__secondary-content article-secondary-content__image"
       />
       <video


### PR DESCRIPTION
## :unicorn: Problème
Nos images sont souvent dans des containers à taille maximum, mais nous ne fournissons pas l'information à nuxt-img pour qu'il puisse les optimiser

## :robot: Proposition
En 2 min j'ai pu trouver ces deux composants à améliorer, il y en a d'autres mais cela fait déjà gagner du poids au build et aux pages

## :rainbow: Remarques
Différence sur le build complet : 
![Screenshot 2024-06-21 at 14 46 58](https://github.com/1024pix/pix-site/assets/26384707/5662c681-5ae4-4889-87cb-a15752fb9366)

![Screenshot 2024-06-21 at 14 47 16](https://github.com/1024pix/pix-site/assets/26384707/23a12f4a-9b7d-434f-8437-e2082a58d24f)



Différence sur la page index.
![Screenshot 2024-06-21 at 14 50 29](https://github.com/1024pix/pix-site/assets/26384707/12ececf2-8547-4826-975e-71a772b28f77)

![Screenshot 2024-06-21 at 14 50 45](https://github.com/1024pix/pix-site/assets/26384707/1be85fd3-0d00-4e4b-98d0-220f1a6fccec)


## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
