### PR TITLE
[BUGFIX] La locale de la page n'est pas renseignée

### DIFF
--- a/pix-pro/layouts/default.vue
+++ b/pix-pro/layouts/default.vue
@@ -11,9 +11,14 @@
 </template>
 
 <script setup>
+const i18nHead = useLocaleHead();
+
 useHead({
   titleTemplate: (titleChunk) => {
     return titleChunk ? `${titleChunk} | Pix Pro` : 'Pix Pro';
+  },
+  htmlAttrs: {
+    lang: i18nHead.value.htmlAttrs?.lang,
   },
 });
 </script>

--- a/pix-site/layouts/default.vue
+++ b/pix-site/layouts/default.vue
@@ -24,9 +24,14 @@ const { origin } = useRequestURL();
 const config = useAppConfig();
 const domainOrg = config.domainOrg;
 
+const i18nHead = useLocaleHead();
+
 useHead({
   titleTemplate: (titleChunk) => {
     return titleChunk ? `${titleChunk} | Pix` : 'Pix';
+  },
+  htmlAttrs: {
+    lang: i18nHead.value.htmlAttrs?.lang,
   },
 });
 


### PR DESCRIPTION
## :unicorn: Problème
L'attribut `lang` de la balise `html` n'est plus renseigné. Il est nécessaire pour améliorer l'indexation par les moteurs de recherche, ainsi que pour les lecteurs d'écran.

## :robot: Proposition
Remettre cette balise sur les layouts de nos différents sites avec Nuxt i18n. Voir la doc https://i18n.nuxtjs.org/docs/guide/seo.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que la bonne locale est bien renseignée dans l'attribut `lang` de la balise `html`, sur tous les sites.
