### PR TITLE
[TECH] : Fix redirection with slug

### DIFF
--- a/pix-site/servers.conf.erb
+++ b/pix-site/servers.conf.erb
@@ -81,7 +81,7 @@ server {
 
     location /fr {
       rewrite ^/fr$ https://pix.fr/support permanent;
-      rewrite ^/fr/(.*)$ https://pix.fr/support/$1 permanent;
+      rewrite ^/fr/(.*)$ https://pix.fr/support permanent;
     }
     location / {
       rewrite ^/$ https://pix.fr/support permanent;
@@ -89,6 +89,6 @@ server {
     }
     location /en {
       rewrite ^/en$ https://pix.org/en/support permanent;
-      rewrite ^/en/(.*)$ https://pix.org/en/support/$1 permanent;
+      rewrite ^/en/(.*)$ https://pix.org/en/support permanent;
     }
 }


### PR DESCRIPTION
## :unicorn: Problème
quand on redirige depuis support.pix.org avec des paramètres d'url ces paramètres sont repris sur pix.fr/support alors qu'ils ne sont pas bon

## :robot: Proposition

## :rainbow: Remarques

## :100: Pour tester