### PR TITLE
[FEATURE] Positionner la métadonnée de la langue dans les pages (PIX-13360)

### DIFF
--- a/pix-pro/i18n.config.ts
+++ b/pix-pro/i18n.config.ts
@@ -2,6 +2,7 @@ import { generateConfig } from '../shared/i18n.config';
 const reachableLocales = [
   {
     code: 'en',
+    iso: 'en',
     file: 'en.js',
     name: 'English',
     icon: 'globe-europe.svg',
@@ -9,6 +10,7 @@ const reachableLocales = [
   },
   {
     code: 'fr',
+    iso: 'fr',
     file: 'fr.js',
     name: 'Français',
     icon: 'globe-europe.svg',
@@ -16,6 +18,7 @@ const reachableLocales = [
   },
   {
     code: 'fr-fr',
+    iso: 'fr-fr',
     file: 'fr-fr.js',
     name: 'France',
     icon: 'flag-fr.svg',

--- a/pix-pro/layouts/default.vue
+++ b/pix-pro/layouts/default.vue
@@ -1,13 +1,15 @@
 <template>
-  <div id="app" class="app-viewport">
-    <skip-link />
-    <hot-news-banner />
-    <navigation-slice-zone />
-    <main id="main" role="main" tabindex="-1">
-      <slot />
-    </main>
-    <shared-footer-slice-zone />
-  </div>
+  <Html :lang="head.htmlAttrs.lang" :dir="head.htmlAttrs.dir">
+    <div id="app" class="app-viewport">
+      <skip-link />
+      <hot-news-banner />
+      <navigation-slice-zone />
+      <main id="main" role="main" tabindex="-1">
+        <slot />
+      </main>
+      <shared-footer-slice-zone />
+    </div>
+  </Html>
 </template>
 
 <script setup>
@@ -15,6 +17,11 @@ useHead({
   titleTemplate: (titleChunk) => {
     return titleChunk ? `${titleChunk} | Pix Pro` : 'Pix Pro';
   },
+});
+
+const head = useLocaleHead({
+  addSeoAttributes: true,
+  addDirAttribute: true,
 });
 </script>
 

--- a/pix-site/i18n.config.ts
+++ b/pix-site/i18n.config.ts
@@ -2,6 +2,7 @@ import { generateConfig } from '../shared/i18n.config';
 const reachableLocales = [
   {
     code: 'en',
+    iso: 'en',
     file: 'en.js',
     name: 'English',
     icon: 'globe-europe.svg',
@@ -9,6 +10,7 @@ const reachableLocales = [
   },
   {
     code: 'fr',
+    iso: 'fr',
     file: 'fr.js',
     name: 'Français',
     icon: 'globe-europe.svg',
@@ -16,6 +18,7 @@ const reachableLocales = [
   },
   {
     code: 'fr-fr',
+    iso: 'fr-fr',
     file: 'fr-fr.js',
     name: 'France',
     icon: 'flag-fr.svg',
@@ -23,6 +26,7 @@ const reachableLocales = [
   },
   {
     code: 'fr-be',
+    iso: 'fr-be',
     file: 'fr-be.js',
     name: 'Belgique (Français)',
     icon: 'flag-be.svg',
@@ -30,6 +34,7 @@ const reachableLocales = [
   },
   {
     code: 'nl-be',
+    iso: 'nl-be',
     file: 'nl-be.js',
     name: 'België (Nederlands)',
     icon: 'flag-be.svg',

--- a/pix-site/layouts/default.vue
+++ b/pix-site/layouts/default.vue
@@ -1,18 +1,20 @@
 <template>
-  <div id="app" class="app-viewport">
-    <skip-link />
-    <hot-news-banner />
-    <locale-suggestion-banner
-      :is-open="showBanner"
-      :domain-org="domainOrg"
-      @handle-close-banner="closeLocaleSuggestionBanner"
-    />
-    <navigation-slice-zone />
-    <main id="main" role="main" tabindex="-1">
-      <slot />
-    </main>
-    <shared-footer-slice-zone />
-  </div>
+  <Html :lang="head.htmlAttrs.lang" :dir="head.htmlAttrs.dir">
+    <div id="app" class="app-viewport">
+      <skip-link />
+      <hot-news-banner />
+      <locale-suggestion-banner
+        :is-open="showBanner"
+        :domain-org="domainOrg"
+        @handle-close-banner="closeLocaleSuggestionBanner"
+      />
+      <navigation-slice-zone />
+      <main id="main" role="main" tabindex="-1">
+        <slot />
+      </main>
+      <shared-footer-slice-zone />
+    </div>
+  </Html>
 </template>
 
 <script setup>
@@ -28,6 +30,11 @@ useHead({
   titleTemplate: (titleChunk) => {
     return titleChunk ? `${titleChunk} | Pix` : 'Pix';
   },
+});
+
+const head = useLocaleHead({
+  addDirAttribute: true,
+  addSeoAttributes: true,
 });
 
 onMounted(async () => {

--- a/shared/pages/[uri].vue
+++ b/shared/pages/[uri].vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <Html :lang="head.htmlAttrs.lang" :dir="head.htmlAttrs.dir">
     <div v-if="data.type === 'form_page'">
       <form-page :content="data.data" />
     </div>
@@ -9,12 +9,17 @@
     <div v-if="data.type === 'slices_page'">
       <prismic-custom-slice-zone :slices="data.data.body" />
     </div>
-  </div>
+  </Html>
 </template>
 
 <script setup>
 const appConfig = useAppConfig();
 const { locale: i18nLocale } = useI18n();
+const head = useLocaleHead({
+  addDirAttribute: true,
+  identifierAttribute: 'id',
+  addSeoAttributes: true,
+});
 const { client, filter } = usePrismic();
 const route = useRoute();
 


### PR DESCRIPTION
## :unicorn: Problème

Actuellement les pages des sites vitrine ne portent pas la métadonnée de la langue.

Ainsi : 
* elles sont potentiellement mal indexées par les moteurs de recherche (même si Google indique dans sa documentation ne pas tenir compte de cette information)
* elles sont mal vocalisées par les technologies d’assistance, par exemple une page en anglais est vocalisée avec l'accent français, une page en français est vocalisée avec l'accent anglais, etc.

## :robot: Proposition

Tirer partie du [Nuxt i18n module (qui fournit `useLocaleHead`)]( https://i18n.nuxtjs.org/docs/guide/seo) pour ajouter automatiquement les attributs `lang` et `dir` à la base `<html>`. Le module Nuxt i18n va ajouter un attribut `lang` dans la balise HTML `<html>` de la racine de chaque page web.

La documentation pour l'attribut `lang` est la suivante : https://developer.mozilla.org/fr/docs/Web/HTML/Global_attributes/lang . On y lit que l'attribut `lang` prend une valeur au format BCP47 qui le format des locales.

## :rainbow: Remarques

RAS

## :100: Pour tester

* Constater que les pages web suivantes contiennent un attribut `lang` dans la balise HTML `<html>` de la racine : 
   * https://site-pr682.review.pix.fr/
   * https://site-pr682.review.pix.fr/score-et-niveaux
   * https://site-pr682.review.pix.org/fr
   * https://site-pr682.review.pix.org/fr/score-et-niveaux
   * https://site-pr682.review.pix.org/en
   * https://site-pr682.review.pix.org/en/the-tests
   * https://pro-pr682.review.pix.fr/
   * https://pro-pr682.review.pix.fr/entreprises
   * https://pro-pr682.review.pix.org/fr
   * https://pro-pr682.review.pix.org/fr/entreprises
   * https://pro-pr682.review.pix.org/en/
   * https://pro-pr682.review.pix.org/en/business
* Constater que la vocalisation des pages web suivantes est effectuée avec l'accent français : 
   * https://site-pr682.review.pix.fr/
   * https://site-pr682.review.pix.fr/score-et-niveaux
   * https://site-pr682.review.pix.org/fr
   * https://site-pr682.review.pix.org/fr/score-et-niveaux
   * https://pro-pr682.review.pix.fr/
   * https://pro-pr682.review.pix.fr/entreprises
   * https://pro-pr682.review.pix.org/fr
   * https://pro-pr682.review.pix.org/fr/entreprises
* Constater que la vocalisation des pages web suivantes est effectuée avec l'accent anglais : 
   * https://site-pr682.review.pix.org/en
   * https://site-pr682.review.pix.org/en/the-tests
   * https://pro-pr682.review.pix.org/en/
   * https://pro-pr682.review.pix.org/en/business
