### PR TITLE
[FEATURE] Mettre à jour le fichier robots.txt (PIX-14053)

### DIFF
--- a/shared/public/robots.txt
+++ b/shared/public/robots.txt
@@ -1,6 +1,1 @@
 User-agent: *
-Disallow: /support/*
-Disallow: /en/support/*
-Disallow: /fr/support/*
-Disallow: /fr-be/support/*
-Disallow: /nl-be/support/*


### PR DESCRIPTION
## :unicorn: Problème
Pendant la livraison du nouveau support, il a été décidé de ne pas référencer les nouvelles pages d’accueil du support. L’objectif étant de ne pas référencer/afficher les anciennes et les nouvelles pages d’accueil sur Google. L’ancien support étant archivé, il faut permettre le référencement des nouveaux liens dans Google.

## :robot: Proposition
Mettre à jour le robots.txt en enlevant la règle qui désactive le référencement des pages supports

## :rainbow: Remarques
RAS

## :100: Pour tester
- Aller sur la page /robots.txt de chaque lien des RA et vérifier qu'il n'y a plus les lignes suivantes 
```
Disallow: /support/*
Disallow: /en/support/*
Disallow: /fr/support/*
Disallow: /fr-be/support/*
Disallow: /nl-be/support/*
```
  - [Pix Site .fr RA](https://site-pr697.review.pix.fr/robots.txt)
  - [Pix Site .org RA](https://site-pr697.review.pix.org/robots.txt)
  - [Pix Pro .fr RA](https://pro-pr697.review.pix.fr/robots.txt)
  - [Pix Pro .org RA](https://pro-pr697.review.pix.org/robots.txt)