### PR TITLE
[BUGFIX] Réparer les liens des images en preview

### DIFF
--- a/pix-pro/components/LocaleChoice.vue
+++ b/pix-pro/components/LocaleChoice.vue
@@ -14,7 +14,7 @@
         <img class="locale-link__icon" :src="'/images/' + locale.icon" alt="" />
         <span class="locale-link__text">{{ locale.name }}</span>
       </a>
-      <nuxt-img class="planet" src="/images/planet.svg" />
+      <img class="planet" src="/images/planet.svg" />
     </div>
   </main>
 </template>

--- a/pix-site/components/LocaleChoice.vue
+++ b/pix-site/components/LocaleChoice.vue
@@ -14,7 +14,7 @@
         <img class="locale-link__icon" :src="'/images/' + locale.icon" alt="" />
         <span class="locale-link__text">{{ locale.name }}</span>
       </a>
-      <nuxt-img class="planet" src="/images/planet.svg" />
+      <img class="planet" src="/images/planet.svg" />
     </div>
   </main>
 </template>

--- a/shared/nuxt.config.ts
+++ b/shared/nuxt.config.ts
@@ -38,6 +38,9 @@ const config = {
     },
     linkResolver: '../shared/services/link-resolver.js',
   },
+  image: {
+    provider: 'prismic',
+  },
   runtimeConfig: {
     public: {
       easiwareScriptUrl: process.env.EASIWARE_SCRIPT_URL,


### PR DESCRIPTION
## :unicorn: Problème

En preview, les images importées ne s'affichent plus comme souhaité.

## :robot: Proposition

En regardant les sources des images, elles étaient toutes préfixées par `/_ipx/_/`.
Il se trouve qu'IPX est le [provider par défaut de NuxtImage](https://image.nuxt.com/providers/ipx).

Le remplacer [par Prismic](https://image.nuxt.com/providers/prismic) (le code dans la documentation n'est pas bon).

Pour les images locales (comme la planète dans la page de sélection de langue), utiliser directement un tag `<img />`.

## :100: Pour tester

- Se connecter à Prismic
- Tester la page https://site-pr698.review.pix.fr/parcours-autonomes 
