### PR TITLE
[BUGFIX] Réparer le lien de l'image de planète sur la page de choix de locale

### DIFF
--- a/pix-pro/components/LocaleChoice.vue
+++ b/pix-pro/components/LocaleChoice.vue
@@ -14,7 +14,7 @@
         <img class="locale-link__icon" :src="'/images/' + locale.icon" alt="" />
         <span class="locale-link__text">{{ locale.name }}</span>
       </a>
-      <nuxt-img class="planet" src="/images/planet.svg" />
+      <img class="planet" src="/images/planet.svg" />
     </div>
   </main>
 </template>

--- a/pix-site/components/LocaleChoice.vue
+++ b/pix-site/components/LocaleChoice.vue
@@ -14,7 +14,7 @@
         <img class="locale-link__icon" :src="'/images/' + locale.icon" alt="" />
         <span class="locale-link__text">{{ locale.name }}</span>
       </a>
-      <nuxt-img class="planet" src="/images/planet.svg" />
+      <img class="planet" src="/images/planet.svg" />
     </div>
   </main>
 </template>


### PR DESCRIPTION
## :unicorn: Problème

La planète ne s'affiche plus.

## :robot: Proposition

Pour les images locales, éviter d'utiliser le composant `NuxtImg` qui utilise des providers pour fournir les images.

## 🔬 Pour tester 

Aller sur les 2 sites en `.org` et visualiser la planète.
