### PR TITLE
[BUGFIX] Réparer l'affichage des images en preview (PIX-14766)

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -9,8 +9,10 @@ GEOAPI_HOST=<GEOAPI_HOST>
 SITE=pix-site
 
 EASIWARE_SCRIPT_URL=<EASIWARE_SCRIPT_URL>
-# Burger menu and navigation menu with new structure are available
+
+# Enable built-in image in application build with Nuxt Image
 #
 # presence: optional
 # type: boolean
 # default: false
+IS_BUILTIN_IMAGES_ENABLED=false

--- a/shared/nuxt.config.ts
+++ b/shared/nuxt.config.ts
@@ -7,6 +7,9 @@ const config = {
       script: [],
     },
   },
+  image: {
+    provider: process.env.IS_BUILTIN_IMAGES_ENABLED ? undefined : 'prismic',
+  },
   appConfig: {
     domainFr: process.env.DOMAIN_FR,
     domainOrg: process.env.DOMAIN_ORG,
@@ -32,10 +35,10 @@ const config = {
   },
   modules: ['@nuxt/test-utils/module'],
   prismic: {
-    endpoint: 'pix-site',
     clientConfig: {
       accessToken: process.env.PRISMIC_API_TOKEN,
     },
+    endpoint: 'pix-site',
     linkResolver: '../shared/services/link-resolver.js',
   },
   runtimeConfig: {


### PR DESCRIPTION
## :unicorn: Problème
L'affichage de nouvelles images ne s'affichent plus lors des preview Prismic.

Cela est causée par les changements effectuées pour intégrer les images au build de l'application.
Les nouvelles images en preview ne sont pas intégrées au build ce qui cause ce problème.

## :robot: Proposition
Ajouter une variable d'environnement IS_BUILTIN_IMAGES_ENABLED pour gérer ce comportement.

- Dans le cas où la variable est à false, alors la fonctionnalité d'intégration des images au build de l'application est désactivée pour permettre à la preview de fonctionner correctement.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Sur Prismic, ajouter une nouvelle image à la banque d'images.
- Modifier un document avec le tag `pix-site` en ajoutant cette nouvelle image.
- Tester la preview avec le bouton `Preview the page` en choisissant Test images (pix.fr)
- Vérifier que l'image s'affiche bien sur la preview.
- Modifier un document avec le tag `pix-pro` en ajoutant cette nouvelle image.
- Tester la preview avec le bouton `Preview the page` en choisissant Test images (pro.fr)
- Vérifier que l'image s'affiche bien sur la preview.