### PR TITLE
[BUGFIX] Corriger les liens sur la page de choix de locale (PIX-14127)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,7 @@ Deux répertoires :
 
 ## Docker
 
-Un dockerfile est diposible à la racine du projet, pour pix-site et pix-pro
+Un dockerfile est disponible à la racine du projet, pour pix-site et pix-pro
 
 ### Build pix-site
 

--- a/pix-site/components/LocaleChoice.vue
+++ b/pix-site/components/LocaleChoice.vue
@@ -5,7 +5,7 @@
         <img class="logo-pix" src="/images/logo-pix-blanc.svg" alt="Pix" />
       </h1>
       <a
-        v-for="locale in reachableLocales"
+        v-for="locale in availableLocales"
         :key="locale.code"
         class="locale-link"
         :href="`${locale.domain}/${locale.code === 'fr-fr' ? '' : locale.code}`"
@@ -20,7 +20,8 @@
 </template>
 
 <script setup>
-import { reachableLocales } from '../i18n.config.ts';
+const runtimeConfig = useRuntimeConfig();
+const availableLocales = runtimeConfig.public.availableLocales;
 
 const { setLocaleCookie } = useLocaleCookie();
 


### PR DESCRIPTION
## :unicorn: Problème

Les liens vers les versions localisées sur la page de choix de locale ne fonctionnent plus, par exemple pour l'anglais international, l'url générée est https://pix.org/undefined/en

## 🔬 Analyse

Lorsque le code est généré côté serveur, le domaine (qui est fourni par les variables d'environnement `DOMAIN_FR` et `DOMAIN_ORG`) est bien renseigné. Il semble que le problème survienne lorsqu'il y a un re-render côté client : dans ce cas, les variables d'environnement du serveur ne sont pas accessible.

## :robot: Proposition

Récupérer les locales et les domaines associés à l'aide du hook `useRuntimeConfig` qui fournit une variable `

## :rainbow: Remarques

- Nous n'avons pas réussi à reproduire le problème en local : même en compilant le site à l'aide de la commande `generate` et en servant les fichiers statiques avec un serveur web, il ne semble ne pas y avoir de re-render côté client. Le problème survient uniquement lorsque le site est déployé sur Scalingo (en production ou dans une review app).

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
