### PR TITLE
[BUGFIX] Corriger les liens sur la page de choix de locale (PIX-14127)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,7 @@ Deux répertoires :
 
 ## Docker
 
-Un dockerfile est diposible à la racine du projet, pour pix-site et pix-pro
+Un dockerfile est disponible à la racine du projet, pour pix-site et pix-pro
 
 ### Build pix-site
 

--- a/pix-pro/components/LocaleChoice.vue
+++ b/pix-pro/components/LocaleChoice.vue
@@ -5,7 +5,7 @@
         <img class="logo-pix" src="/images/logo-pix-blanc.svg" alt="Pix" />
       </h1>
       <a
-        v-for="locale in reachableLocales"
+        v-for="locale in availableLocales"
         :key="locale.code"
         class="locale-link"
         :href="`${locale.domain}/${locale.code === 'fr-fr' ? '' : locale.code}`"
@@ -20,7 +20,8 @@
 </template>
 
 <script setup>
-import { reachableLocales } from '../i18n.config.ts';
+const runtimeConfig = useRuntimeConfig();
+const availableLocales = runtimeConfig.public.availableLocales;
 
 const { setLocaleCookie } = useLocaleCookie();
 const { locales, defaultLocale } = useI18n();

--- a/pix-pro/components/LocaleSwitcher.vue
+++ b/pix-pro/components/LocaleSwitcher.vue
@@ -56,16 +56,18 @@
 </template>
 
 <script setup>
-import { reachableLocales } from '../i18n.config';
 import { onClickOutside } from '@vueuse/core';
+
+const runtimeConfig = useRuntimeConfig();
+const availableLocales = runtimeConfig.public.availableLocales;
 
 const { setLocaleCookie } = useLocaleCookie();
 
 const { localeProperties, t } = useI18n();
 
-const frLocale = reachableLocales.find((l) => l.code === 'fr');
-const enLocale = reachableLocales.find((l) => l.code === 'en');
-const frFrLocale = reachableLocales.find((l) => l.code === 'fr-fr');
+const frLocale = availableLocales.find((l) => l.code === 'fr');
+const enLocale = availableLocales.find((l) => l.code === 'en');
+const frFrLocale = availableLocales.find((l) => l.code === 'fr-fr');
 
 const buttonRef = ref(null);
 const localesMenuRef = ref(null);

--- a/pix-site/components/LocaleChoice.vue
+++ b/pix-site/components/LocaleChoice.vue
@@ -5,7 +5,7 @@
         <img class="logo-pix" src="/images/logo-pix-blanc.svg" alt="Pix" />
       </h1>
       <a
-        v-for="locale in reachableLocales"
+        v-for="locale in availableLocales"
         :key="locale.code"
         class="locale-link"
         :href="`${locale.domain}/${locale.code === 'fr-fr' ? '' : locale.code}`"
@@ -20,7 +20,8 @@
 </template>
 
 <script setup>
-import { reachableLocales } from '../i18n.config.ts';
+const runtimeConfig = useRuntimeConfig();
+const availableLocales = runtimeConfig.public.availableLocales;
 
 const { setLocaleCookie } = useLocaleCookie();
 

--- a/pix-site/components/LocaleSwitcher.vue
+++ b/pix-site/components/LocaleSwitcher.vue
@@ -76,18 +76,20 @@
 </template>
 
 <script setup>
-import { reachableLocales } from '../i18n.config';
 import { onClickOutside } from '@vueuse/core';
+
+const runtimeConfig = useRuntimeConfig();
+const availableLocales = runtimeConfig.public.availableLocales;
 
 const { setLocaleCookie } = useLocaleCookie();
 
 const { localeProperties, t } = useI18n();
 
-const frLocale = reachableLocales.find((l) => l.code === 'fr');
-const enLocale = reachableLocales.find((l) => l.code === 'en');
-const frFrLocale = reachableLocales.find((l) => l.code === 'fr-fr');
-const frBeLocale = reachableLocales.find((l) => l.code === 'fr-be');
-const nlBeLocale = reachableLocales.find((l) => l.code === 'nl-be');
+const frLocale = availableLocales.find((l) => l.code === 'fr');
+const enLocale = availableLocales.find((l) => l.code === 'en');
+const frFrLocale = availableLocales.find((l) => l.code === 'fr-fr');
+const frBeLocale = availableLocales.find((l) => l.code === 'fr-be');
+const nlBeLocale = availableLocales.find((l) => l.code === 'nl-be');
 
 const buttonRef = ref(null);
 const localesMenuRef = ref(null);

--- a/pix-site/tests/integration/components/LocaleChoice.test.ts
+++ b/pix-site/tests/integration/components/LocaleChoice.test.ts
@@ -1,7 +1,8 @@
 import { render, screen } from '@testing-library/vue';
 
 import LocaleChoice from '~/components/LocaleChoice.vue';
-import { reachableLocales } from '~/i18n.config.ts';
+
+const localeNames = ['English', 'Français'];
 
 describe('LocaleChoice', () => {
   beforeEach(() => {
@@ -16,8 +17,8 @@ describe('LocaleChoice', () => {
 
   test('displays the name of each locale', () => {
     // then
-    reachableLocales.forEach((locale) => {
-      expect(screen.findByText(locale.name)).toBeTruthy();
+    localeNames.forEach((localeName) => {
+      expect(screen.findByText(localeName)).toBeTruthy();
     });
   });
 });

--- a/pix-site/tests/integration/components/LocaleSwitcher.test.ts
+++ b/pix-site/tests/integration/components/LocaleSwitcher.test.ts
@@ -4,7 +4,48 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import LocaleSwitcher from '~/components/LocaleSwitcher.vue';
 
 const localeProperties = { code: 'fr-fr', name: 'Français', icon: 'fr' };
-
+const availableLocales = [
+  {
+    code: 'en',
+    iso: 'en',
+    file: 'en.js',
+    name: 'English',
+    icon: 'globe-europe.svg',
+    domain: 'https://example.org/',
+  },
+  {
+    code: 'fr',
+    iso: 'fr',
+    file: 'fr.js',
+    name: 'Français',
+    icon: 'globe-europe.svg',
+    domain: 'https://example.org/',
+  },
+  {
+    code: 'fr-fr',
+    iso: 'fr-fr',
+    file: 'fr-fr.js',
+    name: 'France',
+    icon: 'flag-fr.svg',
+    domain: 'https://example.fr/',
+  },
+  {
+    code: 'fr-be',
+    iso: 'fr-be',
+    file: 'fr-be.js',
+    name: 'Belgique (Français)',
+    icon: 'flag-be.svg',
+    domain: 'https://example.org/',
+  },
+  {
+    code: 'nl-be',
+    iso: 'nl-be',
+    file: 'nl-be.js',
+    name: 'België (Nederlands)',
+    icon: 'flag-be.svg',
+    domain: 'https://example.org/',
+  },
+];
 mockNuxtImport('useI18n', () => {
   return () => {
     return { localeProperties, t: (str) => str };
@@ -20,6 +61,7 @@ mockNuxtImport('useRuntimeConfig', () => {
   return () => ({
     public: {
       siteDomain: 'ORG',
+      availableLocales,
     },
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Sur https://pix.org/ les liens vers les versions localisées sur la page de choix de locale ne fonctionnent plus, par exemple pour l'anglais international, l'URL générée est https://pix.org/undefined/en

## 🔬 Analyse

Dans `pix-site/i18n.config.ts` et `pix-pro/i18n.config.ts` le `domain` est fourni par les variables d'environnement `DOMAIN_FR` et `DOMAIN_ORG`. Ces variables d'environnement sont bien définies lorsque ce code est exécuté côté serveur, **mais pas lorsque ce code est exécuté dans le navigateur**. Dans ce cas, les variables d'environnement du serveur ne sont pas accessibles.

:bug: :lady_beetle: Ce bug est présent depuis la publication de la [v5.13.0 (29/08/2024)](https://github.com/1024pix/pix-site/blob/dev/CHANGELOG.md) qui est la première version du projet *pix-site* qui a effectué une montée de version de *nuxt* depuis le passage de *pix-site* à Nuxt3.

## :robot: Proposition

Partout où les locales, avec les domaines associés, sont utilisées, récupérer ces locales à l'aide du hook `useRuntimeConfig` qui fournit une variable `availableLocales` alimentée par les variables d'environnement à la compilation.

## :rainbow: Remarques

- Nous n'avons pas réussi à reproduire le problème en local : même en compilant le site à l'aide de la commande `generate` et en servant les fichiers statiques avec un serveur web, il ne semble ne pas y avoir de re-render côté client. Le problème survient uniquement lorsque le site est déployé sur Scalingo (en production ou dans une review app).
- Il est très étonnant que ce problème de `domain` non défini (`undefined`) ne se soit pas manifesté sur le LocaleSwitcher car théoriquement il aurait dû se manifester. Mais nous avons généralisé le correctif partout où les locales étaient importées.
- TODO pour le futur : il faudra faire un audit dans le reste du code du projet pour savoir si d'autres variables d'environnement comme `DOMAIN_FR` et `DOMAIN_ORG` ne sont pas utilisées dans d'autres parties du code qui ne passeraient pas par le mécanisme de `useRuntimeConfig` et se mettre alors à utiliser `useRuntimeConfig` pour ces morceaux de code.

## :100: Pour tester

### Tester [Pix Site (.org)](https://site-pr703.review.pix.org/)

1. Constater que la page de choix de locale (LocaleChoice) s'affiche (sinon : supprimer les cookies)
2. Constater que les liens vers les différentes version localisées sont tous fonctionnels
3. Se rendre sur une page de version localisée
4. Constater que les liens du menu de locales (LocaleSwitcher) sont tous fonctionnels (en version grand format et en version réduite « mobile »)
 
### Tester [Pix Pro (.org)](https://pro-pr703.review.pix.org/)

1. Constater que la page de choix de locale (LocaleChoice) s'affiche (sinon : supprimer les cookies)
2. Constater que les liens vers les différentes version localisées sont tous fonctionnels
3. Se rendre sur une page de version localisée
4. Constater que les liens du menu de locales (LocaleSwitcher) sont tous fonctionnels (en version grand format et en version réduite « mobile »)
