### PR TITLE
[TECH] Corriger tous les warnings du linting et interdire les warnings (PIX-14221)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 **/build/
 **/.output/
 **/.nuxt/
+**/playwright-report/

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "5.13.1",
   "description": "Site vitrine de Pix",
   "scripts": {
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint": "eslint . --max-warnings 0",
+    "lint:fix": "eslint . --fix --max-warnings 0"
   },
   "license": "ISC",
   "private": true,

--- a/pix-pro/components/LocaleChoice.vue
+++ b/pix-pro/components/LocaleChoice.vue
@@ -24,7 +24,6 @@ const runtimeConfig = useRuntimeConfig();
 const availableLocales = runtimeConfig.public.availableLocales;
 
 const { setLocaleCookie } = useLocaleCookie();
-const { locales, defaultLocale } = useI18n();
 
 function updateLocale(localeCode) {
   setLocaleCookie(localeCode);

--- a/pix-pro/error.vue
+++ b/pix-pro/error.vue
@@ -3,16 +3,13 @@
     <a :href="t('home-page-url')">
       <img class="logo" src="/images/pix-logo.svg" alt="Lien pour revenir à l'accueil" />
     </a>
+    <!-- eslint-disable-next-line vue/no-v-html -->
     <div v-html="t('error-content')" />
   </div>
 </template>
 
 <script setup>
 const { locale: i18nLocale, t } = useI18n();
-
-const props = defineProps({
-  error: Object,
-});
 
 useHead({
   title: 'Error | Pix',

--- a/pix-site/error.vue
+++ b/pix-site/error.vue
@@ -3,16 +3,13 @@
     <a :href="t('home-page-url')">
       <img class="logo" src="/images/pix-logo.svg" alt="Lien pour revenir à l'accueil" />
     </a>
+    <!-- eslint-disable-next-line vue/no-v-html -->
     <div v-html="t('error-content')" />
   </div>
 </template>
 
 <script setup>
 const { locale: i18nLocale, t } = useI18n();
-
-const props = defineProps({
-  error: Object,
-});
 
 useHead({
   title: 'Error | Pix',

--- a/shared/components/BurgerMenu/BurgerMenu.vue
+++ b/shared/components/BurgerMenu/BurgerMenu.vue
@@ -39,7 +39,7 @@ import { UseFocusTrap } from '@vueuse/integrations/useFocusTrap/component';
 
 const { t } = useI18n();
 
-const props = defineProps({
+defineProps({
   items: {
     type: Object,
     default: null,

--- a/shared/components/BurgerMenu/BurgerMenuFooter.vue
+++ b/shared/components/BurgerMenu/BurgerMenuFooter.vue
@@ -31,12 +31,14 @@
 <script setup>
 const { localeProperties, t } = useI18n();
 
-const props = defineProps({
+defineProps({
   actions: {
     type: Array,
     default: null,
   },
 });
+
+defineEmits(['toggleLocaleSwitcher']);
 </script>
 
 <style lang="scss" scoped>

--- a/shared/components/BurgerMenu/BurgerMenuHeader.vue
+++ b/shared/components/BurgerMenu/BurgerMenuHeader.vue
@@ -27,6 +27,8 @@ defineProps({
   },
 });
 
+defineEmits(['closeMenu']);
+
 const hasLink = (item) => {
   return item.url.link_type !== 'Any';
 };

--- a/shared/components/BurgerMenu/BurgerMenuLocalesList.vue
+++ b/shared/components/BurgerMenu/BurgerMenuLocalesList.vue
@@ -47,6 +47,8 @@ const props = defineProps({
   },
 });
 
+defineEmits(['close']);
+
 const localeSwitcher = ref(null);
 
 const updateLocaleCookie = (localeCode) => {

--- a/shared/components/BurgerMenu/BurgerMenuSections.vue
+++ b/shared/components/BurgerMenu/BurgerMenuSections.vue
@@ -28,7 +28,12 @@
 </template>
 
 <script setup>
-const props = defineProps(['sections']);
+defineProps({
+  field: {
+    type: Object,
+    required: true,
+  },
+});
 const emits = defineEmits(['close-menu']);
 const { getEnvironmentUrl } = useEnvironmentUrl();
 

--- a/shared/components/LocaleSuggestionBanner.vue
+++ b/shared/components/LocaleSuggestionBanner.vue
@@ -20,6 +20,7 @@ export default {
       type: String,
     },
   },
+  emits: ['handleCloseBanner'],
 };
 </script>
 

--- a/shared/components/Modal.vue
+++ b/shared/components/Modal.vue
@@ -9,6 +9,8 @@
 <script setup>
 import { ref, onMounted } from 'vue';
 
+defineEmits(['closeModal']);
+
 const modalRef = ref(null);
 
 onMounted(() => {

--- a/shared/components/NavigationDropdown.vue
+++ b/shared/components/NavigationDropdown.vue
@@ -15,8 +15,8 @@
         </div>
         <ul class="navigation-dropdown__sub-list">
           <li
-            v-for="(link, index) in section.links"
-            :key="`link-${index}`"
+            v-for="(link, linkIndex) in section.links"
+            :key="`link-${linkIndex}`"
             class="navigation-dropdown-sub-list__sub-item"
           >
             <nuxt-link
@@ -50,6 +50,8 @@ defineProps({
     default: null,
   },
 });
+
+defineEmits(['sublink-click']);
 </script>
 
 <style scoped lang="scss">

--- a/shared/components/PrismicCustomSliceZone.vue
+++ b/shared/components/PrismicCustomSliceZone.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup>
-const props = defineProps({
+defineProps({
   slices: {
     type: Array,
     default: null,

--- a/shared/components/SimplePage.vue
+++ b/shared/components/SimplePage.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script setup>
-const props = defineProps({
+defineProps({
   content: {
     type: Object,
     default: null,

--- a/shared/pages/support/form/[support-form].vue
+++ b/shared/pages/support/form/[support-form].vue
@@ -8,6 +8,7 @@
       :field="data.supportForm.form_introduction"
       class="easiware-form__introduction"
     />
+    <!-- eslint-disable-next-line vue/no-v-html -->
     <p class="easiware-form__required-info" v-html="t('support.form.required-info')" />
   </easiware-form>
 </template>


### PR DESCRIPTION
## :unicorn: Problème

Les warnings du linting ne sont pas considérés comme bloquants pour la CI et à la longue : 
* les warnings s'accumulent sans fin, ce qui n'est pas une solution à long terme
* les warnings vraiment utiles sont noyés dans la masse

## :robot: Proposition

1. Corriger tous les warnings pertinents et positionner des exceptions lorsque le code contrevenant est légitime (`eslint-disable`)
2. Pour éviter que la situation ne se dégrade à nouveau : modifier le fichier `package.json` pour que la commande `npm run lint` considère désormais la présence de warnings comme une erreur à obligatoirement corriger

## :rainbow: Remarques

RAS

## :100: Pour tester

Faire une passe globale de non-régression sur les 4 pix-sites, en apportant une attention particulière sur les composants qui ont été modifiés avec des corrections pour le linting.
