### PR TITLE
[FEATURE] MAJ de la metadescription du Centre d'aide(PIX-14175)

### DIFF
--- a/shared/pages/support/index.vue
+++ b/shared/pages/support/index.vue
@@ -20,7 +20,7 @@
 
 <script setup>
 const { client } = usePrismic();
-const { locale: i18nLocale } = useI18n();
+const { locale: i18nLocale, t } = useI18n();
 
 /* I18n Routes */
 defineI18nRoute({
@@ -31,6 +31,11 @@ defineI18nRoute({
     'fr-be': '/support',
     'nl-be': '/support',
   },
+});
+
+useHead({
+  title: t('support.meta.title'),
+  meta: [{ name: 'description', content: t('support.meta.description') }],
 });
 
 /* Fetch personas list */

--- a/shared/translations/en.js
+++ b/shared/translations/en.js
@@ -79,5 +79,10 @@ export default {
       'contact-title': "Can't find the answer to your question?",
       'contact-cta': 'Contact the support',
     },
+    meta: {
+      title: 'Help Center and Contact',
+      description:
+        'Any question? Do you need help? Check out our FAQ or contact our support using the form dedicated to your situation.',
+    },
   },
 };

--- a/shared/translations/en.js
+++ b/shared/translations/en.js
@@ -48,7 +48,6 @@ export default {
     'pix-certification-application': 'Application for accreditation as a certification center | Pix',
     'pix-orga-higher-school-registration': 'Finalise slot inquiry | Pix Orga sup',
     'pix-orga-registration': 'Request for information | Pix pro',
-    support: 'Support | Pix',
   },
   'preview-page-load': 'Preview page loading...',
   'home-page-url': `${process.env.DOMAIN_ORG}/en/`,

--- a/shared/translations/fr-be.js
+++ b/shared/translations/fr-be.js
@@ -48,7 +48,6 @@ export default {
     'pix-certification-application': "Demande d'agrément comme centre de certification | Pix",
     'pix-orga-higher-school-registration': "Finaliser la demande d'espace | Pix Orga sup",
     'pix-orga-registration': "Demande d'information | Pix pro",
-    support: 'Support | Pix',
   },
   'preview-page-load': 'Chargement de la page de prévisualisation...',
   'home-page-url': `${process.env.DOMAIN_ORG}/fr-be/`,

--- a/shared/translations/fr-be.js
+++ b/shared/translations/fr-be.js
@@ -80,5 +80,10 @@ export default {
       'contact-title': 'Vous ne trouvez pas la réponse à votre question ?',
       'contact-cta': 'Contacter le support',
     },
+    meta: {
+      title: 'Centre d’aide et contact',
+      description:
+        'Une question ? Besoin d’aide ? Trouvez votre réponse en consultant notre FAQ ou contactez le support via le formulaire adapté à votre situation.',
+    },
   },
 };

--- a/shared/translations/fr-fr.js
+++ b/shared/translations/fr-fr.js
@@ -80,5 +80,10 @@ export default {
       'contact-title': 'Vous ne trouvez pas la réponse à votre question ?',
       'contact-cta': 'Contacter le support',
     },
+    meta: {
+      title: 'Centre d’aide et contact',
+      description:
+        'Une question ? Besoin d’aide ? Trouvez votre réponse en consultant notre FAQ ou contactez le support via le formulaire adapté à votre situation.',
+    },
   },
 };

--- a/shared/translations/fr-fr.js
+++ b/shared/translations/fr-fr.js
@@ -48,7 +48,6 @@ export default {
     'pix-certification-application': "Demande d'agrément comme centre de certification | Pix",
     'pix-orga-higher-school-registration': "Finaliser la demande d'espace | Pix Orga sup",
     'pix-orga-registration': "Demande d'information | Pix pro",
-    support: 'Support | Pix',
   },
   'preview-page-load': 'Chargement de la page de prévisualisation...',
   'home-page-url': `${process.env.DOMAIN_FR}/`,

--- a/shared/translations/fr.js
+++ b/shared/translations/fr.js
@@ -80,5 +80,10 @@ export default {
       'contact-title': 'Vous ne trouvez pas la réponse à votre question ?',
       'contact-cta': 'Contacter le support',
     },
+    meta: {
+      title: 'Centre d’aide et contact',
+      description:
+        'Une question ? Besoin d’aide ? Trouvez votre réponse en consultant notre FAQ ou contactez le support via le formulaire adapté à votre situation.',
+    },
   },
 };

--- a/shared/translations/fr.js
+++ b/shared/translations/fr.js
@@ -44,7 +44,6 @@ export default {
     'pix-certification-application': "Demande d'agrément comme centre de certification | Pix",
     'pix-orga-higher-school-registration': "Finaliser la demande d'espace | Pix Orga sup",
     'pix-orga-registration': "Demande d'information | Pix pro",
-    support: 'Support | Pix',
   },
   form: {
     'not-supported':

--- a/shared/translations/nl-be.js
+++ b/shared/translations/nl-be.js
@@ -48,7 +48,6 @@ export default {
     'pix-certification-application': "Demande d'agrément comme centre de certification | Pix",
     'pix-orga-higher-school-registration': "Finaliser la demande d'espace | Pix Orga sup",
     'pix-orga-registration': "Demande d'information | Pix pro",
-    support: 'Support | Pix',
   },
   'preview-page-load': 'Chargement de la page de prévisualisation...',
   'home-page-url': `${process.env.DOMAIN_ORG}/nl-be/`,

--- a/shared/translations/nl-be.js
+++ b/shared/translations/nl-be.js
@@ -71,7 +71,7 @@ export default {
     'change-locale-switcher': 'Changer la langue',
     'change-locale-switcher-button': 'Changer',
   },
-back: 'Retour',
+  back: 'Retour',
   support: {
     form: {
       'required-info': "Tous les champs marqués d'une <span>*</span> sont obligatoires",
@@ -79,6 +79,11 @@ back: 'Retour',
     faq: {
       'contact-title': 'Vous ne trouvez pas la réponse à votre question ?',
       'contact-cta': 'Contacter le support',
+    },
+    meta: {
+      title: 'Helpcentrum & Contact',
+      description:
+        'Heb je een vraag? Heb je hulp nodig? Vind je antwoord in de FAQ of neem contact met ons op via het formulier dat is aangepast aan jouw situatie.',
     },
   },
 };

--- a/shared/translations/nl-be.js
+++ b/shared/translations/nl-be.js
@@ -71,4 +71,14 @@ export default {
     'change-locale-switcher': 'Changer la langue',
     'change-locale-switcher-button': 'Changer',
   },
+back: 'Retour',
+  support: {
+    form: {
+      'required-info': "Tous les champs marqués d'une <span>*</span> sont obligatoires",
+    },
+    faq: {
+      'contact-title': 'Vous ne trouvez pas la réponse à votre question ?',
+      'contact-cta': 'Contacter le support',
+    },
+  },
 };


### PR DESCRIPTION
## :unicorn: Problème
Il manque une meta-description pour la pge support de Pix Site

## :robot: Proposition
Modifier le titre et ajouter une meta-description pour la page suivant le wording suivant :

### FR : 
Titre : Centre d’aide et contact | Pix
Description : Une question ? Besoin d’aide ? Trouvez votre réponse en consultant notre FAQ ou contactez le support via le formulaire adapté à votre situation.

### NL :
Titre : Helpcentrum & Contact | Pix
Description : Heb je een vraag? Heb je hulp nodig? Vind je antwoord in de FAQ of neem contact met ons op via het formulier dat is aangepast aan jouw situatie.


### EN : 
Titre : Help Center and Contact | Pix
Description : Any question? Do you need help? Check out our FAQ or contact our support using the form dedicated to your situation.

## :rainbow: Remarques
- J'ai ajouté des clés de trad manquantes en NL-BE
- j'ai supprimé une clés de trad non utilisées (parmi tant d'autres)

## :100: Pour tester
- aller sur la page centre d'aide de pix Site
- inspecter la page et aller dans la console
- vérifier la présence et le wording du titre et de la meta-description
- répéter les 3 étapes précédentes dans toutes les langues : fr, fr-fr, fr-be, nl-be, en