### PR TITLE
[BUGFIX] Corriger le problème des locales disponibles non-identiques entre pix-site à pix-pro (PIX-14143)

### DIFF
--- a/pix-pro/i18n.config.ts
+++ b/pix-pro/i18n.config.ts
@@ -2,9 +2,11 @@ import { generateConfig } from '../shared/i18n.config';
 
 const reachableLocales = [
   {
+    // The "code" property should be renamed into "name": https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale
     code: 'en',
     iso: 'en',
     file: 'en.js',
+    // The "name" property should be renamed into "displayName": https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames/DisplayNames
     name: 'English',
     icon: 'globe-europe.svg',
     domain: process.env.DOMAIN_ORG,
@@ -27,6 +29,8 @@ const reachableLocales = [
   },
 ];
 
+const reachableLocaleNames = reachableLocales.map(reachableLocale => reachableLocale.code);
+
 const config = generateConfig(reachableLocales);
 export default { ...config };
-export { reachableLocales };
+export { reachableLocales, reachableLocaleNames };

--- a/pix-pro/nuxt.config.ts
+++ b/pix-pro/nuxt.config.ts
@@ -1,5 +1,5 @@
 import { getRoutesToGenerate } from './services/get-routes-to-generate';
-import i18nConfig, { reachableLocales } from './i18n.config';
+import i18nConfig, { reachableLocales, reachableLocaleNames } from './i18n.config';
 
 export default async () => {
   return defineNuxtConfig({
@@ -28,6 +28,7 @@ export default async () => {
       public: {
         site: 'https://pro.pix.',
         availableLocales: reachableLocales,
+        availableLocaleNames: reachableLocaleNames,
       },
     },
     nitro: {

--- a/pix-site/i18n.config.ts
+++ b/pix-site/i18n.config.ts
@@ -2,9 +2,11 @@ import { generateConfig } from '../shared/i18n.config';
 
 const reachableLocales = [
   {
+    // The "code" property should be renamed into "name": https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale
     code: 'en',
     iso: 'en',
     file: 'en.js',
+    // The "name" property should be renamed into "displayName": https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames/DisplayNames
     name: 'English',
     icon: 'globe-europe.svg',
     domain: process.env.DOMAIN_ORG,
@@ -43,6 +45,8 @@ const reachableLocales = [
   },
 ];
 
+const reachableLocaleNames = reachableLocales.map(reachableLocale => reachableLocale.code);
+
 const config = generateConfig(reachableLocales);
 export default { ...config };
-export { reachableLocales };
+export { reachableLocales, reachableLocaleNames };

--- a/pix-site/nuxt.config.ts
+++ b/pix-site/nuxt.config.ts
@@ -1,5 +1,5 @@
 import { getRoutesToGenerate } from './services/get-routes-to-generate';
-import i18nConfig, { reachableLocales } from './i18n.config';
+import i18nConfig, { reachableLocales, reachableLocaleNames } from './i18n.config';
 
 export default async () => {
   const routes = process.env.NODE_ENV !== 'test' ? await getRoutesToGenerate({ locales: i18nConfig.locales }) : [];
@@ -24,6 +24,7 @@ export default async () => {
         siteDomain: process.env.SITE_DOMAIN,
         formKeysToMap: process.env.FORM_KEYS_TO_MAP || null,
         availableLocales: reachableLocales,
+        availableLocaleNames: reachableLocaleNames,
       },
     },
     nitro: {

--- a/shared/composables/useLocaleCookie.ts
+++ b/shared/composables/useLocaleCookie.ts
@@ -3,8 +3,11 @@ const LOCALE_COOKIE_NAME = 'locale';
 export default function useLocaleCookie() {
   const appConfig = useAppConfig();
   const runtimeConfig = useRuntimeConfig();
+
   const domainFrUrl = new URL(appConfig.domainFr);
   const domainOrgUrl = new URL(appConfig.domainOrg);
+
+  const availableLocaleNames = runtimeConfig.public.availableLocaleNames as Array<string>;
 
   const previousLocaleCookieToDelete = useCookie(LOCALE_COOKIE_NAME, {
     maxAge: 31536000, // 1 year
@@ -29,8 +32,22 @@ export default function useLocaleCookie() {
     if (callback) callback();
   }
 
+  function getBestMatchingLocaleName(localeName: string) {
+    if (availableLocaleNames.includes(localeName)) {
+      return localeName;
+    }
+
+    const languageLocaleName = new Intl.Locale(localeName).language;
+    if (availableLocaleNames.includes(languageLocaleName)) {
+      return languageLocaleName;
+    }
+
+    return availableLocaleNames[0];
+  }
+
   return {
     localeCookie,
     setLocaleCookie,
+    getBestMatchingLocaleName,
   };
 }

--- a/shared/composables/useLocaleCookie.ts
+++ b/shared/composables/useLocaleCookie.ts
@@ -1,26 +1,30 @@
+const LOCALE_COOKIE_NAME = 'locale';
+
 export default function useLocaleCookie() {
   const appConfig = useAppConfig();
   const runtimeConfig = useRuntimeConfig();
   const domainFrUrl = new URL(appConfig.domainFr);
   const domainOrgUrl = new URL(appConfig.domainOrg);
 
-  const previousLocaleCookie = useCookie('locale', {
-    maxAge: 31536000,
+  const previousLocaleCookieToDelete = useCookie(LOCALE_COOKIE_NAME, {
+    maxAge: 31536000, // 1 year
     sameSite: 'strict',
   });
 
-  const localeCookie = useCookie('locale', {
+  const localeCookie = useCookie(LOCALE_COOKIE_NAME, {
     domain: runtimeConfig.public.siteDomain === 'ORG' ? domainOrgUrl.hostname : domainFrUrl.hostname,
-    maxAge: 31536000,
+    maxAge: 31536000, // 1 year
     sameSite: 'strict',
   });
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
   function setLocaleCookie(locale: string, callback?: Function): void {
     const localeCanonicalName = Intl.getCanonicalLocales(locale)?.[0];
-    if (previousLocaleCookie.value) {
-      previousLocaleCookie.value = null;
+
+    if (previousLocaleCookieToDelete.value) {
+      previousLocaleCookieToDelete.value = null;
     }
+
     localeCookie.value = localeCanonicalName;
     if (callback) callback();
   }

--- a/shared/pages/index.vue
+++ b/shared/pages/index.vue
@@ -10,12 +10,14 @@ definePageMeta({
   layout: 'empty',
 });
 
-const { localeCookie } = useLocaleCookie();
+const { localeCookie, getBestMatchingLocaleName } = useLocaleCookie();
 const locale = localeCookie.value;
+
 onBeforeMount(() => {
   const router = useRouter();
+
   if (locale) {
-    return router.replace(`/${locale}/`);
+    return router.replace(`/${getBestMatchingLocaleName(locale)}/`);
   }
 });
 </script>

--- a/shared/tests/composables/useLocaleCookie.test.ts
+++ b/shared/tests/composables/useLocaleCookie.test.ts
@@ -3,6 +3,8 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 
 import useLocaleCookie from '../../composables/useLocaleCookie';
 
+const availableLocaleNames = ['en', 'fr', 'fr-fr'];
+
 mockNuxtImport('useCookie', () => {
   return () => ({
     value: '',
@@ -18,6 +20,7 @@ mockNuxtImport('useRuntimeConfig', () => {
   return () => ({
     public: {
       siteDomain: 'ORG',
+      availableLocaleNames,
     },
   });
 });
@@ -71,6 +74,47 @@ describe('#useLocaleCookie', () => {
 
         // then
         expect(localeCookie.value).toEqual('nl-BE');
+      });
+    });
+  });
+
+  describe('getBestMatchingLocaleName', () => {
+    describe('when wanted locale is available', () => {
+      test('returns the same locale name', () => {
+        // given
+        const { getBestMatchingLocaleName } = useLocaleCookie();
+
+        // when
+        const matchingLocaleName = getBestMatchingLocaleName('fr-fr');
+
+        // then
+        expect(matchingLocaleName).toEqual('fr-fr');
+      });
+    });
+
+    describe('when wanted locale is unavailable but an available locale with same language is', () => {
+      test('returns the same locale name', () => {
+        // given
+        const { getBestMatchingLocaleName } = useLocaleCookie();
+
+        // when
+        const matchingLocaleName = getBestMatchingLocaleName('fr-be');
+
+        // then
+        expect(matchingLocaleName).toEqual('fr');
+      });
+    });
+
+    describe('when wanted locale is unavailable and no available locale with same language is', () => {
+      test('returns the first available locale name', () => {
+        // given
+        const { getBestMatchingLocaleName } = useLocaleCookie();
+
+        // when
+        const matchingLocaleName = getBestMatchingLocaleName('nl-be');
+
+        // then
+        expect(matchingLocaleName).toEqual('en');
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème

Quand on a un cookie de locale positionné par Pix Site avec une locale non-disponible sur Pix Pro, on a une erreur « error-content » quand on va sur Pix Pro.

Dans tous les pix-sites il manque un fallback lorsque la locale spécifiée dans le cookie locale n’existe pas dans le pix-site en question.

## :robot: Proposition

Implémenter une fonction `getBestMatchingLocaleName` pour présenter la meilleure page localisée à l'utilisateur en fonction des locales disponibles sur le pix-site visité.

## :rainbow: Remarques

RAS

## :100: Pour tester

Il y a une différence de comportement entre le comportement des pix-sites entre la production, en local et dans les RA. En effet les RA des pix-site et des pix-pro ne sont pas sur le même domaine.

Donc pour ce ticket aucun test n'est probant dans les RA. Il faut donc faire des tests en local.

1. cd `pix-site/`
2. Exécuter la commande : `npm run dev:site:org`
3. Aller sur http://localhost:7001/ et cliquer sur België (Nederlands)
4. Constater le positionnement d'un cookie `locale` avec la valeur `nl-BE`
5. Arrêter la commande `npm run dev:site:org`
6. `cd pix-pro/`
7. Exécuter la commande : `npm run dev:site:org`
8. Aller sur http://localhost:7001/ (et pas sur `http://localhost:7001/nl-be`)
9. Constater que l'utilisateur est redirigé vers http://localhost:7001/en/ mais que son cookie `locale` a toujours la valeur `nl-BE`

Refaire la même opération avec `Belgique (Français)` (`fr-BE`) et constater que l'utilisateur est redirigé vers http://localhost:7001/en/