### PR TITLE
[BUGFIX] Réparer le burger menu du site vitrine (PIX-14793).

### DIFF
--- a/shared/components/BurgerMenu/BurgerMenuSections.vue
+++ b/shared/components/BurgerMenu/BurgerMenuSections.vue
@@ -29,6 +29,10 @@
 
 <script setup>
 defineProps({
+  sections: {
+    type: Array,
+    required: true,
+  },
   field: {
     type: Object,
     required: true,
@@ -42,7 +46,7 @@ const handleLinkClick = () => {
 };
 </script>
 
-<style lang="scss" scoped>
+<style lang='scss' scoped>
 .burger-menu-nav-sections-list {
   padding: 0.75rem 0;
   border-bottom: 1px solid $grey-20;


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le menu au format mobile du site vitrine est cassé. En effet, les sous catégories ne s'affichent plus.

## :robot: Proposition
Réparer le menu.

## :rainbow: Remarques
Il manquait la décalaration d'une props dans le composant vue.

## :100: Pour tester
- Aller sur [la review app](https://site-pr720.review.pix.fr/)
- Ouvrir l'application au format mobile
- Parcourir les catégories du menu
- Vérifier que les sous catégories s'affichent
