### PR TITLE
[BUGFIX] Mettre le bouton pour fermer la bannière de nouveauté dans un vrai bouton

### DIFF
--- a/shared/components/HotNewsBanner.vue
+++ b/shared/components/HotNewsBanner.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="isOpen && hotNews" class="hot-news">
     <prismic-rich-text :field="hotNews" :serializer="customPrismicRichTextSerializer" />
-    <img class="close" src="/images/close-icon.svg" alt="Fermer" @click.stop="closeBanner" />
+    <button><img class="close" src="/images/close-icon.svg" alt="Fermer" @click.stop="closeBanner" /></button>
   </div>
 </template>
 


### PR DESCRIPTION
## :fallen_leaf: Problème
Dans la bannière de nouveauté, le bouton "fermer" apparaissait comme une image pour les lecteurs d'écran et non comme un bouton.

## :chestnut: Proposition
Mettre cette image et son action dans une simple balise de type button.

## :jack_o_lantern: Remarques
Je n'ai pas pu vérifier qu'il s'agissait du bon bouton car impossible de mettre en place l'environnement de travail, il faudrait retravailler la doc.

## :wood: Pour tester
Se rendre sur la page principal. Si une bannière de nouveauté s'affiche, vérifier que le bouton fermer est bien un bouton et pas seulement une image.