### PR TITLE
[TECH] Ajouter un tracking Matomo sur les recherches FAQ support (PIX-15433).

### DIFF
--- a/pix-pro/error.vue
+++ b/pix-pro/error.vue
@@ -1,11 +1,17 @@
 <template>
-  <div class="error">
-    <a :href="t('home-page-url')">
-      <img class="logo" src="/images/pix-logo.svg" alt="Lien pour revenir à l'accueil" />
-    </a>
-    <!-- eslint-disable-next-line vue/no-v-html -->
-    <div v-html="t('error-content')" />
-  </div>
+  <template v-if="isDevelopmentMode">
+    <h1>Nuxt error</h1>
+    <pre>{{ error }}</pre>
+  </template>
+  <template v-else>
+    <div class="error">
+      <a :href="t('home-page-url')">
+        <img class="logo" src="/images/pix-logo.svg" alt="Lien pour revenir à l'accueil" />
+      </a>
+      <!-- eslint-disable-next-line vue/no-v-html -->
+      <div v-html="t('error-content')" />
+    </div>
+  </template>
 </template>
 
 <script setup>
@@ -17,6 +23,13 @@ useHead({
     lang: i18nLocale,
   },
 });
+
+const error = useError();
+const isDevelopmentMode = process.env.NODE_ENV !== 'production';
+
+if (isDevelopmentMode) {
+  console.table(error.value);
+}
 </script>
 
 <style lang="scss">

--- a/pix-site/error.vue
+++ b/pix-site/error.vue
@@ -1,11 +1,17 @@
 <template>
-  <div class="error">
-    <a :href="t('home-page-url')">
-      <img class="logo" src="/images/pix-logo.svg" alt="Lien pour revenir à l'accueil" />
-    </a>
-    <!-- eslint-disable-next-line vue/no-v-html -->
-    <div v-html="t('error-content')" />
-  </div>
+  <template v-if="isDevelopmentMode">
+    <h1>Nuxt error</h1>
+    <pre>{{ error }}</pre>
+  </template>
+  <template v-else>
+    <div class="error">
+      <a :href="t('home-page-url')">
+        <img class="logo" src="/images/pix-logo.svg" alt="Lien pour revenir à l'accueil" />
+      </a>
+      <!-- eslint-disable-next-line vue/no-v-html -->
+      <div v-html="t('error-content')" />
+    </div>
+  </template>
 </template>
 
 <script setup>
@@ -17,6 +23,13 @@ useHead({
     lang: i18nLocale,
   },
 });
+
+const error = useError();
+const isDevelopmentMode = process.env.NODE_ENV !== 'production';
+
+if (isDevelopmentMode) {
+  console.table(error.value);
+}
 </script>
 
 <style lang="scss">

--- a/shared/pages/support/faq/[faq-persona].vue
+++ b/shared/pages/support/faq/[faq-persona].vue
@@ -64,6 +64,9 @@
 </template>
 
 <script setup>
+import { useDebounceFn } from '@vueuse/core';
+
+const { $pushMatomoEvent } = useNuxtApp();
 const { client } = usePrismic();
 const { locale: i18nLocale, t } = useI18n();
 const route = useRoute();
@@ -143,6 +146,15 @@ const displayPost = ({ post }) => {
   return simplifyString(getPostTitle(post.uid)).includes(simplifyString(searchInput.value));
 };
 
+const debouncedMatomoEvent = useDebounceFn((inputValue) => {
+  $pushMatomoEvent(
+    'Support',
+    'FAQ',
+    "Recherche dans la barre d'une FAQ support",
+    `${data.value.currentPersona.faq_page_title[0].text}: '${inputValue}'`,
+  );
+}, 1500);
+
 const handleSearch = async (inputValue) => {
   searchInput.value = inputValue;
 
@@ -160,6 +172,8 @@ const handleSearch = async (inputValue) => {
   });
 
   filteredPostsCount.value = postsCount;
+
+  debouncedMatomoEvent(inputValue);
 };
 </script>
 

--- a/shared/plugins/matomo.ts
+++ b/shared/plugins/matomo.ts
@@ -1,0 +1,11 @@
+export default defineNuxtPlugin(() => {
+  return {
+    provide: {
+      pushMatomoEvent: (eventCategory: string, eventAction: string, eventName: string, value: string | number): void => {
+        if (import.meta.client && _mtm) {
+          _mtm.push(['trackEvent', eventCategory, eventAction, eventName, value]);
+        }
+      },
+    },
+  };
+});

--- a/shared/plugins/matomo.ts
+++ b/shared/plugins/matomo.ts
@@ -2,8 +2,8 @@ export default defineNuxtPlugin(() => {
   return {
     provide: {
       pushMatomoEvent: (eventCategory: string, eventAction: string, eventName: string, value: string | number): void => {
-        if (import.meta.client && _mtm) {
-          _mtm.push(['trackEvent', eventCategory, eventAction, eventName, value]);
+        if (import.meta.client && window._mtm) {
+          window._mtm.push(['trackEvent', eventCategory, eventAction, eventName, value]);
         }
       },
     },


### PR DESCRIPTION
## :gift: Proposition

On veut connaitre les mots recherchés par les utilisateurs, notamment ceux qui n’ont pas mené à une satisfaction.

## :socks: Remarques

Pour ne pas avoir trop de logs, on debounce la recherche pour connaitre la saisie finale de l’utilisateur.

## :santa: Pour tester

?
