### PR TITLE
[FEATURE] Transformer l'image cliquable de fermeture de la bannière en bouton. (PIX-16144)

### DIFF
--- a/shared/components/HotNewsBanner.vue
+++ b/shared/components/HotNewsBanner.vue
@@ -1,7 +1,9 @@
 <template>
   <div v-if="isOpen && hotNews" class="hot-news">
     <prismic-rich-text :field="hotNews" :serializer="customPrismicRichTextSerializer" />
-    <img class="close" src="/images/close-icon.svg" alt="Fermer" @click.stop="closeBanner" />
+    <button class="close" type="button">
+      <img src="/images/close-icon.svg" alt="Fermer" @click.stop="closeBanner" />
+    </button>
   </div>
 </template>
 
@@ -59,12 +61,20 @@ const closeBanner = () => {
     text-decoration: underline;
   }
 }
+
 .close {
   margin-right: 20px;
   opacity: 0.5;
   transition: 0.5s;
   cursor: pointer;
-  height: 20px;
+  appearance: none;
+  border: none;
+  background: transparent;
+
+  img {
+    filter: invert(1);
+    height: 20px;
+  }
 
   @media (min-width: 769px) {
     margin-right: 32px;


### PR DESCRIPTION
## :pancakes: Problème
Théotime a relevé que l'image cliquable de fermeture de la bannière n'était pas un bouton, ce qui n'est pas accessible. 

## :bacon: Proposition
Ajouter une balise bouton autour de l'image.

## 🧃 Remarques
Théotime avait créé une PR pour résoudre le problème sur un fork du projet, on a dû reprendre ses modifications sur une branche par facilité d'usage.

## :yum: Pour tester
- Aller sur Pix Site
- Constater que le bouton de fermeture de la bannière en haut à droite est de couleur grise (noire au survol)
- Constater que c'est bien un bouton en inspectant l'élément
