### PR TITLE
[A11Y] Ajouter l'action close banner sur le bouton au lieu de l'image (PIX-16144 bis).

### DIFF
--- a/shared/components/HotNewsBanner.vue
+++ b/shared/components/HotNewsBanner.vue
@@ -1,8 +1,8 @@
 <template>
   <div v-if="isOpen && hotNews" class="hot-news">
     <prismic-rich-text :field="hotNews" :serializer="customPrismicRichTextSerializer" />
-    <button class="close" type="button">
-      <img src="/images/close-icon.svg" alt="Fermer" @click.stop="closeBanner" />
+    <button class="close" type="button" @click="closeBanner">
+      <img src="/images/close-icon.svg" alt="Fermer" />
     </button>
   </div>
 </template>


### PR DESCRIPTION
## :pancakes: Problème
On a oublié dans le ticket 16144 de déplacer l'action sur le bouton plutôt que sur l'image

## :bacon: Proposition
Corriger cet oubli.

## :yum: Pour tester
- Vérifier que l'action est bien sur le bouton
