### PR TITLE
[BUGFIX] Conserver la bonne locale lors du retour sur Pix Site (PIX-16290)

### DIFF
--- a/pix-pro/i18n.config.ts
+++ b/pix-pro/i18n.config.ts
@@ -30,7 +30,10 @@ const reachableLocales = [
 ];
 
 const reachableLocaleNames = reachableLocales.map(reachableLocale => reachableLocale.code);
+// When the locales are by default written in their canonical form this reachableLocaleCanonicalNames variable
+// will be useless and thus removed.
+const reachableLocaleCanonicalNames = reachableLocaleNames.map(localeName => new Intl.Locale(localeName).toString());
 
 const config = generateConfig(reachableLocales);
 export default { ...config };
-export { reachableLocales, reachableLocaleNames };
+export { reachableLocales, reachableLocaleNames, reachableLocaleCanonicalNames };

--- a/pix-pro/nuxt.config.ts
+++ b/pix-pro/nuxt.config.ts
@@ -1,5 +1,5 @@
 import { getRoutesToGenerate } from './services/get-routes-to-generate';
-import i18nConfig, { reachableLocales, reachableLocaleNames } from './i18n.config';
+import i18nConfig, { reachableLocales, reachableLocaleNames, reachableLocaleCanonicalNames } from './i18n.config';
 
 export default async () => {
   return defineNuxtConfig({
@@ -29,6 +29,7 @@ export default async () => {
         site: 'https://pro.pix.',
         availableLocales: reachableLocales,
         availableLocaleNames: reachableLocaleNames,
+        availableLocaleCanonicalNames: reachableLocaleCanonicalNames,
       },
     },
     nitro: {

--- a/pix-site/i18n.config.ts
+++ b/pix-site/i18n.config.ts
@@ -46,7 +46,10 @@ const reachableLocales = [
 ];
 
 const reachableLocaleNames = reachableLocales.map(reachableLocale => reachableLocale.code);
+// When the locales are by default written in their canonical form this reachableLocaleCanonicalNames variable
+// will be useless and thus removed.
+const reachableLocaleCanonicalNames = reachableLocaleNames.map(localeName => new Intl.Locale(localeName).toString());
 
 const config = generateConfig(reachableLocales);
 export default { ...config };
-export { reachableLocales, reachableLocaleNames };
+export { reachableLocales, reachableLocaleNames, reachableLocaleCanonicalNames };

--- a/pix-site/nuxt.config.ts
+++ b/pix-site/nuxt.config.ts
@@ -1,5 +1,5 @@
 import { getRoutesToGenerate } from './services/get-routes-to-generate';
-import i18nConfig, { reachableLocales, reachableLocaleNames } from './i18n.config';
+import i18nConfig, { reachableLocales, reachableLocaleNames, reachableLocaleCanonicalNames } from './i18n.config';
 
 export default async () => {
   const routes = process.env.NODE_ENV !== 'test' ? await getRoutesToGenerate({ locales: i18nConfig.locales }) : [];
@@ -25,6 +25,7 @@ export default async () => {
         formKeysToMap: process.env.FORM_KEYS_TO_MAP || null,
         availableLocales: reachableLocales,
         availableLocaleNames: reachableLocaleNames,
+        availableLocaleCanonicalNames: reachableLocaleCanonicalNames,
       },
     },
     nitro: {

--- a/shared/composables/useLocaleCookie.ts
+++ b/shared/composables/useLocaleCookie.ts
@@ -7,7 +7,7 @@ export default function useLocaleCookie() {
   const domainFrUrl = new URL(appConfig.domainFr);
   const domainOrgUrl = new URL(appConfig.domainOrg);
 
-  const availableLocaleNames = runtimeConfig.public.availableLocaleNames as Array<string>;
+  const availableLocaleCanonicalNames = runtimeConfig.public.availableLocaleCanonicalNames as Array<string>;
 
   const previousLocaleCookieToDelete = useCookie(LOCALE_COOKIE_NAME, {
     maxAge: 31536000, // 1 year
@@ -33,16 +33,16 @@ export default function useLocaleCookie() {
   }
 
   function getBestMatchingLocaleName(localeName: string) {
-    if (availableLocaleNames.includes(localeName)) {
+    if (availableLocaleCanonicalNames.includes(new Intl.Locale(localeName).toString())) {
       return localeName;
     }
 
     const languageLocaleName = new Intl.Locale(localeName).language;
-    if (availableLocaleNames.includes(languageLocaleName)) {
+    if (availableLocaleCanonicalNames.includes(languageLocaleName)) {
       return languageLocaleName;
     }
 
-    return availableLocaleNames[0];
+    return availableLocaleCanonicalNames[0];
   }
 
   return {

--- a/shared/tests/composables/useLocaleCookie.test.ts
+++ b/shared/tests/composables/useLocaleCookie.test.ts
@@ -3,7 +3,8 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 
 import useLocaleCookie from '../../composables/useLocaleCookie';
 
-const availableLocaleNames = ['en', 'fr', 'fr-fr'];
+const availableLocaleNames = ['en', 'fr', 'fr-fr', 'fr-be'];
+const availableLocaleCanonicalNames = availableLocaleNames.map(localeName => new Intl.Locale(localeName).toString());
 
 mockNuxtImport('useCookie', () => {
   return () => ({
@@ -21,6 +22,7 @@ mockNuxtImport('useRuntimeConfig', () => {
     public: {
       siteDomain: 'ORG',
       availableLocaleNames,
+      availableLocaleCanonicalNames,
     },
   });
 });
@@ -91,6 +93,18 @@ describe('#useLocaleCookie', () => {
         expect(matchingLocaleName).toEqual('fr-fr');
       });
     });
+    describe('when wanted locale is available but not written in canonical form', () => {
+      test('returns the same locale name', () => {
+        // given
+        const { getBestMatchingLocaleName } = useLocaleCookie();
+
+        // when
+        const matchingLocaleName = getBestMatchingLocaleName('fr-BE');
+
+        // then
+        expect(matchingLocaleName).toEqual('fr-BE');
+      });
+    });
 
     describe('when wanted locale is unavailable but an available locale with same language is', () => {
       test('returns the same locale name', () => {
@@ -98,10 +112,10 @@ describe('#useLocaleCookie', () => {
         const { getBestMatchingLocaleName } = useLocaleCookie();
 
         // when
-        const matchingLocaleName = getBestMatchingLocaleName('fr-be');
+        const matchingLocaleName = getBestMatchingLocaleName('en-us');
 
         // then
-        expect(matchingLocaleName).toEqual('fr');
+        expect(matchingLocaleName).toEqual('en');
       });
     });
 


### PR DESCRIPTION
## :pancakes: Problème

Lorsqu'on se rend sur https://pix.org/ la première fois, on doit choisir sa locale. Cela fait, la locale est conservée dans un cookie `locale` et est réutilisée lorsqu'on revient à la racine de Pix site. Cependant, il a été constaté que lorsqu'on a choisi la locale `fr-BE` du site, on est redirigé sur https://pix.org/fr au lieu d'être redirigé sur la version correspondant à la locale  `fr-BE` du site.

## :bacon: Proposition

Modifier la fonction `getBestMatchingLocaleName` qui gère la correspondance des locales pour travailler uniquement sur des versions canoniques de locales et non pas sur un mélange de versions non-canoniques et de versions canoniques.

## 🧃 Remarques

Cette PR est un correctif minimaliste pour corriger uniquement le problème de redirection vers la version du site correspondant à la locale de l'utilisateur. La bonne solution définitive est de ne plus avoir dans la configuration des Pix Sites que des locales dans leur version canonique, mais tout en assurant la gestion des anciens URL contenant la version non-canonique des URL. La bonne solution demande un peu plus de temps pour réaliser des tests un peu plus poussés et de la gestion du changement.

## :yum: Pour tester

Tous les tests sont à accomplir en navigation privée pour ne pas être pollué par les données persistantes de son navigateur.

Pour vérifier la correction du problème : 

- Se rendre sur Pix Site .org (https://site-pr745.review.pix.org/),
- Choisir la locale `Belgique (Français)`,
- Constater qu'on arrive bien sur la version correspondant à la locale `fr-BE` du site (c'est à dire sur https://site-pr745.review.pix.org/fr-be/)
- Se rendre à nouveau à la racine de Pix Site .org (https://site-pr745.review.pix.org/), en faisant la modification de l'URL dans la barre d'adresse de son navigateur,
- Constater qu'on revient bien sur la version version correspondant à la locale `fr-BE` du site

:information_source: Selon le type de navigation on arrive soit sur des URL dans lesquels la locale est écrite en version canonique (par exemple https://site-pr745.review.pix.org/fr-BE/), soit sur des URL dans lesquels la locale est écrite en minuscules (par exemple https://site-pr745.review.pix.org/fr-be/). Ce n'est pas uniforme et cohérent mais les 2 types d'URL fonctionnent et il n'y a donc aucune régression. Évidemment ce n'est pas la bonne solution définitive cf. la section _Remarques_.

### Tests de non-régression

Une fois la vérification que le problème rapporté a bien été corrigé il est nécessaire de faire une passe de non-régression suivant les différents configurations des Pix Sites : 
* suivant les différents sites : Pix Site et Pix Pro
* suivant les différents domaines : `.fr` et `.org`
* suivant les différents facteurs de taille d'affichage : format grand ou format petit (qui utilise alors le composant _BurgerMenu_)
* avec les différentes locales

En effet les tests de ce projet sont encore peu couvrants et notamment quasiment absents pour Pix Pro.