### PR TITLE
[FEATURE] Ajout de formulaire Freescout pour remplacer les formulaires Easiware

### DIFF
--- a/shared/components/FreescoutForm.vue
+++ b/shared/components/FreescoutForm.vue
@@ -1,0 +1,57 @@
+<template>
+  <section class="freescout-form">
+    <div class="freescout-form__container">
+      <slot></slot>
+      <iframe ref="iframeRef" class="freescout-form__iframe" :src="freescoutUrl" @load="resizeIframe()">
+        {{ $t(`form.not-supported`) }}
+      </iframe>
+    </div>
+  </section>
+</template>
+
+<script setup>
+const iframeRef = ref(null);
+defineProps({
+  freescoutUrl: {
+    type: String,
+    default: null,
+  },
+});
+
+const resizeIframe = () => {
+  if (!iframeRef.value) return;
+
+  try {
+    const height = iframeRef.value.contentWindow.document.documentElement.scrollHeight;
+    iframeRef.value.style.height = `${height}px`;
+  } catch (e) {
+    console.warn('Cannot access iframe content:', e);
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.freescout-form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2.5rem;
+  background-color: #452d9d;
+}
+
+.freescout-form__container {
+  position: relative;
+  max-width: 50rem;
+  padding: 2rem;
+  background: white;
+  border-radius: 16px;
+  line-height: 1.25;
+  overflow: hidden;
+}
+
+.freescout-form__iframe {
+  width:100%;
+  border:none;
+  height: 1000px;
+}
+</style>

--- a/shared/components/FreescoutForm.vue
+++ b/shared/components/FreescoutForm.vue
@@ -2,31 +2,33 @@
   <section class="freescout-form">
     <div class="freescout-form__container">
       <slot></slot>
-      <iframe ref="iframeRef" class="freescout-form__iframe" :src="freescoutUrl" @load="resizeIframe()">
+      <iframe ref="iframeRef" class="freescout-form__iframe" :src="freescoutUrl" :style="[iframeHeight]">
         {{ $t(`form.not-supported`) }}
       </iframe>
     </div>
   </section>
 </template>
 
-<script setup>
-const iframeRef = ref(null);
-defineProps({
-  freescoutUrl: {
-    type: String,
-    default: null,
+<script>
+export default {
+  name: 'FreescoutForm',
+  props: {
+    freescoutUrl: {
+      type: String,
+      default: null,
+    },
+    heightForIframe: {
+      type: String,
+      default: null,
+    },
   },
-});
-
-const resizeIframe = () => {
-  if (!iframeRef.value) return;
-
-  try {
-    const height = iframeRef.value.contentWindow.document.documentElement.scrollHeight;
-    iframeRef.value.style.height = `${height}px`;
-  } catch (e) {
-    console.warn('Cannot access iframe content:', e);
-  }
+  computed: {
+    iframeHeight() {
+      const style = {};
+      style.minHeight = (this.heightForIframe || '900') + 'px';
+      return style;
+    },
+  },
 };
 </script>
 

--- a/shared/pages/support/form/[support-form].vue
+++ b/shared/pages/support/form/[support-form].vue
@@ -1,5 +1,5 @@
 <template>
-  <easiware-form :solution-id="data.supportForm.solution_id" :form-id="data.supportForm.form_id">
+  <easiware-form v-if="data.supportForm.useEasiwareForm" :solution-id="data.supportForm.solution_id" :form-id="data.supportForm.form_id">
     <h1 v-if="data.supportForm.form_title?.length" class="easiware-form__title">
       {{ data.supportForm.form_title?.[0].text }}
     </h1>
@@ -11,6 +11,16 @@
     <!-- eslint-disable-next-line vue/no-v-html -->
     <p class="easiware-form__required-info" v-html="t('support.form.required-info')" />
   </easiware-form>
+  <freescout-form v-else :freescout-url="data.supportForm.freescout_url.url">
+    <h1 v-if="data.supportForm.form_title?.length" class="easiware-form__title">
+      {{ data.supportForm.form_title?.[0].text }}
+    </h1>
+    <prismic-rich-text
+      v-if="data.supportForm.form_introduction?.length"
+      :field="data.supportForm.form_introduction"
+      class="easiware-form__introduction"
+    />
+  </freescout-form>
 </template>
 
 <script setup>
@@ -35,6 +45,7 @@ const { data } = await useAsyncData(async () => {
     const supportForm = await client.getByUID('easiware_form', route.params.slug, {
       lang: i18nLocale.value,
     });
+    supportForm.data.useEasiwareForm = !supportForm.data.freescout_url.url;
     return { supportForm: supportForm.data };
   } catch (err) {
     console.error(err);

--- a/shared/pages/support/form/[support-form].vue
+++ b/shared/pages/support/form/[support-form].vue
@@ -11,7 +11,7 @@
     <!-- eslint-disable-next-line vue/no-v-html -->
     <p class="easiware-form__required-info" v-html="t('support.form.required-info')" />
   </easiware-form>
-  <freescout-form v-else :freescout-url="data.supportForm.freescout_url.url">
+  <freescout-form v-else :freescout-url="data.supportForm.freescout_url.url" :height-for-iframe="data.supportForm.freescout_height">
     <h1 v-if="data.supportForm.form_title?.length" class="easiware-form__title">
       {{ data.supportForm.form_title?.[0].text }}
     </h1>


### PR DESCRIPTION
## :pancakes: Problème

Nous migrons nos outils du support d'Easiware à Freescout, nous changeons donc l'intégration des formulaires de support dans le site vitrine.

## :bacon: Proposition

Pour simplifier la migration : 
- Ajout d'un composant FreescoutForm
- Ajout de l'info freescout_url au sein des Support Form coté Prismic
- Si l'URL freescout existe, on affiche le freescout, sinon on laisse easiware.

## 🧃 Remarques

Une fois la migration faite, on pourra supprimer la partie Easiware du code

## :yum: Pour tester

L'url : https://site-pr747.review.pix.fr/support/form/eleve a un Freescout URL
L'url https://site-pr747.review.pix.fr/support/form/etudiant-e n'en a pas 