### PR TITLE
Réparer les pages d'accueil de support pour chaque locale

### DIFF
--- a/pix-site/services/get-routes-to-generate.js
+++ b/pix-site/services/get-routes-to-generate.js
@@ -16,6 +16,10 @@ export const getRoutesToGenerate = async function ({ locales }) {
 
   if (process.env.SITE_DOMAIN === 'ORG') {
     routes.push('/');
+    routes.push('/fr/support/');
+    routes.push('/fr-be/support/');
+    routes.push('/en/support/');
+    routes.push('/nl-be/support/');
   }
 
   console.info(`${routes.length} routes will be generated`);


### PR DESCRIPTION
## 🌸 Problème
Actuellement, il y a une 403 quand on essaie de charger les pages org/{locale}/support.

## 🌳 Proposition
Ajouter les routes à générer en dur afin de débloquer la situation

## 🐝 Remarques


## 🤧 Pour tester
Visiter les routes en question, constater que les pages sont chargées en 200
