### PR TITLE
[TECH] Génerer une page index pour chaque locale

### DIFF
--- a/pix-site/services/get-routes-to-generate.js
+++ b/pix-site/services/get-routes-to-generate.js
@@ -3,7 +3,7 @@ import { linkResolver } from '../../shared/services/link-resolver.js';
 
 export const getRoutesToGenerate = async function ({ locales }) {
   const client = await prismic.createClient('https://pix-site.cdn.prismic.io/api/v2');
-  const { routes, totalPages } = await getRoutesInPage(client, 1, locales);
+  let { routes, totalPages } = await getRoutesInPage(client, 1, locales);
 
   for (let page = 2; page <= totalPages; page++) {
     const { routes: nextPageRoutes } = await getRoutesInPage(client, page, locales);
@@ -16,10 +16,9 @@ export const getRoutesToGenerate = async function ({ locales }) {
 
   if (process.env.SITE_DOMAIN === 'ORG') {
     routes.push('/');
-    routes.push('/fr/support/');
-    routes.push('/fr-be/support/');
-    routes.push('/en/support/');
-    routes.push('/nl-be/support/');
+
+    const supportRoutesToGenerate = locales.map(({ code }) => `/${code}/support/`);
+    routes = routes.concat(supportRoutesToGenerate);
   }
 
   console.info(`${routes.length} routes will be generated`);


### PR DESCRIPTION
## 🌸 Problème
Actuellement, les locales sont écrites en dur dans les routes à générer. Cela posera un problème quand on ajoutera une autre locale sur pix-site.

## 🌳 Proposition
Se baser sur la liste des locales définie pour pix site.

## 🐝 Remarques


## 🤧 Pour tester

