### PR TITLE
[BUGFIX] Ajouter les pages actualites en dur pour la generation statique

### DIFF
--- a/pix-site/services/get-routes-to-generate.js
+++ b/pix-site/services/get-routes-to-generate.js
@@ -12,14 +12,20 @@ export const getRoutesToGenerate = async function ({ locales }) {
 
   if (process.env.SITE_DOMAIN === 'FR') {
     routes.push('/support/');
+    routes.push('/actualites/');
   }
 
   if (process.env.SITE_DOMAIN === 'ORG') {
     routes.push('/');
+
     routes.push('/fr/support/');
     routes.push('/fr-be/support/');
     routes.push('/en/support/');
     routes.push('/nl-be/support/');
+
+    routes.push('/fr/actualites/');
+    routes.push('/fr-be/actualites/');
+    routes.push('/en/news/');
   }
 
   console.info(`${routes.length} routes will be generated`);


### PR DESCRIPTION
## 🌸 Problème
Même genre de problème que sur la [PR](https://github.com/1024pix/pix-site/pull/754), mais cette fois ci sur les pages `/actualites`, aussi bien sur pix.fr que sur pix.org 

## 🌳 Proposition
Ajouter les routes en dur afin que nuxt génère un index.html.

## 🐝 Remarques


## 🤧 Pour tester
Sur .fr, Visiter chaque route et vérifier qu'on obtient bien une 200 et non une 403 sur : 
- [https://site-pr756.review.pix.fr/actualites/](https://site-pr756.review.pix.fr/actualites/)

Sur .org, Visiter chaque route et vérifier qu'on obtient bien une 200 et non une 403 sur : 
- https://site-pr756.review.pix.org/fr/actualites/
- https://site-pr756.review.pix.org/fr-be/actualites/
- https://site-pr756.review.pix.org/en/news/
