### PR TITLE
feature: add http headers auto

### DIFF
--- a/pix-pro/servers.conf.erb
+++ b/pix-pro/servers.conf.erb
@@ -102,4 +102,14 @@ server {
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header X-Forwarded-Host  $host;
   }
+
+  <% ENV.each do |key,value|
+    if key.start_with? 'ADD_HTTP_HEADER' %>
+      add_header <%=
+        key.sub(/^ADD_HTTP_HEADER_/, '').split("_").map(&:capitalize).join("-")
+      %> "<%=
+        value.gsub('\\', '\\\\\\\\').gsub('"','\\"').gsub('$','\\$')
+      %>" ;
+    <% end
+  end %>
 }

--- a/pix-site/servers.conf.erb
+++ b/pix-site/servers.conf.erb
@@ -102,6 +102,16 @@ server {
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header X-Forwarded-Host  $host;
   }
+
+  <% ENV.each do |key,value|
+    if key.start_with? 'ADD_HTTP_HEADER' %>
+      add_header <%=
+        key.sub(/^ADD_HTTP_HEADER_/, '').split("_").map(&:capitalize).join("-")
+      %> "<%=
+        value.gsub('\\', '\\\\\\\\').gsub('"','\\"').gsub('$','\\$')
+      %>" ;
+    <% end
+  end %>
 }
 
 server {


### PR DESCRIPTION
## 🌸 Problème

Il n'y a pas de CSP sur pix-site et pix-pro. Pourtant, un en-tête est bien proposé dans les variables d'environnement sur Scalingo.

## 🌳 Proposition

Cela vient du fait que la config nginx n'ajoute pas automatiquement les en-têtes à partir des variables d'env. C'est ce que cette PR ajoute.

## 🐝 Remarques

Cet ajout pourra servir à d'autres en-têtes

## 🤧 Pour tester

Se connecter à la RA et regarder si l'en-tête `Content-Security-Policy` ou `Content-Security-Policy-Report-Only`
