### PR TITLE
[FEATURE] Ajouter des tag dans la liste des actualités (PIX-18408)

### DIFF
--- a/shared/components/NewsItemCard.vue
+++ b/shared/components/NewsItemCard.vue
@@ -9,6 +9,7 @@
       </div>
 
       <div class="news-item-card__body">
+
         <p class="news-item-card__meta">
           <span :class="`news-item-card__category ${categoryClassName}`">
             {{ t(categoryLabel) }}
@@ -22,6 +23,9 @@
         <h3 class="news-item-card__title">{{ slice.title[0].text }}</h3>
 
         <prismic-rich-text :field="slice.excerpt" class="news-item-card__excerpt" />
+        <ul v-if="showTags" class="tags">
+          <li v-for="(tag, index) in filteredTags" :key="`tags-${index}`"><tag :label="tag"></tag></li>
+        </ul>
       </div>
     </nuxt-link>
   </li>
@@ -44,6 +48,10 @@ const props = defineProps({
     type: String,
     default: null,
   },
+  tags: {
+    type: Array,
+    default: null,
+  },
 });
 
 const categoryClassName = `news-item-card__category--${props.slice.category.toLowerCase()}`;
@@ -53,9 +61,20 @@ const categoryLabel = props.slice.category.toLowerCase();
 const date = useDateFormat(props.slice.date, 'DD MMMM YYYY', {
   locales: i18nLocale.value,
 });
+const filteredTags = props?.tags?.filter(tag => tag.startsWith('tag-')).map(tag => tag.replace('tag-', '')) ?? [];
+const showTags = filteredTags.length > 0;
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
+.tags {
+  display: inline-flex;
+  gap: .5rem;
+  list-style-type: none;
+  margin: 0;
+  padding-left: 0;
+  font-weight: $font-semi-bold;
+  font-size: .75rem;
+}
 .news-item-card {
   max-width: 340px;
   margin: 20px auto;

--- a/shared/components/Tag.vue
+++ b/shared/components/Tag.vue
@@ -1,0 +1,22 @@
+<template>
+  <span class="tag">{{ label }}</span>
+</template>
+
+<script setup>
+defineProps({
+  label: {
+    required: true,
+    type: String,
+    default: null,
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.tag {
+  border-radius: 2rem;
+  background: $default-gradient;
+  color: $grey-5;
+  padding: .5rem 1rem;
+}
+</style>

--- a/shared/pages/news/index.vue
+++ b/shared/pages/news/index.vue
@@ -18,6 +18,7 @@
             v-for="(item, index) in newsItems"
             :key="`item-${index}`"
             :slice="item.data"
+            :tags="item.tags"
             :uid="item.uid"
           />
         </template>

--- a/shared/translations/fr-be.js
+++ b/shared/translations/fr-be.js
@@ -58,7 +58,8 @@ export default {
     <br/>Si vous avez besoin d’aide, vous pouvez consulter le
     <a href="https://support.pix.org/fr/support/home">support</a>.
     </p>`,
-  'locale-suggestion-banner-text': 'Vous semblez ne pas être en France. Voulez-vous accéder au <a href="{domainOrgUrl}">site Pix international</a> ?',
+  'locale-suggestion-banner-text':
+    'Vous semblez ne pas être en France. Voulez-vous accéder au <a href="{domainOrgUrl}">site Pix international</a> ?',
   'skip-link': 'Aller au contenu',
   'burger-menu': {
     name: 'Navigation principale',

--- a/shared/translations/fr-fr.js
+++ b/shared/translations/fr-fr.js
@@ -58,7 +58,8 @@ export default {
     <br/>Si vous avez besoin d’aide, vous pouvez consulter le
     <a href="https://support.pix.org/fr/support/home">support</a>.
     </p>`,
-  'locale-suggestion-banner-text': 'Vous semblez ne pas être en France. Voulez-vous accéder au <a href="{domainOrgUrl}">site Pix international</a> ?',
+  'locale-suggestion-banner-text':
+    'Vous semblez ne pas être en France. Voulez-vous accéder au <a href="{domainOrgUrl}">site Pix international</a> ?',
   'skip-link': 'Aller au contenu',
   'burger-menu': {
     name: 'Navigation principale',

--- a/shared/translations/fr.js
+++ b/shared/translations/fr.js
@@ -58,7 +58,8 @@ export default {
     <br/>Si vous avez besoin d’aide, vous pouvez consulter le
     <a href="https://support.pix.org/fr/support/home">support</a>.
     </p>`,
-  'locale-suggestion-banner-text': 'Vous semblez ne pas être en France. Voulez-vous accéder au <a href="{domainOrgUrl}">site Pix international</a> ?',
+  'locale-suggestion-banner-text':
+    'Vous semblez ne pas être en France. Voulez-vous accéder au <a href="{domainOrgUrl}">site Pix international</a> ?',
   'skip-link': 'Aller au contenu',
   'burger-menu': {
     name: 'Navigation principale',

--- a/shared/translations/nl-be.js
+++ b/shared/translations/nl-be.js
@@ -58,7 +58,8 @@ export default {
     <br/>Si vous avez besoin d’aide, vous pouvez consulter le
     <a href="https://support.pix.org/fr/support/home">support</a>.
     </p>`,
-  'locale-suggestion-banner-text': 'Vous semblez ne pas être en France. Voulez-vous accéder au <a href="{domainOrgUrl}">site Pix international</a> ?',
+  'locale-suggestion-banner-text':
+    'Vous semblez ne pas être en France. Voulez-vous accéder au <a href="{domainOrgUrl}">site Pix international</a> ?',
   'skip-link': 'Aller au contenu',
   'burger-menu': {
     name: 'Navigation principale',


### PR DESCRIPTION
## 🔆 Problème

On souhaiterait pouvoir ajouter des tags sur certaines actualités en plus de la catégorie sur la page qui liste les actus.

## ⛱️ Proposition

Il est possible d'ajouter des tag à des document Prismic. On va chercher les tag associés à un document prismic en suivant la nomenclature suivante `tag-Contenu du tag` pour ne conserver que les tag qui commence par `tag-`

## 🌊 Remarques
ras

## 🏄 Pour tester

- Ajouter la RA en review app
- Ajouter des tags sur le document (ex `tag-C'est la vacances!`)
- Faire la preview sut la RA

<img width="372" height="646" alt="image" src="https://github.com/user-attachments/assets/bce63b55-cccb-49b1-bdc3-1af318abe708" />
