### PR TITLE
[BUGFIX] Réparer les icones des pages supports sur Pix Pro (PIX-18207).

### DIFF
--- a/pix-pro/nuxt.config.ts
+++ b/pix-pro/nuxt.config.ts
@@ -2,16 +2,10 @@ import { getRoutesToGenerate } from './services/get-routes-to-generate';
 import i18nConfig, { reachableLocales, reachableLocaleNames, reachableLocaleCanonicalNames } from './i18n.config';
 
 export default async () => {
+  const routes = process.env.NODE_ENV !== 'test' ? await getRoutesToGenerate({ locales: i18nConfig.locales }) : [];
+
   return defineNuxtConfig({
     extends: ['../shared'],
-    hooks: {
-      async 'nitro:config'(nitroConfig) {
-        if (process.env.NODE_ENV === 'test') return;
-        const routes = await getRoutesToGenerate({ locales: i18nConfig.locales });
-        // @ts-expect-error TODO define the typing
-        nitroConfig.prerender.routes = routes;
-      },
-    },
     devServer: {
       port: Number(process.env.PORT) || 6001,
     },
@@ -35,6 +29,7 @@ export default async () => {
     nitro: {
       prerender: {
         crawlLinks: false,
+        routes,
       },
     },
     i18n: i18nConfig,

--- a/pix-pro/services/get-routes-to-generate.js
+++ b/pix-pro/services/get-routes-to-generate.js
@@ -10,6 +10,22 @@ export const getRoutesToGenerate = async function ({ locales }) {
     routes.push(...nextPageRoutes);
   }
 
+  if (process.env.SITE_DOMAIN === 'FR') {
+    routes.push('/support/');
+    routes.push('/support/professionnel(le)');
+    routes.push('/actualites/');
+  }
+
+  if (process.env.SITE_DOMAIN === 'ORG') {
+    routes.push('/');
+
+    routes.push('/fr/support/');
+    routes.push('/en/support/');
+
+    routes.push('/fr/actualites/');
+    routes.push('/en/news/');
+  }
+
   console.info(`${routes.length} routes will be generated`);
   return routes;
 };

--- a/shared/nuxt.config.ts
+++ b/shared/nuxt.config.ts
@@ -7,9 +7,6 @@ const config = {
       script: [],
     },
   },
-  image: {
-    provider: process.env.IS_BUILTIN_IMAGES_ENABLED ? undefined : 'prismic',
-  },
   appConfig: {
     domainFr: process.env.DOMAIN_FR,
     domainOrg: process.env.DOMAIN_ORG,

--- a/shared/pages/[uri].vue
+++ b/shared/pages/[uri].vue
@@ -46,8 +46,6 @@ const { data } = await useAsyncData(async () => {
   if (slicesPage.total_results_size > 0) return slicesPage.results[0];
 });
 
-console.log({ description: data.value.data.seo_description?.[0]?.text });
-
 useSeoMeta({
   title: data.value.data.title[0]?.text,
   ogTitle: data.value.data.title[0]?.text,


### PR DESCRIPTION
## 🔆 Problème

Les pages Pix Pro ont des 404 sur les icones, ce qui signifie que les icones ne sont pas présents dans le build.

## ⛱️ Proposition

On comprend alors que le build ne contient pas les pages de suppport et que ces dernières sont générées à la volée et ne peuvent pas utiliser le serveur h3 pour les urls `/_ipx` comme en local mais essaie de résoudre dans le dossier `_ipx` du build.

On ajoute comme du côté de pix-site les pages de support à générer. 

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Se rendre sur Pix pro [`/support/professionnel(le)`](https://pro-pr769.review.pix.fr/support/professionnel(le)) et constater que les icones sont présentes