### PR TITLE
[FEATURE] Ne plus passer par une page intercalaire si un seul persona dans contexte (PIX-18014).

### DIFF
--- a/shared/components/Support/SupportPersonaCard.vue
+++ b/shared/components/Support/SupportPersonaCard.vue
@@ -28,9 +28,15 @@ const props = defineProps({
 const urlLocale = currentLocale.value === 'fr-fr' ? '' : `/${currentLocale.value}`;
 
 const cardLink = computed(() => {
-  return props.content.slug
-    ? `${urlLocale}/support/${props.content.slug}`
-    : `${urlLocale}/support/${route.params.parent_persona_name}/${props.content.sub_slug}`;
+  if (!props.content.slug) {
+    return `${urlLocale}/support/${route.params.parent_persona_name}/${props.content.sub_slug}`;
+  }
+
+  if (props.content.subPersonas.length > 1) {
+    return `${urlLocale}/support/${props.content.slug}`;
+  }
+
+  return `${urlLocale}/support/${props.content.slug}/${props.content.subPersonas[0]}`;
 });
 </script>
 

--- a/shared/pages/support/faq/[faq-persona].vue
+++ b/shared/pages/support/faq/[faq-persona].vue
@@ -86,17 +86,17 @@ defineI18nRoute({
   },
 });
 
-const backLink = computed(() => {
-  const localeUrl = i18nLocale.value !== 'fr-fr' ? `/${i18nLocale.value}` : '';
-  return `${localeUrl}/support/${route.params.parent_persona}`;
-});
-
 /* Fetch persona data */
 const { data } = await useAsyncData(async () => {
   try {
     const queryPersona = await client.getByUID('support__persona_faq', route.params.current_persona, {
       lang: i18nLocale.value,
     });
+
+    const queryCurrentParentPersona = await client.getSingle('personas_list', { lang: i18nLocale.value });
+    const parentPersonaChildrenCount = queryCurrentParentPersona.data.body.find((item) => {
+      return item.primary.slug === route.params.parent_persona;
+    }).items.length;
 
     const queryPosts = await client.getAllByType('support__faq_post', { lang: i18nLocale.value });
 
@@ -110,6 +110,7 @@ const { data } = await useAsyncData(async () => {
         ...queryPersona.data,
       },
       personaPosts: queryPosts,
+      parentPersonaChildrenCount,
       contactForm,
     };
   } catch (err) {
@@ -121,6 +122,13 @@ const { data } = await useAsyncData(async () => {
 /* Computed */
 const displayPopularPosts = computed(() => {
   return !searchInput.value?.length && data.value.currentPersona.popular_posts.length;
+});
+
+const backLink = computed(() => {
+  const localeUrl = i18nLocale.value !== 'fr-fr' ? `/${i18nLocale.value}` : '';
+  const parentPersonaHasOnlyOneChild = data.value.parentPersonaChildrenCount === 1;
+
+  return parentPersonaHasOnlyOneChild ? `${localeUrl}/support` : `${localeUrl}/support/${route.params.parent_persona}`;
 });
 
 /* Methods */

--- a/shared/pages/support/index.vue
+++ b/shared/pages/support/index.vue
@@ -43,7 +43,10 @@ const { data } = await useAsyncData(async () => {
   try {
     const supportPage = await client.getSingle('personas_list', { lang: i18nLocale.value });
 
-    const mainPersonas = supportPage?.data.body.map(persona => persona.primary);
+    const mainPersonas = supportPage?.data.body.map(persona => ({
+      ...persona.primary,
+      subPersonas: persona.items.map(item => item.sub_persona.slug),
+    }));
 
     return {
       supportPageData: supportPage?.data,


### PR DESCRIPTION
## 🔆 Problème

Dans la FAQ, lorsqu'un contexte ne contient qu'un seul persona l'utilisateur est obligé de passer par une page intercalaire et donc de cliquer deux fois sur son persona

Exemples : _Particulier_, _Demandeur d'emploi_, _Médiation numérique_.

## ⛱️ Proposition

Dans l'index du centre d'aide, checker le nombre de sous-personas pour chaque persona parents.

S'il n'y a qu'un enfant, alors le lien emmène direct dessus.

## 🌊 Remarques

Il a aussi fallu gérer le lien "retour" dans la page de ce persona-enfant.

## 🏄 Pour tester

Se balader dans les [pages support en RA](https://site-pr771.review.pix.fr/support/) et vérifier que tout fonctionne comme attendu.
