### PR TITLE
[FEATURE] Ajouter par défaut le form d'un persona dans un article de FAQ (PIX-18017).

### DIFF
--- a/shared/pages/support/faq/[faq-post].vue
+++ b/shared/pages/support/faq/[faq-post].vue
@@ -45,7 +45,7 @@ const { data } = await useAsyncData(async () => {
 
     const contactForm = document.data.contact_form_link.id
       ? await client.getByID(document.data.contact_form_link.id, { lang: i18nLocale.value })
-      : null;
+      : currentPersona.data.contact_form_link;
 
     return {
       content: document.data,


### PR DESCRIPTION
## 🔆 Problème

Actuellement, pour que le formulaire de contact figure dans chaque article, il faut renseigner le formulaire souhaité à l'intérieur de l'article.
Cela oblige donc à créer des articles uniques pour chaque persona, or beaucoup d'articles sont identiques, ce qui oblige de créer beaucoup de pages qui doivent avoir un URI unique différent.

## ⛱️ Proposition

Si aucun formulaire n'est spécifié dans le post de la FAQ, alors on vient afficher le formulaire du persona.
Il est tout de même toujours possible d'indiquer un autre formulaire spécifique.

## 🏄 Pour tester

Reproduire le comportement en RA.

https://site-pr772.review.pix.fr/support/
