### PR TITLE
[BUGFIX] Utiliser l'uid pour générer la liste des personas du support

### DIFF
--- a/shared/pages/support/index.vue
+++ b/shared/pages/support/index.vue
@@ -45,7 +45,7 @@ const { data } = await useAsyncData(async () => {
 
     const mainPersonas = supportPage?.data.body.map(persona => ({
       ...persona.primary,
-      subPersonas: persona.items.map(item => item.sub_persona.slug),
+      subPersonas: persona.items.map(item => item.sub_persona.uid),
     }));
 
     return {


### PR DESCRIPTION
## 🔆 Problème

Le slug n'évolue pas lors des changements sur Prismic et [est déprécié](https://community.prismic.io/t/what-are-slugs/6493), ce qui peut créer des liens qui ne fonctionnent pas. 


## ⛱️ Proposition

Utiliser l'uid qui est à la main de l'équipe support 

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Se rendre sur `fr-be/support` constater que le lien `citoyen-ne/citoyen-ne` est présent au lieu de `citoyen-ne/citoyenne`