### PR TITLE
[BUGFIX] Chargement du bon contenu des articles (PIX-21734).

### DIFF
--- a/shared/pages/news/[slug].vue
+++ b/shared/pages/news/[slug].vue
@@ -26,11 +26,13 @@ defineI18nRoute({
 });
 
 /* Fetch news item */
-const { data: newsItem } = await useAsyncData(() => {
-  return client.getByUID('news_item', route.params.slug, {
-    lang: i18nLocale.value,
+const { data: newsItem } = await useAsyncData(
+  `news-item-${route.params.slug}`,
+  () => {
+    return client.getByUID('news_item', route.params.slug, {
+      lang: i18nLocale.value,
+    });
   });
-});
 
 useSeoMeta({
   title: newsItem.value.data.title[0]?.text,


### PR DESCRIPTION
## 🥀 Problème

Un problème d'affichage de contenu des articles a lieu sur pix-site.

Méthode pour reproduire le problème :

- Aller sur [pix.fr](https://pix.fr/actualites/)
- Cliquer sur un article
- Vérifier que le contenu corresponde à l'article voulu
- Revenir à la page précédente via le bouton précédent du navigateur
- Cliquer sur un autre article
- Le contenu de la page correspond au premier article

Vidéo explicative (bug à partir de 0:14)

https://github.com/user-attachments/assets/3c015642-6363-43fd-80ab-bfb17251742b

**Explication technique :**

La méthode `useAsyncData` dispose d'un cache afin de ne pas être exécutée plus de fois que nécessaire si des données venaient à déjà exister.

Dans le cadre du développement local, nous ne rencontrons pas ce problème car le "Hot Module Replacement" (HMR) et certains mécanismes de cache sont souvent moins agressifs ou réinitialisés plus fréquemment qu'en environement de production, où la méthode `useAsyncData` de `shared/pages/news/[slug].vue` n'est pas rappelée lors du changement d'article.

A l'inverse, en production, Nuxt essaie d'être performant. Si une clé de cache identique pour les appels API est utilisée (ou si aucune clé n'est définie explicitement), Nuxt peut penser que les données sont déjà en mémoire et ne refera pas d'appel à la fonction de chargement.

Pour pouvoir reproduire ce problème en local, il faut d'abord passer par une étape de build afin de simuler ce qui est envoyé en production : 

```bash
npm run generate
npx serve .output/public
```

## 🏹 Proposition

Nous rajoutons une clé de cache dynamique basée sur le slug, différent pour chaque article, et forçant un nouvel appel à la méthode `useAsyncData`, pour fetcher le bon article.
[Documentation sur les clés réactives](https://nuxt.com/docs/4.x/api/composables/use-async-data#reactive-keys)

## 💌 Remarques

Il aurait également été possible d'ajouter un watcher sur la méthode `useAsyncData`, en remplacement/complément et qui aurait "écouté" les changements de slug et ainsi pu forcer le rechargement des données.
[Documentation sur le watcher](https://nuxt.com/docs/4.x/api/composables/use-async-data#watch-params)

```javascript
const { data: newsItem } = await useAsyncData(
  `news-item-${route.params.slug}`,
  () => {
    return client.getByUID('news_item', route.params.slug, {
      lang: i18nLocale.value,
    });
  },
  {
    watch: [() => routes.params.slug]
  }
);
```

## ❤️‍🔥 Pour tester

- Aller sur pix-site.
- Aller sur la page actualités
- Cliquer sur un article
- Vérifier que le contenu corresponde à l'article voulu
- Revenir à la page précédente via le bouton précédent du navigateur
- Cliquer sur un autre article
- Vérifier que le contenu de la page corresponde bien à ce nouvel article