### PR TITLE
[tech] add plausible redirection for pro.pix.fr to proxy pix.fr

### DIFF
--- a/pix-site/servers.conf.erb
+++ b/pix-site/servers.conf.erb
@@ -103,6 +103,32 @@ server {
       proxy_set_header X-Forwarded-Host  $host;
   }
 
+  #Analytics site pro.pix.fr
+  location = /analytics-pro/script.js {
+    proxy_pass https://plausible.io/js/pa-nCUY83gpZtScG4N4_PcqU.js;
+    proxy_set_header Host plausible.io;
+
+
+    # Tiny, negligible performance improvement. Very optional.
+    proxy_buffering on;
+
+    # Cache the script for 5 minutes, as long as plausible.io returns a valid response
+    proxy_cache_valid 200 5m;
+    proxy_cache_use_stale updating error timeout invalid_header http_500;
+  }
+
+  location = /analytics-pro/event {
+    proxy_pass https://plausible.io/api/event;
+    proxy_set_header Host plausible.io;
+    proxy_buffering on;
+    proxy_http_version 1.1;
+
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host  $host;
+  }
+  #fin analytics pro.pix.fr
+
   <% ENV.each do |key,value|
     if key.start_with? 'ADD_HTTP_HEADER' %>
       add_header <%=

--- a/pix-site/tests/e2e/layout/header.spec.ts
+++ b/pix-site/tests/e2e/layout/header.spec.ts
@@ -9,7 +9,6 @@ test.describe('layout/header', () => {
     const siteHeader = page.getByRole('banner');
 
     // Logos zone
-    expect(siteHeader.getByAltText('République française, liberté égalité fraternité')).toBeVisible();
     expect(siteHeader.getByAltText('Pix')).toBeVisible();
 
     // Locale switcher visibility


### PR DESCRIPTION
## 🌎 Problème

Ajoute une redirection sur pix.fr vers le script plausible de pro.pix.fr pour éviter de déployer un proxy entier juste pour servir ce fichier car webflow ne permet pas de mettre en oeuvre un proxy directement chez eux.


## 🔭 Proposition

2 urls sont ajoutées :
- pix.fr/analytics-pro/script.js -> proxy vers le script plausible
- pix.fr/analytics-pro/event -> proxy vers l'api event plausible

## 🪐 Remarques

ATTENTION, il faudra maintenir ces lignes en cas de modification sur pix.fr afin d'éviter une rupture de service sur l'analytics pro.

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
