### PR TITLE
[FEATURE] Add github action to upload SBOMs to Deptrack

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,56 @@
+name: "Security Checks"
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  upload_sboms:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Cyclone DX
+        run: npm install @cyclonedx/cyclonedx-npm@4.2.0
+
+      - name: Pix Site Monorepo - Create SBOM
+        run: npm ci && npx @cyclonedx/cyclonedx-npm --output-file pix-site-repo-sbom.json package.json && [ -e "pix-site-repo-sbom.json" ] && echo '[+] SBOM created' || echo '[!] Fail to create SBOM'
+
+      - name: Pix Site Monorepo - Upload BOM to Dependency-Track
+        uses: DependencyTrack/gh-upload-sbom@48feab3080ff9e8f51f4d21861d9fc914eb744f5
+        with:
+          serverHostname: ${{ secrets.DEPENDENCYTRACK_HOSTNAME }}
+          apiKey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
+          projectName: Pix Site Monorepo
+          projectVersion: dev
+          bomFilename: "pix-site-repo-sbom.json"
+          autoCreate: true
+
+      - name: Pix Site front - Create SBOM
+        run: npm ci --prefix pix-site/ && npx @cyclonedx/cyclonedx-npm --output-file pix-site-front-sbom.json pix-site/package.json && [ -e "pix-site-front-sbom.json" ] && echo '[+] SBOM created' || echo '[!] Fail to create SBOM'
+
+      - name: Pix Site front - Upload BOM to Dependency-Track
+        uses: DependencyTrack/gh-upload-sbom@48feab3080ff9e8f51f4d21861d9fc914eb744f5
+        with:
+          serverHostname: ${{ secrets.DEPENDENCYTRACK_HOSTNAME }}
+          apiKey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
+          projectName: Pix Site front
+          projectVersion: dev
+          bomFilename: "pix-site-front-sbom.json"
+          autoCreate: true
+
+      - name: Pix Site API - Create SBOM
+        run: npm ci --prefix shared/ && npx @cyclonedx/cyclonedx-npm --output-file pix-site-api-sbom.json shared/package.json && [ -e "pix-site-api-sbom.json" ] && echo '[+] SBOM created' || echo '[!] Fail to create SBOM'
+
+      - name: Pix Site API - Upload BOM to Dependency-Track
+        uses: DependencyTrack/gh-upload-sbom@48feab3080ff9e8f51f4d21861d9fc914eb744f5
+        with:
+          serverHostname: ${{ secrets.DEPENDENCYTRACK_HOSTNAME }}
+          apiKey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
+          projectName: Pix Site API
+          projectVersion: dev
+          bomFilename: "pix-site-api-sbom.json"
+          autoCreate: true
+
+      # Pix-Pro est en cours de décommissionnement


### PR DESCRIPTION
## 🌱 Problème

On aimerait avoir une meilleure vision et un meilleur alerting sur les dépendances, directes et indirectes et leurs vulnérabilités

## 🐣 Proposition

Cette PR crée, pour chaque sous-dossier, un SBOM (Software Bill of Material = inventaire des dépendances directes et indirectes) et l'uploade sur l'appli Dependency-Track.

## 🌷 Remarques

* l'upload se fait au moment de _push sur dev_ pour éviter les multiples versions en parallèle. il reste toujours la mise en recette + la mise en prod pour corriger
* Le hash du tag est utilisé plutôt que son nom pour éviter des attaques type supply-chain (cf. [neteye](https://www.neteye-blog.com/2025/06/how-to-secure-github-actions-with-sha-pinning/) ou [romain lespinasse](https://www.romainlespinasse.dev/posts/github-actions-commit-sha-pinning/))
* Pas de SBOM pour Pix-Pro, car il est bientôt décommissionné

## 🐝 Pour tester

* Fork en cours pour les tests
* test possible en local : 
    * récupérer une clé d'API sur Depedency-Track de sandbox (connexion avec le SSO)
    * `act push --defaultbranch dev -s DEPENDENCYTRACK_HOSTNAME=XXXXX -s DEPENDENCYTRACK_APIKEY=XXXXXXXXX`
