### PR TITLE
[TECH] Redirection well-known pour matrix

### DIFF
--- a/pix-site/nginx/templates/default.conf.template
+++ b/pix-site/nginx/templates/default.conf.template
@@ -44,6 +44,14 @@ server {
     set $extension 'fr';
   }
 
+  location ^~ /.well-known/matrix/ {
+    if ($extension = 'org') {
+      return 301 https://matrix.pix.org$request_uri;
+    }
+
+    return 404;
+  }
+
   if ($http_x_forwarded_host ~ \.org) {
     set $extension 'org';
   }

--- a/pix-site/servers.conf.erb
+++ b/pix-site/servers.conf.erb
@@ -48,6 +48,14 @@ server {
     set $extension 'org';
   }
 
+  location ^~ /.well-known/matrix/ {
+    if ($extension = 'org') {
+      return 301 https://matrix.pix.org$request_uri;
+    }
+
+    return 404;
+  }
+
 <% if ENV['NGINX_GEOAPI_UPSTREAM_HOST'] %>
   location /geolocate {
     proxy_pass https://api/me;


### PR DESCRIPTION
## 💥 Problème

LaSuite.coop a besoin pour la configuration de matrix d'une redirection well-known

## 👩‍🚀 Proposition

On ajoute cette redirection dans le nginx qui livre pix-sitem seulement pour le .org

