### PR TITLE
[TECH] La version d'image docker est maintenant basée sur la date

### DIFF
--- a/.github/workflows/docker-deployment.yml
+++ b/.github/workflows/docker-deployment.yml
@@ -10,15 +10,16 @@ jobs:
   get-last-tag:
     runs-on: ubuntu-latest
     outputs:
-      last_tag: ${{ steps.last-release.outputs.tag }}
+      last_tag: ${{ steps.compute-date-tag.outputs.tag }}
     steps:
-    - uses: actions/checkout@v4
     - name: Get latest release
       id: last-release
       uses: actions-ecosystem/action-get-latest-tag@v1
       with:
         semver_only: true
-
+    - name: Compute tag based on the date
+      id: compute-date-tag
+      run: echo "tag=${{ steps.last-release.outputs.tag }}.$(date +'%Y.%m.%d').$(printf '%03d' ${{ github.run_number }})" >> $GITHUB_OUTPUT
 
   build-and-push-image:
     strategy:


### PR DESCRIPTION
## 🚙 Problème

Prismic livre des nouvelles versions du contenu alors que le code de pix-site n'évolue pas.
L'image docker est versionnée en fonction du tag de pix-site.

## 🍃 Proposition

On utilise une version basée sur la version de pix-site + date + un compteur ( ex: `v4.12.2.2026.12.31.002` ) pour que chaque changement de prismic soit reflétée par la version de l'image docker

