### PR TITLE
[TECH] Utilise un compteur journalier pour marquer la version de l'image docker

### DIFF
--- a/.github/workflows/docker-deployment.yml
+++ b/.github/workflows/docker-deployment.yml
@@ -19,8 +19,23 @@ jobs:
         semver_only: true
     - name: Compute tag based on the date
       id: compute-date-tag
-      run: echo "tag=${{ steps.last-release.outputs.tag }}.$(date +'%Y.%m.%d').$(printf '%03d' ${{ github.run_number }})" >> $GITHUB_OUTPUT
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        TODAY_API=$(date +'%Y-%m-%d')
+        DAILY_RUN_COUNT=$(gh run list --workflow "${{ github.workflow }}" --created "$TODAY_API" -L 1000 --json databaseId -q 'length')
 
+        if [ -z "$DAILY_RUN_COUNT" ]; then
+          DAILY_RUN_COUNT=0
+        fi
+
+        DAILY_RUN_COUNT=$(( DAILY_RUN_COUNT + 1 ))
+
+        FORMATTED_COUNT=$(printf '%03d' $DAILY_RUN_COUNT)
+
+        TODAY_TAG=$(date +'%Y.%m.%d')
+        FINAL_TAG="${{ steps.last-release.outputs.tag }}.$TODAY_TAG.$FORMATTED_COUNT"
+        echo "tag=$FINAL_TAG" >> $GITHUB_OUTPUT
   build-and-push-image:
     strategy:
       matrix:


### PR DESCRIPTION
## 🚙 Problème

Prismic livre des nouvelles versions du contenu alors que le code de pix-site n'évolue pas.
L'image docker est versionnée en fonction la version de pix-site + date + un compteur ( ex: `v4.12.2.2026.12.31.002` )
Le compteur est le compteur du total de lancement du workflow, et non le compteur du nombre de lancement du jour.

## 🍃 Proposition

On utilise un script bash pour calculer le nombre de workflow lancés dans la journée
