### PR TITLE
[BUGFIX] Réparer les entrées actives du menu principal (PIX-23171).

### DIFF
--- a/shared/components/slices/NavigationZone.vue
+++ b/shared/components/slices/NavigationZone.vue
@@ -104,7 +104,7 @@ const subIsActive = (subNavigationLinks) => {
       return splittedLink[linkIndex];
     });
   return paths.some((path) => {
-    return route.path.includes(path);
+    return path.length && route.path.includes(path);
   });
 };
 


### PR DESCRIPTION
## 🪧 Problème

<img width="419" height="374" alt="image" src="https://github.com/user-attachments/assets/a4f3db9d-3962-4c19-8249-4964fd523c2a" />

Comme on peut le voir ici, l’entrée de menu “Nos services” est affichées “active” même lorsque ce n’est pas le cas.


## 🌈 Proposition

Vérifier que le lien de sous-menu a bien une taille valide.

## ✊ Remarques

En fait il éviter que les URLs sur le CMS finisse pas un "/".

<img width="397" height="186" alt="image" src="https://github.com/user-attachments/assets/69312ff4-b8a7-4928-adb6-429a0d627256" />


## 🎉 Pour tester

Tester en RA