### PR TITLE
[TECH] Corrige la configuration nginx qui retourne des 404 pour toutes les pages

### DIFF
--- a/pix-pro/nginx/templates/default.conf.template
+++ b/pix-pro/nginx/templates/default.conf.template
@@ -64,6 +64,10 @@ server {
 
   include includes/rewrites.conf;
 
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
   error_page 400 401 403 404 418 500 502 503 504 /404.html;
 
   location ~ ^/(_assets|_nuxt|images|scripts)/ {

--- a/pix-pro/servers.conf.erb
+++ b/pix-pro/servers.conf.erb
@@ -67,6 +67,10 @@ server {
 
   include /app/nginx/includes/rewrites.conf;
 
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
   error_page 400 401 403 404 418 500 502 503 504 /404.html;
 
   location ~ ^/(_assets|_nuxt|images|scripts)/ {

--- a/pix-site/nginx/templates/default.conf.template
+++ b/pix-site/nginx/templates/default.conf.template
@@ -73,6 +73,10 @@ server {
 
   include includes/rewrites.conf;
 
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
   error_page 400 401 403 404 418 500 502 503 504 /404.html;
 
   location ~ ^/(_assets|_nuxt|images|scripts)/ {

--- a/pix-site/servers.conf.erb
+++ b/pix-site/servers.conf.erb
@@ -75,6 +75,10 @@ server {
 
   include /app/nginx/includes/rewrites.conf;
 
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
   error_page 400 401 403 404 418 500 502 503 504 /404.html;
 
   location ~ ^/(_assets|_nuxt|images|scripts)/ {


### PR DESCRIPTION
## 🪧 Problème

Toutes les pages testées par Oh Dear sont marquées en "broken link" parce que le nginx retourne une 404 même si la page se charge correctement

## 🌈 Proposition

On corrige la configuration de nginx pour qu'il prenne en charge Nuxt correctement

