### PR TITLE
Corrige la configuration nginx qui gère mal certain paths

### DIFF
--- a/pix-pro/nginx/templates/default.conf.template
+++ b/pix-pro/nginx/templates/default.conf.template
@@ -65,7 +65,7 @@ server {
   include includes/rewrites.conf;
 
   location / {
-    try_files $uri $uri/ /index.html;
+    try_files $uri $uri/ $uri/index.html $uri.html /index.html;
   }
 
   error_page 400 401 403 404 418 500 502 503 504 /404.html;

--- a/pix-pro/servers.conf.erb
+++ b/pix-pro/servers.conf.erb
@@ -68,7 +68,7 @@ server {
   include /app/nginx/includes/rewrites.conf;
 
   location / {
-    try_files $uri $uri/ /index.html;
+    try_files $uri $uri/ $uri/index.html $uri.html /index.html;
   }
 
   error_page 400 401 403 404 418 500 502 503 504 /404.html;

--- a/pix-site/nginx/templates/default.conf.template
+++ b/pix-site/nginx/templates/default.conf.template
@@ -74,7 +74,7 @@ server {
   include includes/rewrites.conf;
 
   location / {
-    try_files $uri $uri/ /index.html;
+    try_files $uri $uri/ $uri/index.html $uri.html /index.html;
   }
 
   error_page 400 401 403 404 418 500 502 503 504 /404.html;

--- a/pix-site/servers.conf.erb
+++ b/pix-site/servers.conf.erb
@@ -76,7 +76,7 @@ server {
   include /app/nginx/includes/rewrites.conf;
 
   location / {
-    try_files $uri $uri/ /index.html;
+    try_files $uri $uri/ $uri/index.html $uri.html /index.html;
   }
 
   error_page 400 401 403 404 418 500 502 503 504 /404.html;


### PR DESCRIPTION
## 🪧 Problème

Suite à la configuration (PR #801) pour que Oh Dear puisse tester les liens, certaines urls renvoyaient vers la base du site plutôt que vers la page en question

## 🌈 Proposition

On corrige la configuration de nginx pour prendre en compte tous les cas d'URL possibles générés par nuxt

