### PR TITLE
[TECH] Corrige l'action qui crée l'image docker lors de la création d'un tag

### DIFF
--- a/.github/workflows/docker-deployment.yml
+++ b/.github/workflows/docker-deployment.yml
@@ -10,33 +10,40 @@ jobs:
   get-last-tag:
     runs-on: ubuntu-latest
     outputs:
-      last_tag: ${{ steps.compute-date-tag.outputs.tag }}
+      last_tag: ${{ steps.set-tag.outputs.tag }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Get latest release
       id: last-release
+      if: startsWith(github.ref, 'refs/tags/') == false
       uses: actions-ecosystem/action-get-latest-tag@v1
       with:
         semver_only: true
-    - name: Compute tag based on the date
-      id: compute-date-tag
+    - name: Set tag
+      id: set-tag
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        TODAY_API=$(date +'%Y-%m-%d')
-        DAILY_RUN_COUNT=$(gh run list --workflow "${{ github.workflow }}" --created "$TODAY_API" -L 1000 --json databaseId -q 'length')
+        if [[ "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
+          echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+        else
+          TODAY_API=$(date +'%Y-%m-%d')
+          DAILY_RUN_COUNT=$(gh run list --workflow "${{ github.workflow }}" --created "$TODAY_API" -L 1000 --json databaseId -q 'length')
 
-        if [ -z "$DAILY_RUN_COUNT" ]; then
-          DAILY_RUN_COUNT=0
+          if [ -z "$DAILY_RUN_COUNT" ]; then
+            DAILY_RUN_COUNT=0
+          fi
+
+          DAILY_RUN_COUNT=$(( DAILY_RUN_COUNT + 1 ))
+
+          FORMATTED_COUNT=$(printf '%03d' $DAILY_RUN_COUNT)
+
+          TODAY_TAG=$(date +'%Y.%m.%d')
+          FINAL_TAG="${{ steps.last-release.outputs.tag }}.$TODAY_TAG.$FORMATTED_COUNT"
+          echo "tag=$FINAL_TAG" >> $GITHUB_OUTPUT
         fi
-
-        DAILY_RUN_COUNT=$(( DAILY_RUN_COUNT + 1 ))
-
-        FORMATTED_COUNT=$(printf '%03d' $DAILY_RUN_COUNT)
-
-        TODAY_TAG=$(date +'%Y.%m.%d')
-        FINAL_TAG="${{ steps.last-release.outputs.tag }}.$TODAY_TAG.$FORMATTED_COUNT"
-        echo "tag=$FINAL_TAG" >> $GITHUB_OUTPUT
   build-and-push-image:
     strategy:
       matrix:


### PR DESCRIPTION
## 🪧 Problème

Lorsqu'un tag est créé, le workflow docker-deployment échoue à cause du step actions-ecosystem/action-get-latest-tag@v1

## 🌈 Proposition

Quand l'évènement qui déclenche l'action est la création d'un tag, on peut récupérer le tag directement, sans utiliser ce step.

