### PR TITLE
[TECH] Supprime la configuration location de niginx

### DIFF
--- a/pix-pro/servers.conf.erb
+++ b/pix-pro/servers.conf.erb
@@ -67,10 +67,6 @@ server {
 
   include /app/nginx/includes/rewrites.conf;
 
-  location / {
-    try_files $uri $uri/ $uri/index.html $uri.html /index.html;
-  }
-
   error_page 400 401 403 404 418 500 502 503 504 /404.html;
 
   location ~ ^/(_assets|_nuxt|images|scripts)/ {

--- a/pix-site/servers.conf.erb
+++ b/pix-site/servers.conf.erb
@@ -75,10 +75,6 @@ server {
 
   include /app/nginx/includes/rewrites.conf;
 
-  location / {
-    try_files $uri $uri/ $uri/index.html $uri.html /index.html;
-  }
-
   error_page 400 401 403 404 418 500 502 503 504 /404.html;
 
   location ~ ^/(_assets|_nuxt|images|scripts)/ {


### PR DESCRIPTION
## 🪧 Problème

La configuration de nginx avait été corrigée parce que, même si les pages s'affichait, elles retournaient toutes une erreur 404

Or, avec cette correction, les pages du support ne s'affichent pas. 

Le problème vient du fait que le lien https://pix.fr/support/enseignement-scolaire/collegien-ou-lyceen/jai-plusieurs-comptes-pix-comment-faire qui devrait correspondre à : 
 - soit un fichier `support/enseignement-scolaire/collegien-ou-lyceen/jai-plusieurs-comptes-pix-comment-faire/index.html`
 - soit un fichier `support/enseignement-scolaire/collegien-ou-lyceen/jai-plusieurs-comptes-pix-comment-faire.hmtl`
correspond en fait à un fichier `support/enseignement-scolaire/collegien-ou-lyceen/index.html`

Ce que la configuration par défaut de nginx à l'air de gérer (sans compter les 404).

## 🌈 Proposition

on revient en arrière sur cette configuration puisque les 404 ne gênent pas les utilisateurs, mais seulement Oh Dear.

