### PR TITLE
[BUGFIX] Correction des liens vers les personas support

### DIFF
--- a/shared/pages/support/[persona-sub-list].vue
+++ b/shared/pages/support/[persona-sub-list].vue
@@ -31,6 +31,9 @@ defineI18nRoute({
     'fr-fr': '/support/[parent_persona_name]',
     'fr-be': '/support/[parent_persona_name]',
     'nl-be': '/support/[parent_persona_name]',
+    es: '/support/[parent_persona_name]',
+    it: '/support/[parent_persona_name]',
+    'de-AT': '/support/[parent_persona_name]',
   },
 });
 

--- a/shared/pages/support/faq/[faq-persona].vue
+++ b/shared/pages/support/faq/[faq-persona].vue
@@ -85,6 +85,9 @@ defineI18nRoute({
     'fr-fr': '/support/[parent_persona]/[current_persona]',
     'fr-be': '/support/[parent_persona]/[current_persona]',
     'nl-be': '/support/[parent_persona]/[current_persona]',
+    es: '/support/[parent_persona]/[current_persona]',
+    it: '/support/[parent_persona]/[current_persona]',
+    'de-AT': '/support/[parent_persona]/[current_persona]',
   },
 });
 

--- a/shared/pages/support/faq/[faq-post].vue
+++ b/shared/pages/support/faq/[faq-post].vue
@@ -26,6 +26,9 @@ defineI18nRoute({
     'fr-fr': '/support/[parent_persona]/[current_persona]/[post_uid]',
     'fr-be': '/support/[parent_persona]/[current_persona]/[post_uid]',
     'nl-be': '/support/[parent_persona]/[current_persona]/[post_uid]',
+    es: '/support/[parent_persona]/[current_persona]/[post_uid]',
+    it: '/support/[parent_persona]/[current_persona]/[post_uid]',
+    'de-AT': '/support/[parent_persona]/[current_persona]/[post_uid]',
   },
 });
 

--- a/shared/pages/support/form/[support-form].vue
+++ b/shared/pages/support/form/[support-form].vue
@@ -38,6 +38,9 @@ defineI18nRoute({
     'fr-fr': '/support/form/[slug]',
     'fr-be': '/support/form/[slug]',
     'nl-be': '/support/form/[slug]',
+    es: '/support/form/[slug]',
+    it: '/support/form/[slug]',
+    'de-AT': '/support/form/[slug]',
   },
 });
 

--- a/shared/pages/support/index.vue
+++ b/shared/pages/support/index.vue
@@ -32,6 +32,9 @@ defineI18nRoute({
     'fr-fr': '/support',
     'fr-be': '/support',
     'nl-be': '/support',
+    es: '/support',
+    it: '/support',
+    'de-AT': '/support',
   },
 });
 


### PR DESCRIPTION
## 🪧 Problème

Les liens des personas support ne fonctionnent pas.

## 🌈 Proposition

Ajouter les routes qui manquent pour les personas support pour les 3 nouvelles locales.

## ✊ Remarques

RAS

## 🎉 Pour tester

Tester les différents sites pour vérifier que les liens vers les personas support pour les 3 nouvelles locales sont bien fonctionnels et qu’il n’y a pas de régressions.